### PR TITLE
feat: memory_tags and session_tags with filters and passive suggestions

### DIFF
--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -548,6 +548,9 @@ GUIDELINES:
 				mcp.WithString("summary",
 					mcp.Description("Summary of what was accomplished"),
 				),
+				mcp.WithString("tags",
+					mcp.Description("Comma-separated tags for this session (e.g. 'feature,auth,backend')"),
+				),
 			),
 			handleSessionEnd(s),
 		)
@@ -1003,9 +1006,16 @@ func handleSessionEnd(s *store.Store) server.ToolHandlerFunc {
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		id, _ := req.GetArguments()["id"].(string)
 		summary, _ := req.GetArguments()["summary"].(string)
+		tagsRaw, _ := req.GetArguments()["tags"].(string)
 
 		if err := s.EndSession(id, summary); err != nil {
 			return mcp.NewToolResultError("Failed to end session: " + err.Error()), nil
+		}
+
+		if tags := parseTags(tagsRaw); len(tags) > 0 {
+			if err := s.SetSessionTags(id, tags); err != nil {
+				return mcp.NewToolResultError("Failed to set session tags: " + err.Error()), nil
+			}
 		}
 
 		return mcp.NewToolResultText(fmt.Sprintf("Session %q completed", id)), nil

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -28,12 +28,13 @@ var openDB = sql.Open
 // ─── Types ───────────────────────────────────────────────────────────────────
 
 type Session struct {
-	ID        string  `json:"id"`
-	Project   string  `json:"project"`
-	Directory string  `json:"directory"`
-	StartedAt string  `json:"started_at"`
-	EndedAt   *string `json:"ended_at,omitempty"`
-	Summary   *string `json:"summary,omitempty"`
+	ID        string   `json:"id"`
+	Project   string   `json:"project"`
+	Directory string   `json:"directory"`
+	StartedAt string   `json:"started_at"`
+	EndedAt   *string  `json:"ended_at,omitempty"`
+	Summary   *string  `json:"summary,omitempty"`
+	Tags      []string `json:"tags,omitempty"`
 }
 
 type Observation struct {
@@ -203,11 +204,12 @@ type EnrolledProject struct {
 }
 
 type syncSessionPayload struct {
-	ID        string  `json:"id"`
-	Project   string  `json:"project"`
-	Directory string  `json:"directory"`
-	EndedAt   *string `json:"ended_at,omitempty"`
-	Summary   *string `json:"summary,omitempty"`
+	ID        string    `json:"id"`
+	Project   string    `json:"project"`
+	Directory string    `json:"directory"`
+	EndedAt   *string   `json:"ended_at,omitempty"`
+	Summary   *string   `json:"summary,omitempty"`
+	Tags      *[]string `json:"tags,omitempty"`
 }
 
 type syncObservationPayload struct {
@@ -779,6 +781,7 @@ func (s *Store) GetSession(id string) (*Session, error) {
 	if err := row.Scan(&sess.ID, &sess.Project, &sess.Directory, &sess.StartedAt, &sess.EndedAt, &sess.Summary); err != nil {
 		return nil, err
 	}
+	s.loadTagsForSession(&sess)
 	return &sess, nil
 }
 
@@ -1633,6 +1636,7 @@ func (s *Store) Export() (*ExportData, error) {
 		if err := rows.Scan(&sess.ID, &sess.Project, &sess.Directory, &sess.StartedAt, &sess.EndedAt, &sess.Summary); err != nil {
 			return nil, err
 		}
+		s.loadTagsForSession(&sess)
 		data.Sessions = append(data.Sessions, sess)
 	}
 	if err := rows.Err(); err != nil {
@@ -1707,6 +1711,11 @@ func (s *Store) Import(data *ExportData) (*ImportResult, error) {
 			return nil, fmt.Errorf("import session %s: %w", sess.ID, err)
 		}
 		n, _ := res.RowsAffected()
+		if n > 0 && sess.Tags != nil {
+			if err := s.setTagsForSessionTx(tx, sess.ID, sess.Tags); err != nil {
+				return nil, fmt.Errorf("import session %s: tags: %w", sess.ID, err)
+			}
+		}
 		result.SessionsImported += int(n)
 	}
 
@@ -2368,6 +2377,14 @@ func (s *Store) backfillSessionSyncMutationsTx(tx *sql.Tx, project string) error
 		if err := rows.Scan(&payload.ID, &payload.Project, &payload.Directory, &payload.EndedAt, &payload.Summary); err != nil {
 			return err
 		}
+		var sess Session
+		sess.ID = payload.ID
+		s.loadTagsForSession(&sess)
+		tags := sess.Tags
+		if tags == nil {
+			tags = []string{}
+		}
+		payload.Tags = &tags
 		if err := s.enqueueSyncMutationTx(tx, SyncEntitySession, payload.ID, SyncOpUpsert, payload); err != nil {
 			return err
 		}
@@ -2584,7 +2601,7 @@ func observationPayloadFromObservation(obs *Observation) syncObservationPayload 
 }
 
 func (s *Store) applySessionPayloadTx(tx *sql.Tx, payload syncSessionPayload) error {
-	_, err := s.execHook(tx,
+	if _, err := s.execHook(tx,
 		`INSERT INTO sessions (id, project, directory, ended_at, summary)
 		 VALUES (?, ?, ?, ?, ?)
 		 ON CONFLICT(id) DO UPDATE SET
@@ -2593,8 +2610,15 @@ func (s *Store) applySessionPayloadTx(tx *sql.Tx, payload syncSessionPayload) er
 		   ended_at = COALESCE(excluded.ended_at, sessions.ended_at),
 		   summary = COALESCE(excluded.summary, sessions.summary)`,
 		payload.ID, payload.Project, payload.Directory, payload.EndedAt, payload.Summary,
-	)
-	return err
+	); err != nil {
+		return err
+	}
+	if payload.Tags != nil {
+		if err := s.setTagsForSessionTx(tx, payload.ID, *payload.Tags); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (s *Store) applyObservationUpsertTx(tx *sql.Tx, payload syncObservationPayload) error {
@@ -2942,6 +2966,12 @@ func SuggestTags(typ, title, content string) []string {
 	}
 
 	text := strings.ToLower(title + " " + content)
+	tokens := make(map[string]struct{})
+	for _, tok := range strings.FieldsFunc(text, func(r rune) bool {
+		return (r < 'a' || r > 'z') && (r < '0' || r > '9')
+	}) {
+		tokens[tok] = struct{}{}
+	}
 	candidates := []string{
 		"auth", "authentication", "authorization",
 		"database", "sql", "sqlite", "postgres", "mysql",
@@ -2960,7 +2990,10 @@ func SuggestTags(typ, title, content string) []string {
 		"error", "panic",
 	}
 	for _, kw := range candidates {
-		if !seen[kw] && strings.Contains(text, kw) {
+		if !seen[kw] {
+			if _, ok := tokens[kw]; !ok {
+				continue
+			}
 			tags = append(tags, kw)
 			seen[kw] = true
 			if len(tags) >= 5 {
@@ -3145,6 +3178,67 @@ func (s *Store) loadTagsForObservation(o *Observation) {
 			o.Tags = append(o.Tags, tag)
 		}
 	}
+}
+
+func (s *Store) setTagsForSessionTx(tx *sql.Tx, sessionID string, tags []string) error {
+	if _, err := s.execHook(tx, "DELETE FROM session_tags WHERE session_id = ?", sessionID); err != nil {
+		return err
+	}
+	for _, raw := range tags {
+		tag := normalizeTag(raw)
+		if tag == "" {
+			continue
+		}
+		if _, err := s.execHook(tx, "INSERT OR IGNORE INTO session_tags (session_id, tag) VALUES (?, ?)", sessionID, tag); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *Store) loadTagsForSession(sess *Session) {
+	rows, err := s.queryItHook(s.db,
+		"SELECT tag FROM session_tags WHERE session_id = ? ORDER BY tag", sess.ID)
+	if err != nil {
+		return
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var tag string
+		if rows.Scan(&tag) == nil {
+			sess.Tags = append(sess.Tags, tag)
+		}
+	}
+}
+
+// SetSessionTags replaces the tag set for a session and enqueues a sync mutation.
+func (s *Store) SetSessionTags(id string, tags []string) error {
+	return s.withTx(func(tx *sql.Tx) error {
+		if err := s.setTagsForSessionTx(tx, id, tags); err != nil {
+			return err
+		}
+		var project, directory string
+		var endedAt, summary *string
+		if err := tx.QueryRow(
+			`SELECT project, directory, ended_at, summary FROM sessions WHERE id = ?`, id,
+		).Scan(&project, &directory, &endedAt, &summary); err != nil {
+			return err
+		}
+		normalizedTags := make([]string, 0, len(tags))
+		for _, raw := range tags {
+			if t := normalizeTag(raw); t != "" {
+				normalizedTags = append(normalizedTags, t)
+			}
+		}
+		return s.enqueueSyncMutationTx(tx, SyncEntitySession, id, SyncOpUpsert, syncSessionPayload{
+			ID:        id,
+			Project:   project,
+			Directory: directory,
+			EndedAt:   endedAt,
+			Summary:   summary,
+			Tags:      &normalizedTags,
+		})
+	})
 }
 
 // loadTagsForSearchResults is the SearchResult equivalent of loadTagsForObservations.

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -4720,3 +4720,138 @@ func TestApplyPulledMutationClearsTagsOnUpdate(t *testing.T) {
 		t.Errorf("expected no tags after clear via sync, got: %v", dstObs[0].Tags)
 	}
 }
+
+func TestSetSessionTagsPersistsAndLoads(t *testing.T) {
+	s := newTestStore(t)
+	newTestSession(t, s, "sess-tag-session", "mnemo")
+
+	if err := s.SetSessionTags("sess-tag-session", []string{"backend", "AUTH", "back-end"}); err != nil {
+		t.Fatalf("SetSessionTags: %v", err)
+	}
+
+	sess, err := s.GetSession("sess-tag-session")
+	if err != nil {
+		t.Fatalf("GetSession: %v", err)
+	}
+	tagSet := make(map[string]bool)
+	for _, tag := range sess.Tags {
+		tagSet[tag] = true
+	}
+	if !tagSet["backend"] {
+		t.Errorf("expected tag 'backend', got: %v", sess.Tags)
+	}
+	if !tagSet["auth"] {
+		t.Errorf("expected tag 'auth' (normalized from 'AUTH'), got: %v", sess.Tags)
+	}
+	// "back-end" normalizes to "back-end" but "backend" is already in the set —
+	// both should be present since they normalize differently.
+	if !tagSet["back-end"] {
+		t.Errorf("expected tag 'back-end', got: %v", sess.Tags)
+	}
+}
+
+func TestSessionTagsExportImportRoundTrip(t *testing.T) {
+	src := newTestStore(t)
+	newTestSession(t, src, "sess-export-tags", "mnemo")
+
+	if err := src.SetSessionTags("sess-export-tags", []string{"feature", "sync"}); err != nil {
+		t.Fatalf("SetSessionTags: %v", err)
+	}
+
+	data, err := src.Export()
+	if err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+
+	var exported *Session
+	for i := range data.Sessions {
+		if data.Sessions[i].ID == "sess-export-tags" {
+			exported = &data.Sessions[i]
+			break
+		}
+	}
+	if exported == nil {
+		t.Fatal("session not found in export")
+	}
+	tagSet := make(map[string]bool)
+	for _, tag := range exported.Tags {
+		tagSet[tag] = true
+	}
+	if !tagSet["feature"] || !tagSet["sync"] {
+		t.Errorf("expected tags [feature, sync] in export, got: %v", exported.Tags)
+	}
+
+	dst := newTestStore(t)
+	if _, err := dst.Import(data); err != nil {
+		t.Fatalf("Import: %v", err)
+	}
+
+	sess, err := dst.GetSession("sess-export-tags")
+	if err != nil {
+		t.Fatalf("GetSession after import: %v", err)
+	}
+	tagSet2 := make(map[string]bool)
+	for _, tag := range sess.Tags {
+		tagSet2[tag] = true
+	}
+	if !tagSet2["feature"] || !tagSet2["sync"] {
+		t.Errorf("expected tags [feature, sync] after import, got: %v", sess.Tags)
+	}
+}
+
+func TestSessionTagsSyncPayloadIncludesTags(t *testing.T) {
+	s := newTestStore(t)
+	newTestSession(t, s, "sess-sync-session-tags", "mnemo")
+
+	if err := s.SetSessionTags("sess-sync-session-tags", []string{"api", "refactor"}); err != nil {
+		t.Fatalf("SetSessionTags: %v", err)
+	}
+
+	mutations := enrollAndList(t, s, "mnemo")
+
+	var sessionMutation *SyncMutation
+	for i := range mutations {
+		if mutations[i].Entity == SyncEntitySession && mutations[i].EntityKey == "sess-sync-session-tags" {
+			sessionMutation = &mutations[i]
+		}
+	}
+	if sessionMutation == nil {
+		t.Fatal("no session mutation found")
+	}
+
+	var payload syncSessionPayload
+	if err := decodeSyncPayload([]byte(sessionMutation.Payload), &payload); err != nil {
+		t.Fatalf("decodeSyncPayload: %v", err)
+	}
+	if payload.Tags == nil {
+		t.Fatal("payload.Tags is nil — session tags not included in sync payload")
+	}
+	tagSet := make(map[string]bool)
+	for _, tag := range *payload.Tags {
+		tagSet[tag] = true
+	}
+	if !tagSet["api"] || !tagSet["refactor"] {
+		t.Errorf("expected tags [api, refactor] in session payload, got: %v", *payload.Tags)
+	}
+}
+
+func TestSuggestTagsNoSubstringMatch(t *testing.T) {
+	// "decision" as type should not suggest "ci" (substring of "decision")
+	tags := SuggestTags("decision", "some decision about architecture", "we decided to use X")
+	for _, tag := range tags {
+		if tag == "ci" {
+			t.Errorf("SuggestTags incorrectly suggested 'ci' from 'decision' via substring match")
+		}
+	}
+}
+
+func TestSuggestTagsExactTokenMatch(t *testing.T) {
+	tags := SuggestTags("bugfix", "ci pipeline fix", "the ci job was failing due to missing env")
+	tagSet := make(map[string]bool)
+	for _, tag := range tags {
+		tagSet[tag] = true
+	}
+	if !tagSet["ci"] {
+		t.Errorf("expected 'ci' tag when 'ci' appears as a whole word, got: %v", tags)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #1, #2, #3

Adds a tag system to mnemo observations and sessions without breaking the existing SQLite/FTS5 design.

**Store layer**

- Two new junction tables: `observation_tags` and `session_tags`, added via non-destructive migration.
- `Tags []string` on `Observation`, `AddObservationParams`, `UpdateObservationParams`, and `SearchOptions`.
- Tag normalization: lowercase, `[a-z0-9-]` only, trimmed.
- Tags are saved within the same transaction as the observation (both insert and topic_key upsert paths).
- `UpdateObservation`: `Tags != nil` replaces, `nil` preserves, empty slice clears.
- `RecentObservations`, `AllObservations`, `FormatContext`: variadic `tags` parameter — no breaking change for existing callers.
- `Search`: all-match filter via subquery on `observation_tags`.
- `SuggestTags`: infers tags from type family and content keywords.
- `PassiveCaptureResult.SuggestedTags`: aggregated suggestions across all extracted learnings.

**MCP layer**

- `mem_save`: optional `tags` param (comma-separated). Suggests tags in the response when none are provided.
- `mem_update`: optional `tags` param. Empty string clears all tags; omitting leaves them unchanged.
- `mem_search`: optional `tags` param, all-match filter.
- `mem_context`: optional `tags` param, filters observations included in context.
- `mem_capture_passive`: response includes suggested tags.
- `mem_suggest_topic_key`: response includes suggested tags alongside the topic_key.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes — 12 new tests covering tag CRUD, normalization, filters, and `SuggestTags`
- [x] `claude plugin validate plugin/claude-code` passes
- [ ] Manual smoke test: `mem_save` with tags, `mem_search` filtering by tag, `mem_context` with tag filter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tagging for observations and sessions — add, update, persist, export/import, and display tags.
  * Tools accept optional tags; suggested tags are shown only when no explicit tags are provided.
  * Search and context filtering by tags (results must match all requested tags).
  * Normalized automatic tag suggestions surfaced in save, suggest, and passive-capture flows.

* **Tests**
  * Comprehensive tests for tag persistence, normalization, search/filtering, update semantics, import/export round-trips, and suggestion generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->