### PR TITLE
feat: add mem_related_tags tool for tag co-occurrence

### DIFF
--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -65,6 +65,7 @@ var ProfileAgent = map[string]bool{
 	"mem_list_tags":         true,
 	"mem_merge_tags":        true,
 	"mem_tag_stats":         true,
+	"mem_related_tags":      true,
 }
 
 // ProfileAdmin contains tools for CLI curation and dashboards.
@@ -472,6 +473,43 @@ Examples:
 				),
 			),
 			handleTagStats(s),
+		)
+	}
+
+	// ─── mem_related_tags ───────────────────────────────────────────────
+	if shouldRegister("mem_related_tags", allowlist) {
+		srv.AddTool(
+			mcp.NewTool("mem_related_tags",
+				mcp.WithDescription("Find tags that frequently co-occur with a given tag in observations or sessions. Useful for discovering related topics and navigating the tag graph."),
+				mcp.WithTitleAnnotation("Related Tags"),
+				mcp.WithReadOnlyHintAnnotation(true),
+				mcp.WithDestructiveHintAnnotation(false),
+				mcp.WithIdempotentHintAnnotation(true),
+				mcp.WithOpenWorldHintAnnotation(false),
+				mcp.WithString("tag",
+					mcp.Required(),
+					mcp.Description("Tag to find related tags for."),
+				),
+				mcp.WithString("project",
+					mcp.Description("Project name (omit for all projects)."),
+				),
+				mcp.WithNumber("limit",
+					mcp.Description("Max results to return (default: 20, 0 = no limit)."),
+				),
+				mcp.WithString("since",
+					mcp.Description("ISO8601 date. Only count co-occurrences after this date (e.g. '2026-01-01')."),
+				),
+				mcp.WithNumber("min_cooccurrence",
+					mcp.Description("Minimum co-occurrence count to include a tag (default: 1)."),
+				),
+				mcp.WithBoolean("include_observations",
+					mcp.Description("Include co-occurrences from observations (default: true)."),
+				),
+				mcp.WithBoolean("include_sessions",
+					mcp.Description("Include co-occurrences from sessions (default: true)."),
+				),
+			),
+			handleRelatedTags(s),
 		)
 	}
 
@@ -1071,6 +1109,68 @@ func handleMergeTags(s *store.Store) server.ToolHandlerFunc {
 		}
 		msg := fmt.Sprintf("Merged %q → %q: %d observation(s), %d session(s) updated.", from, canonicalTo, obsCount, sessCount)
 		return mcp.NewToolResultText(msg), nil
+	}
+}
+
+func handleRelatedTags(s *store.Store) server.ToolHandlerFunc {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		tag, _ := req.GetArguments()["tag"].(string)
+		if strings.TrimSpace(tag) == "" {
+			return mcp.NewToolResultError("'tag' is required"), nil
+		}
+		project, _ := req.GetArguments()["project"].(string)
+		limit := intArg(req, "limit", 20)
+		minCooc := intArg(req, "min_cooccurrence", 0)
+		sinceStr, _ := req.GetArguments()["since"].(string)
+		includeObs := boolArg(req, "include_observations", true)
+		includeSes := boolArg(req, "include_sessions", true)
+
+		if limit < 0 {
+			return mcp.NewToolResultError("limit must be >= 0"), nil
+		}
+
+		opts := store.RelatedTagsOptions{
+			Limit:               limit,
+			MinCooccurrence:     minCooc,
+			IncludeObservations: includeObs,
+			IncludeSessions:     includeSes,
+		}
+		if sinceStr != "" {
+			t, err := time.Parse(time.RFC3339, sinceStr)
+			if err != nil {
+				t, err = time.Parse("2006-01-02", sinceStr)
+				if err != nil {
+					return mcp.NewToolResultError("invalid since format: use ISO8601 (e.g. '2026-01-01T00:00:00Z' or '2026-01-01')"), nil
+				}
+			}
+			opts.Since = t
+		}
+
+		related, err := s.RelatedTags(project, tag, opts)
+		if err != nil {
+			return mcp.NewToolResultError("Failed to get related tags: " + err.Error()), nil
+		}
+
+		if len(related) == 0 {
+			msg := fmt.Sprintf("No tags co-occur with %q", tag)
+			if project != "" {
+				msg += " in project " + project
+			}
+			return mcp.NewToolResultText(msg + "."), nil
+		}
+
+		var b strings.Builder
+		label := "all projects"
+		if project != "" {
+			label = fmt.Sprintf("project %q", project)
+		}
+		fmt.Fprintf(&b, "Tags related to %q in %s (%d results):\n\n", tag, label, len(related))
+		fmt.Fprintf(&b, "  %-30s %12s   %s\n", "Tag", "Cooccurrences", "Last seen")
+		fmt.Fprintf(&b, "  %-30s %12s   %s\n", strings.Repeat("-", 30), "-------------", "---------")
+		for _, rt := range related {
+			fmt.Fprintf(&b, "  %-30s %12d   %s\n", rt.Tag, rt.CooccurrenceCount, rt.LastSeenAt)
+		}
+		return mcp.NewToolResultText(b.String()), nil
 	}
 }
 

--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -1122,11 +1122,23 @@ func handleRelatedTags(s *store.Store) server.ToolHandlerFunc {
 		limit := intArg(req, "limit", 20)
 		minCooc := intArg(req, "min_cooccurrence", 0)
 		sinceStr, _ := req.GetArguments()["since"].(string)
-		includeObs := boolArg(req, "include_observations", true)
-		includeSes := boolArg(req, "include_sessions", true)
+		includeObs, obsProvided := req.GetArguments()["include_observations"].(bool)
+		if !obsProvided {
+			includeObs = true
+		}
+		includeSes, sesProvided := req.GetArguments()["include_sessions"].(bool)
+		if !sesProvided {
+			includeSes = true
+		}
 
 		if limit < 0 {
 			return mcp.NewToolResultError("limit must be >= 0"), nil
+		}
+		if minCooc < 0 {
+			return mcp.NewToolResultError("min_cooccurrence must be >= 0"), nil
+		}
+		if obsProvided && sesProvided && !includeObs && !includeSes {
+			return mcp.NewToolResultError("at least one of include_observations or include_sessions must be true"), nil
 		}
 
 		opts := store.RelatedTagsOptions{

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -87,6 +87,28 @@ type TagWeight struct {
 	IsDominant   bool    // true if this tag is within the top N by frequency
 }
 
+// RelatedTag represents a tag that co-occurs with a queried tag.
+type RelatedTag struct {
+	Tag               string  `json:"tag"`
+	CooccurrenceCount int     `json:"cooccurrence_count"`
+	Score             float64 `json:"score"`
+	LastSeenAt        string  `json:"last_seen_at"`
+}
+
+// RelatedTagsOptions controls RelatedTags behaviour.
+type RelatedTagsOptions struct {
+	// Limit caps results. Zero means no limit.
+	Limit int
+	// Since restricts to co-occurrences seen after this time. Zero means no filter.
+	Since time.Time
+	// MinCooccurrence filters out tags that co-occur fewer than this many times. Zero means no filter.
+	MinCooccurrence int
+	// IncludeObservations counts co-occurrences from observation_tags (default: true when both are false).
+	IncludeObservations bool
+	// IncludeSessions counts co-occurrences from session_tags (default: true when both are false).
+	IncludeSessions bool
+}
+
 type SearchResult struct {
 	Observation
 	Rank float64 `json:"rank"`
@@ -1792,6 +1814,153 @@ func (s *Store) TagStats(project string, opts TagStatsOptions) ([]TagInfo, error
 		tags = append(tags, ti)
 	}
 	return tags, rows.Err()
+}
+
+// RelatedTags returns tags that co-occur with the given tag in observations and/or sessions.
+// When both IncludeObservations and IncludeSessions are false, both sources are used.
+func (s *Store) RelatedTags(project, tag string, opts RelatedTagsOptions) ([]RelatedTag, error) {
+	tag = NormalizeTag(tag)
+	if tag == "" {
+		return nil, fmt.Errorf("tag must not be empty")
+	}
+
+	// If neither flag is set, include both sources.
+	includeObs := opts.IncludeObservations || (!opts.IncludeObservations && !opts.IncludeSessions)
+	includeSes := opts.IncludeSessions || (!opts.IncludeObservations && !opts.IncludeSessions)
+
+	// acc accumulates counts and last-seen dates per co-occurring tag.
+	type entry struct {
+		count    int
+		lastSeen string
+	}
+	acc := make(map[string]*entry)
+
+	maxDate := func(a, b string) string {
+		if a > b {
+			return a
+		}
+		return b
+	}
+
+	if includeObs {
+		q := `
+			SELECT ot2.tag, COUNT(*) AS cnt, MAX(o.created_at) AS last_seen
+			FROM observation_tags ot1
+			JOIN observation_tags ot2
+			  ON ot1.observation_id = ot2.observation_id AND ot2.tag != ot1.tag
+			JOIN observations o ON o.id = ot1.observation_id
+			WHERE ot1.tag = ?
+			  AND o.deleted_at IS NULL`
+		var args []any
+		args = append(args, tag)
+		if project != "" {
+			q += " AND o.project = ?"
+			args = append(args, project)
+		}
+		if !opts.Since.IsZero() {
+			q += " AND o.created_at >= datetime(?)"
+			args = append(args, opts.Since.UTC().Format(time.RFC3339))
+		}
+		q += " GROUP BY ot2.tag"
+
+		rows, err := s.queryItHook(s.db, q, args...)
+		if err != nil {
+			return nil, fmt.Errorf("related tags (observations): %w", err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var t string
+			var cnt int
+			var last string
+			if err := rows.Scan(&t, &cnt, &last); err != nil {
+				return nil, err
+			}
+			if e, ok := acc[t]; ok {
+				e.count += cnt
+				e.lastSeen = maxDate(e.lastSeen, last)
+			} else {
+				acc[t] = &entry{count: cnt, lastSeen: last}
+			}
+		}
+		if err := rows.Err(); err != nil {
+			return nil, err
+		}
+	}
+
+	if includeSes {
+		q := `
+			SELECT st2.tag, COUNT(*) AS cnt, MAX(s.started_at) AS last_seen
+			FROM session_tags st1
+			JOIN session_tags st2
+			  ON st1.session_id = st2.session_id AND st2.tag != st1.tag
+			JOIN sessions s ON s.id = st1.session_id
+			WHERE st1.tag = ?`
+		var args []any
+		args = append(args, tag)
+		if project != "" {
+			q += " AND s.project = ?"
+			args = append(args, project)
+		}
+		if !opts.Since.IsZero() {
+			q += " AND s.started_at >= datetime(?)"
+			args = append(args, opts.Since.UTC().Format(time.RFC3339))
+		}
+		q += " GROUP BY st2.tag"
+
+		rows, err := s.queryItHook(s.db, q, args...)
+		if err != nil {
+			return nil, fmt.Errorf("related tags (sessions): %w", err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var t string
+			var cnt int
+			var last string
+			if err := rows.Scan(&t, &cnt, &last); err != nil {
+				return nil, err
+			}
+			if e, ok := acc[t]; ok {
+				e.count += cnt
+				e.lastSeen = maxDate(e.lastSeen, last)
+			} else {
+				acc[t] = &entry{count: cnt, lastSeen: last}
+			}
+		}
+		if err := rows.Err(); err != nil {
+			return nil, err
+		}
+	}
+
+	// Build result slice, apply MinCooccurrence filter.
+	minC := opts.MinCooccurrence
+	if minC <= 0 {
+		minC = 1
+	}
+	var result []RelatedTag
+	for t, e := range acc {
+		if e.count < minC {
+			continue
+		}
+		result = append(result, RelatedTag{
+			Tag:               t,
+			CooccurrenceCount: e.count,
+			Score:             float64(e.count),
+			LastSeenAt:        e.lastSeen,
+		})
+	}
+
+	// Sort: score desc, tag asc for ties.
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].Score != result[j].Score {
+			return result[i].Score > result[j].Score
+		}
+		return result[i].Tag < result[j].Tag
+	})
+
+	if opts.Limit > 0 && len(result) > opts.Limit {
+		result = result[:opts.Limit]
+	}
+	return result, nil
 }
 
 // tagWeights computes observability signals for a slice of TagInfo.

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -5731,3 +5731,384 @@ func TestTagStatsSortByAlpha(t *testing.T) {
 		t.Fatalf("unexpected alpha ordering: %v %v %v", tags[0].Tag, tags[1].Tag, tags[2].Tag)
 	}
 }
+
+// ─── RelatedTags ─────────────────────────────────────────────────────────────
+
+func TestRelatedTagsFromObservations(t *testing.T) {
+	s := newTestStore(t)
+	newTestSession(t, s, "sess-rt-obs", "proj-rt")
+
+	n := 0
+	add := func(tags []string) {
+		t.Helper()
+		n++
+		if _, err := s.AddObservation(AddObservationParams{
+			SessionID: "sess-rt-obs",
+			Type:      "decision",
+			Title:     fmt.Sprintf("obs %d", n),
+			Content:   fmt.Sprintf("content %d", n),
+			Project:   "proj-rt",
+			Tags:      tags,
+		}); err != nil {
+			t.Fatalf("AddObservation: %v", err)
+		}
+	}
+
+	add([]string{"auth", "backend", "security"})
+	add([]string{"auth", "backend"})
+	add([]string{"auth", "frontend"})
+
+	related, err := s.RelatedTags("proj-rt", "auth", RelatedTagsOptions{IncludeObservations: true})
+	if err != nil {
+		t.Fatalf("RelatedTags: %v", err)
+	}
+
+	byTag := make(map[string]RelatedTag)
+	for _, rt := range related {
+		byTag[rt.Tag] = rt
+	}
+
+	if byTag["backend"].CooccurrenceCount != 2 {
+		t.Errorf("expected backend count=2, got %d", byTag["backend"].CooccurrenceCount)
+	}
+	if byTag["security"].CooccurrenceCount != 1 {
+		t.Errorf("expected security count=1, got %d", byTag["security"].CooccurrenceCount)
+	}
+	if byTag["frontend"].CooccurrenceCount != 1 {
+		t.Errorf("expected frontend count=1, got %d", byTag["frontend"].CooccurrenceCount)
+	}
+	if _, found := byTag["auth"]; found {
+		t.Error("auth should not appear in its own related tags")
+	}
+}
+
+func TestRelatedTagsFromSessions(t *testing.T) {
+	s := newTestStore(t)
+	newTestSession(t, s, "sess-rt-s1", "proj-rts")
+	newTestSession(t, s, "sess-rt-s2", "proj-rts")
+	newTestSession(t, s, "sess-rt-s3", "proj-rts")
+
+	if err := s.SetSessionTags("sess-rt-s1", []string{"api", "backend"}); err != nil {
+		t.Fatalf("SetSessionTags s1: %v", err)
+	}
+	if err := s.SetSessionTags("sess-rt-s2", []string{"api", "backend"}); err != nil {
+		t.Fatalf("SetSessionTags s2: %v", err)
+	}
+	if err := s.SetSessionTags("sess-rt-s3", []string{"api", "frontend"}); err != nil {
+		t.Fatalf("SetSessionTags s3: %v", err)
+	}
+
+	related, err := s.RelatedTags("proj-rts", "api", RelatedTagsOptions{IncludeSessions: true})
+	if err != nil {
+		t.Fatalf("RelatedTags: %v", err)
+	}
+
+	byTag := make(map[string]RelatedTag)
+	for _, rt := range related {
+		byTag[rt.Tag] = rt
+	}
+
+	if byTag["backend"].CooccurrenceCount != 2 {
+		t.Errorf("expected backend count=2, got %d", byTag["backend"].CooccurrenceCount)
+	}
+	if byTag["frontend"].CooccurrenceCount != 1 {
+		t.Errorf("expected frontend count=1, got %d", byTag["frontend"].CooccurrenceCount)
+	}
+}
+
+func TestRelatedTagsBothSources(t *testing.T) {
+	s := newTestStore(t)
+	newTestSession(t, s, "sess-rt-both", "proj-both")
+
+	// obs: auth + backend (1 co-occurrence from observations)
+	if _, err := s.AddObservation(AddObservationParams{
+		SessionID: "sess-rt-both",
+		Type:      "decision",
+		Title:     "obs",
+		Content:   "content",
+		Project:   "proj-both",
+		Tags:      []string{"auth", "backend"},
+	}); err != nil {
+		t.Fatalf("AddObservation: %v", err)
+	}
+	// session: auth + backend (1 co-occurrence from sessions)
+	if err := s.SetSessionTags("sess-rt-both", []string{"auth", "backend"}); err != nil {
+		t.Fatalf("SetSessionTags: %v", err)
+	}
+
+	// Both sources enabled (default).
+	related, err := s.RelatedTags("proj-both", "auth", RelatedTagsOptions{})
+	if err != nil {
+		t.Fatalf("RelatedTags: %v", err)
+	}
+
+	byTag := make(map[string]RelatedTag)
+	for _, rt := range related {
+		byTag[rt.Tag] = rt
+	}
+
+	if byTag["backend"].CooccurrenceCount != 2 {
+		t.Errorf("expected backend count=2 (1 obs + 1 session), got %d", byTag["backend"].CooccurrenceCount)
+	}
+}
+
+func TestRelatedTagsProjectFilter(t *testing.T) {
+	s := newTestStore(t)
+	newTestSession(t, s, "sess-rt-pa", "proj-a")
+	newTestSession(t, s, "sess-rt-pb", "proj-b")
+
+	if _, err := s.AddObservation(AddObservationParams{
+		SessionID: "sess-rt-pa",
+		Type:      "decision",
+		Title:     "obs-a",
+		Content:   "content",
+		Project:   "proj-a",
+		Tags:      []string{"auth", "backend"},
+	}); err != nil {
+		t.Fatalf("AddObservation proj-a: %v", err)
+	}
+	if _, err := s.AddObservation(AddObservationParams{
+		SessionID: "sess-rt-pb",
+		Type:      "decision",
+		Title:     "obs-b",
+		Content:   "content",
+		Project:   "proj-b",
+		Tags:      []string{"auth", "frontend"},
+	}); err != nil {
+		t.Fatalf("AddObservation proj-b: %v", err)
+	}
+
+	related, err := s.RelatedTags("proj-a", "auth", RelatedTagsOptions{IncludeObservations: true})
+	if err != nil {
+		t.Fatalf("RelatedTags: %v", err)
+	}
+
+	byTag := make(map[string]RelatedTag)
+	for _, rt := range related {
+		byTag[rt.Tag] = rt
+	}
+
+	if _, found := byTag["backend"]; !found {
+		t.Error("expected backend from proj-a")
+	}
+	if _, found := byTag["frontend"]; found {
+		t.Error("frontend from proj-b should not appear when filtering by proj-a")
+	}
+}
+
+func TestRelatedTagsSinceFilter(t *testing.T) {
+	s := newTestStore(t)
+	newTestSession(t, s, "sess-rt-since", "proj-since")
+
+	// Add two observations with different tags co-occurring with auth.
+	if _, err := s.AddObservation(AddObservationParams{
+		SessionID: "sess-rt-since",
+		Type:      "decision",
+		Title:     "obs legacy",
+		Content:   "content legacy",
+		Project:   "proj-since",
+		Tags:      []string{"auth", "legacy"},
+	}); err != nil {
+		t.Fatalf("AddObservation legacy: %v", err)
+	}
+	if _, err := s.AddObservation(AddObservationParams{
+		SessionID: "sess-rt-since",
+		Type:      "decision",
+		Title:     "obs modern",
+		Content:   "content modern",
+		Project:   "proj-since",
+		Tags:      []string{"auth", "modern"},
+	}); err != nil {
+		t.Fatalf("AddObservation modern: %v", err)
+	}
+
+	// With no Since filter both should appear.
+	all, err := s.RelatedTags("proj-since", "auth", RelatedTagsOptions{IncludeObservations: true})
+	if err != nil {
+		t.Fatalf("RelatedTags (no filter): %v", err)
+	}
+	byTagAll := make(map[string]RelatedTag)
+	for _, rt := range all {
+		byTagAll[rt.Tag] = rt
+	}
+	if _, found := byTagAll["legacy"]; !found {
+		t.Error("expected legacy in unfiltered results")
+	}
+	if _, found := byTagAll["modern"]; !found {
+		t.Error("expected modern in unfiltered results")
+	}
+
+	// With Since = future, nothing should appear.
+	future := time.Now().UTC().Add(time.Hour)
+	none, err := s.RelatedTags("proj-since", "auth", RelatedTagsOptions{
+		IncludeObservations: true,
+		Since:               future,
+	})
+	if err != nil {
+		t.Fatalf("RelatedTags (future since): %v", err)
+	}
+	if len(none) != 0 {
+		t.Errorf("expected no results with future Since, got %v", none)
+	}
+}
+
+func TestRelatedTagsExcludesSelf(t *testing.T) {
+	s := newTestStore(t)
+	newTestSession(t, s, "sess-rt-self", "proj-self")
+
+	if _, err := s.AddObservation(AddObservationParams{
+		SessionID: "sess-rt-self",
+		Type:      "decision",
+		Title:     "obs",
+		Content:   "content",
+		Project:   "proj-self",
+		Tags:      []string{"auth", "backend"},
+	}); err != nil {
+		t.Fatalf("AddObservation: %v", err)
+	}
+
+	related, err := s.RelatedTags("proj-self", "auth", RelatedTagsOptions{IncludeObservations: true})
+	if err != nil {
+		t.Fatalf("RelatedTags: %v", err)
+	}
+
+	for _, rt := range related {
+		if rt.Tag == "auth" {
+			t.Error("auth must not appear in its own related tags")
+		}
+	}
+}
+
+func TestRelatedTagsOrderByScore(t *testing.T) {
+	s := newTestStore(t)
+	newTestSession(t, s, "sess-rt-order", "proj-order")
+
+	n := 0
+	add := func(tags []string) {
+		t.Helper()
+		n++
+		if _, err := s.AddObservation(AddObservationParams{
+			SessionID: "sess-rt-order",
+			Type:      "decision",
+			Title:     fmt.Sprintf("obs %d", n),
+			Content:   fmt.Sprintf("content %d", n),
+			Project:   "proj-order",
+			Tags:      tags,
+		}); err != nil {
+			t.Fatalf("AddObservation: %v", err)
+		}
+	}
+
+	// backend co-occurs 3 times, frontend once, security twice.
+	add([]string{"auth", "backend"})
+	add([]string{"auth", "backend"})
+	add([]string{"auth", "backend"})
+	add([]string{"auth", "security"})
+	add([]string{"auth", "security"})
+	add([]string{"auth", "frontend"})
+
+	related, err := s.RelatedTags("proj-order", "auth", RelatedTagsOptions{IncludeObservations: true})
+	if err != nil {
+		t.Fatalf("RelatedTags: %v", err)
+	}
+
+	if len(related) < 3 {
+		t.Fatalf("expected at least 3 related tags, got %d", len(related))
+	}
+	if related[0].Tag != "backend" {
+		t.Errorf("expected backend first (count=3), got %q", related[0].Tag)
+	}
+	if related[1].Tag != "security" {
+		t.Errorf("expected security second (count=2), got %q", related[1].Tag)
+	}
+	if related[2].Tag != "frontend" {
+		t.Errorf("expected frontend third (count=1), got %q", related[2].Tag)
+	}
+}
+
+func TestRelatedTagsMinCooccurrence(t *testing.T) {
+	s := newTestStore(t)
+	newTestSession(t, s, "sess-rt-minc", "proj-minc")
+
+	n := 0
+	add := func(tags []string) {
+		t.Helper()
+		n++
+		if _, err := s.AddObservation(AddObservationParams{
+			SessionID: "sess-rt-minc",
+			Type:      "decision",
+			Title:     fmt.Sprintf("obs %d", n),
+			Content:   fmt.Sprintf("content %d", n),
+			Project:   "proj-minc",
+			Tags:      tags,
+		}); err != nil {
+			t.Fatalf("AddObservation: %v", err)
+		}
+	}
+
+	add([]string{"auth", "backend"})
+	add([]string{"auth", "backend"})
+	add([]string{"auth", "rare"})
+
+	related, err := s.RelatedTags("proj-minc", "auth", RelatedTagsOptions{
+		IncludeObservations: true,
+		MinCooccurrence:     2,
+	})
+	if err != nil {
+		t.Fatalf("RelatedTags: %v", err)
+	}
+
+	for _, rt := range related {
+		if rt.Tag == "rare" {
+			t.Error("rare should be excluded by min_cooccurrence=2")
+		}
+	}
+	if len(related) != 1 || related[0].Tag != "backend" {
+		t.Errorf("expected only backend, got %v", related)
+	}
+}
+
+func TestRelatedTagsEmptyTagError(t *testing.T) {
+	s := newTestStore(t)
+	_, err := s.RelatedTags("", "", RelatedTagsOptions{})
+	if err == nil {
+		t.Error("expected error for empty tag")
+	}
+}
+
+func TestRelatedTagsIncludeFlags(t *testing.T) {
+	s := newTestStore(t)
+	newTestSession(t, s, "sess-rt-flags", "proj-flags")
+
+	// obs: auth + obs-only
+	if _, err := s.AddObservation(AddObservationParams{
+		SessionID: "sess-rt-flags",
+		Type:      "decision",
+		Title:     "obs",
+		Content:   "content",
+		Project:   "proj-flags",
+		Tags:      []string{"auth", "obs-only"},
+	}); err != nil {
+		t.Fatalf("AddObservation: %v", err)
+	}
+	// session: auth + sess-only
+	if err := s.SetSessionTags("sess-rt-flags", []string{"auth", "sess-only"}); err != nil {
+		t.Fatalf("SetSessionTags: %v", err)
+	}
+
+	// IncludeObservations=true, IncludeSessions=false → only obs-only should appear.
+	related, err := s.RelatedTags("proj-flags", "auth", RelatedTagsOptions{IncludeObservations: true, IncludeSessions: false})
+	if err != nil {
+		t.Fatalf("RelatedTags: %v", err)
+	}
+	byTag := make(map[string]RelatedTag)
+	for _, rt := range related {
+		byTag[rt.Tag] = rt
+	}
+	if _, found := byTag["obs-only"]; !found {
+		t.Error("obs-only should appear when IncludeObservations=true")
+	}
+	if _, found := byTag["sess-only"]; found {
+		t.Error("sess-only should not appear when IncludeSessions=false")
+	}
+}


### PR DESCRIPTION
Adds mem_related_tags MCP tool and store.RelatedTags().

For a given tag, returns other tags that appear together with it in observations and sessions. Relations are derived at query time, nothing is persisted.

Accepts tag (required), project, limit, since, min_cooccurrence, include_observations, include_sessions.

Score is float64(cooccurrence_count). Recency and dominance adjustments can come once the signal is validated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added mem_related_tags tool to find tags that commonly co-occur with a given tag.
  * Supports project filter, date range (since), min co-occurrence, and result limit.
  * Can analyze observations, sessions, or both; defaults to both when omitted.
  * Accepts RFC3339 or YYYY-MM-DD for dates and returns a table of tags, counts, and last-seen timestamps.

* **Tests**
  * Added comprehensive tests covering options, filters, validation, and source selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->