### PR TITLE
feat: tag-based retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Only after this step proceed with agent setup.
 ## Features
 
 - **Session hooks:** Automatically starts/ends sessions and injects memory context at the beginning of every conversation
-- **14 MCP tools:** `mem_save`, `mem_search`, `mem_context`, `mem_session_summary`, and more, available directly inside your editor
+- **15 MCP tools:** `mem_save`, `mem_search`, `mem_context`, `mem_session_summary`, `mem_list_tags`, and more, available directly inside your editor
 - **Passive capture:** Extracts learnings from conversation transcripts automatically at session end
 - **Full CLI:** Save, search, export, import, and inspect memories from the terminal
 - **Own storage:** Isolated `~/.mnemo/memory.db`, created automatically on first run
@@ -194,25 +194,41 @@ On session start, mnemo detects the project from the git root directory name and
 
 Tools available inside your editor via the `mcp__mnemo__*` namespace:
 
-### Agent profile (default, 11 tools)
+### Agent profile (default, 12 tools)
 
 | Tool | Description |
 |---|---|
-| `mem_save` | Save a memory with title, content, type, and optional topic key |
-| `mem_search` | Full-text search across all memories |
+| `mem_save` | Save a memory with title, content, type, tags, and optional topic key |
+| `mem_search` | Search memories — by text, tags, topic key, or any combination |
 | `mem_context` | Retrieve formatted context from previous sessions |
 | `mem_session_summary` | Save an end-of-session summary with goal, discoveries, next steps |
 | `mem_session_start` | Register a new session |
-| `mem_session_end` | Mark a session as completed |
+| `mem_session_end` | Mark a session as completed, optionally with tags |
 | `mem_get_observation` | Retrieve full content of a memory by ID |
 | `mem_suggest_topic_key` | Suggest a topic key for deduplication |
 | `mem_capture_passive` | Extract and save learnings from free-form text |
 | `mem_save_prompt` | Save a prompt template |
-| `mem_update` | Update an existing memory |
+| `mem_update` | Update an existing memory, including tags |
+| `mem_list_tags` | List all tags in use for a project, ordered by frequency |
 
 ### Admin profile (3 tools)
 
 Available with `--tools=admin`: `mem_delete`, `mem_stats`, `mem_timeline`.
+
+### Search modes
+
+`mem_search` supports several independent intents. They compose:
+
+| Parameter | Type | Semantics |
+|---|---|---|
+| `query` | text, optional | Full-text search via FTS5. Omit to browse by other filters. |
+| `tags` | comma list | Hard filter. Only observations that have **all** listed tags are returned. |
+| `prefer_tags` | comma list | Soft signal. Observations matching more of these tags rank higher. Non-matching results are still returned. |
+| `topic_key` | string | Hard filter. Only observations with this exact topic key. |
+| `type` | string | Hard filter by observation type (e.g. `decision`, `bugfix`). |
+| `project` | string | Scope to a project. |
+
+`mem_context` accepts `tags`, `prefer_tags`, and `topic_key` with the same semantics, applied to recent observation retrieval.
 
 ```bash
 claude mcp add -s user mnemo-admin -- ~/.local/bin/mnemo mcp --tools=admin

--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -173,7 +173,7 @@ func registerTools(srv *server.MCPServer, s *store.Store, allowlist map[string]b
 				mcp.WithString("tags",
 					mcp.Description("Comma-separated tags to filter by (e.g. \"auth,backend\"). Only observations with ALL listed tags are returned."),
 				),
-				mcp.WithString("boost_tags",
+				mcp.WithString("prefer_tags",
 					mcp.Description("Comma-separated tags for soft ranking (e.g. \"auth,backend\"). Observations matching more of these tags rank higher; non-matching observations are still included."),
 				),
 				mcp.WithString("topic_key",
@@ -387,7 +387,7 @@ Examples:
 				mcp.WithString("tags",
 					mcp.Description("Comma-separated tags to filter observations (e.g. \"auth,backend\"). Only observations with ALL listed tags are included."),
 				),
-				mcp.WithString("boost_tags",
+				mcp.WithString("prefer_tags",
 					mcp.Description("Comma-separated tags for soft ranking. Observations matching more of these tags are surfaced first."),
 				),
 				mcp.WithString("topic_key",
@@ -631,7 +631,7 @@ func handleSearch(s *store.Store) server.ToolHandlerFunc {
 		topicKey, _ := req.GetArguments()["topic_key"].(string)
 		limit := intArg(req, "limit", 10)
 		tagsRaw, _ := req.GetArguments()["tags"].(string)
-		boostTagsRaw, _ := req.GetArguments()["boost_tags"].(string)
+		boostTagsRaw, _ := req.GetArguments()["prefer_tags"].(string)
 
 		results, err := s.Search(query, store.SearchOptions{
 			Type:      typ,
@@ -639,7 +639,7 @@ func handleSearch(s *store.Store) server.ToolHandlerFunc {
 			Scope:     scope,
 			TopicKey:  topicKey,
 			Tags:      parseTags(tagsRaw),
-			BoostTags: parseTags(boostTagsRaw),
+			PreferTags: parseTags(boostTagsRaw),
 			Limit:     limit,
 		})
 		if err != nil {
@@ -864,11 +864,11 @@ func handleContext(s *store.Store) server.ToolHandlerFunc {
 		scope, _ := req.GetArguments()["scope"].(string)
 		topicKey, _ := req.GetArguments()["topic_key"].(string)
 		tagsRaw, _ := req.GetArguments()["tags"].(string)
-		boostTagsRaw, _ := req.GetArguments()["boost_tags"].(string)
+		boostTagsRaw, _ := req.GetArguments()["prefer_tags"].(string)
 
 		ctx2, err := s.FormatContextOpts(project, scope, store.ContextOptions{
 			Tags:      parseTags(tagsRaw),
-			BoostTags: parseTags(boostTagsRaw),
+			PreferTags: parseTags(boostTagsRaw),
 			TopicKey:  topicKey,
 		})
 		if err != nil {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -117,7 +117,7 @@ type SearchOptions struct {
 	Scope     string   `json:"scope,omitempty"`
 	TopicKey  string   `json:"topic_key,omitempty"`
 	Tags      []string `json:"tags,omitempty"`
-	BoostTags []string `json:"boost_tags,omitempty"`
+	PreferTags []string `json:"prefer_tags,omitempty"`
 	Limit     int      `json:"limit,omitempty"`
 }
 
@@ -125,8 +125,8 @@ type SearchOptions struct {
 type ContextOptions struct {
 	// Tags is a hard filter: only observations with ALL listed tags are included.
 	Tags []string
-	// BoostTags is a soft signal: observations matching more of these tags rank higher.
-	BoostTags []string
+	// PreferTags is a soft signal: observations matching more of these tags rank higher.
+	PreferTags []string
 	// TopicKey boosts observations that share this topic_key without excluding others.
 	TopicKey string
 }
@@ -1121,7 +1121,7 @@ func (s *Store) recentObservations(project, scope string, limit int, opts Contex
 	}
 
 	// Soft boost (ORDER BY expression) — args must come after WHERE args.
-	boostTags := normalizeTagList(opts.BoostTags)
+	boostTags := normalizeTagList(opts.PreferTags)
 	topicKey := strings.TrimSpace(opts.TopicKey)
 
 	if topicKey != "" || len(boostTags) > 0 {
@@ -1526,9 +1526,9 @@ func (s *Store) Search(query string, opts SearchOptions) ([]SearchResult, error)
 }
 
 // searchByFilter handles Search when query is empty — no FTS, direct table scan.
-// Orders by BoostTags overlap (desc) then created_at (desc).
+// Orders by PreferTags overlap (desc) then created_at (desc).
 func (s *Store) searchByFilter(opts SearchOptions, limit int) ([]SearchResult, error) {
-	boostTags := normalizeTagList(opts.BoostTags)
+	boostTags := normalizeTagList(opts.PreferTags)
 
 	var boostExpr string
 	var boostArgs []any
@@ -1563,10 +1563,10 @@ func (s *Store) searchByFilter(opts SearchOptions, limit int) ([]SearchResult, e
 
 // searchFTS handles Search when a text query is provided.
 // Tag hard-filter and TopicKey filter are applied as WHERE clauses.
-// BoostTags add a secondary sort by overlap count after FTS rank.
+// PreferTags add a secondary sort by overlap count after FTS rank.
 func (s *Store) searchFTS(query string, opts SearchOptions, limit int) ([]SearchResult, error) {
 	ftsQuery := sanitizeFTS(query)
-	boostTags := normalizeTagList(opts.BoostTags)
+	boostTags := normalizeTagList(opts.PreferTags)
 
 	var boostExpr string
 	var boostArgs []any

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -4949,9 +4949,9 @@ func TestSearchEmptyQueryByTopicKey(t *testing.T) {
 	}
 }
 
-// ─── Issue #6 + #7: BoostTags y TopicKey boost ───────────────────────────────
+// ─── Issue #6 + #7: PreferTags y TopicKey boost ───────────────────────────────
 
-func TestSearchBoostTagsRankFirst(t *testing.T) {
+func TestSearchPreferTagsRankFirst(t *testing.T) {
 	s := newTestStore(t)
 	newTestSession(t, s, "sess-boost", "mnemo")
 
@@ -4992,7 +4992,7 @@ func TestSearchBoostTagsRankFirst(t *testing.T) {
 	// With boost: tagged (older) must appear first.
 	results, err := s.Search("architecture note", SearchOptions{
 		Project:   "mnemo",
-		BoostTags: []string{"auth"},
+		PreferTags: []string{"auth"},
 	})
 	if err != nil {
 		t.Fatalf("Search: %v", err)
@@ -5005,7 +5005,7 @@ func TestSearchBoostTagsRankFirst(t *testing.T) {
 	}
 }
 
-func TestRecentObservationsBoostTagsRankFirst(t *testing.T) {
+func TestRecentObservationsPreferTagsRankFirst(t *testing.T) {
 	s := newTestStore(t)
 	newTestSession(t, s, "sess-ctx-boost", "mnemo")
 
@@ -5044,7 +5044,7 @@ func TestRecentObservationsBoostTagsRankFirst(t *testing.T) {
 
 	// With boost: tagged (older) must appear first.
 	obs, err := s.RecentObservationsOpts("mnemo", "project", 10, ContextOptions{
-		BoostTags: []string{"auth"},
+		PreferTags: []string{"auth"},
 	})
 	if err != nil {
 		t.Fatalf("RecentObservationsOpts: %v", err)


### PR DESCRIPTION
Closes #5, #6, #7, #8

## Summary

- **#5** `Search` now accepts an empty query. When omitted, skips FTS5 and queries `observations` directly, ordered by `created_at DESC`. All filters apply: `project`, `type`, `scope`, `tags`, `topic_key`.
- **#6** Added `BoostTags []string` to `SearchOptions` and `ContextOptions`. Separate from `Tags` (hard filter). Observations matching more boost tags rank higher; non-matching results are still returned.
- **#7** Added `TopicKey string` to `SearchOptions` as a hard filter. In `FormatContextOpts` / `RecentObservationsOpts`, `TopicKey` acts as a soft boost: matching observations surface first, others remain.
- **#8** Added `ListTags(project string) ([]TagInfo, error)` and `mem_list_tags` MCP tool. Returns tag, count, last_used_at ordered by frequency.

## MCP changes

- `mem_search`: `query` is now optional; added `boost_tags`, `topic_key`
- `mem_context`: added `boost_tags`, `topic_key`
- `mem_list_tags`: new tool in agent and admin profiles

## Test plan

- [ ] `TestSearchEmptyQueryByTag` — browse by tag without text query
- [ ] `TestSearchEmptyQueryByTopicKey` — browse by topic_key without text query
- [ ] `TestSearchBoostTagsRankFirst` — FTS search with BoostTags ranks boosted results first
- [ ] `TestRecentObservationsBoostTagsRankFirst` — context retrieval with BoostTags
- [ ] `TestRecentObservationsTopicKeyBoost` — TopicKey boosts matching obs first, others remain
- [ ] `TestListTagsReturnsFrequency` — correct counts and ordering
- [ ] `TestListTagsFiltersByProject` — project isolation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tag listing with per-tag frequency and last-used timestamps.
  * Added exact topic-key filtering for searches and context retrieval.

* **Improvements**
  * Search can run without a text query (filter-only mode).
  * Added soft tag boosting to improve result ranking and prioritization.
  * mem_save, mem_update, and mem_session_end now support tags.

* **Documentation**
  * Updated tool docs to describe new search modes, tag semantics, and mem_list_tags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->