### PR TITLE
feat: add Codex agent support

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -299,7 +299,7 @@ setup_codex() {
   elif grep -q '^\[features\]' "$codex_config" 2>/dev/null; then
     local tmp
     tmp=$(mktemp)
-    awk '/^\[features\]/{print; print "codex_hooks = true"; next} 1' "$codex_config" > "$tmp" && mv "$tmp" "$codex_config"
+    awk '/^\[features\]/{print; print "codex_hooks = true"; next} 1' "$codex_config" > "$tmp" && mv "$tmp" "$codex_config" || rm -f "$tmp"
     ok "~/.codex/config.toml: codex_hooks enabled"
   else
     printf '\n[features]\ncodex_hooks = true\n' >> "$codex_config"

--- a/install.sh
+++ b/install.sh
@@ -5,6 +5,7 @@
 # Agent selection (default: claudecode):
 #   bash -s -- --agent=cursor
 #   bash -s -- --agent=windsurf
+#   bash -s -- --agent=codex
 #   bash -s -- --agent=all
 #
 # Environment overrides:
@@ -263,6 +264,60 @@ setup_cursor() {
   ok "~/.cursor/rules/mnemo.mdc written"
 }
 
+# ── setup: Codex ──────────────────────────────────────────────────────────────
+
+setup_codex() {
+  local mnemo_bin="$1"
+  local codex_dir="$HOME/.codex"
+  local hooks_dir="$codex_dir/hooks"
+  local hooks_json="$codex_dir/hooks.json"
+  local codex_config="$codex_dir/config.toml"
+  local agents_md="$codex_dir/AGENTS.md"
+  local marker="## mnemo — Persistent Memory Protocol"
+
+  info "Configuring Codex..."
+
+  mkdir -p "$hooks_dir"
+  cp "$TMP_SCRIPTS/codex/hooks/session-start.sh" "$hooks_dir/"
+  cp "$TMP_SCRIPTS/codex/hooks/stop.sh" "$hooks_dir/"
+  cp "$TMP_SCRIPTS/codex/hooks/mnemo-protocol.md" "$hooks_dir/"
+  chmod +x "$hooks_dir/session-start.sh" "$hooks_dir/stop.sh"
+  ok "Hook scripts installed to ${hooks_dir}"
+
+  touch "$codex_config"
+
+  if grep -q '\[mcp_servers\.mnemo\]' "$codex_config" 2>/dev/null; then
+    ok "~/.codex/config.toml: mnemo MCP already configured"
+  else
+    tail -c1 "$codex_config" | grep -q $'\n' || printf '\n' >> "$codex_config"
+    printf '\n[mcp_servers.mnemo]\ncommand = "%s"\nargs = ["mcp", "--tools=agent"]\n' "$mnemo_bin" >> "$codex_config"
+    ok "~/.codex/config.toml: mnemo MCP configured"
+  fi
+
+  if grep -q 'codex_hooks' "$codex_config" 2>/dev/null; then
+    ok "~/.codex/config.toml: codex_hooks already set"
+  else
+    printf '\n[features]\ncodex_hooks = true\n' >> "$codex_config"
+    ok "~/.codex/config.toml: codex_hooks enabled"
+  fi
+
+  local result
+  result=$(printf '{"hooks":{"SessionStart":[{"matcher":"startup|resume","hooks":[{"type":"command","command":"%s/session-start.sh","statusMessage":"Loading mnemo memory...","timeout":10}]}],"Stop":[{"matcher":"","hooks":[{"type":"command","command":"%s/stop.sh","timeout":10}]}]}}' \
+    "$hooks_dir" "$hooks_dir" | "$mnemo_bin" json-merge "$hooks_json")
+  ok "~/.codex/hooks.json: ${result}"
+
+  if [ -f "$agents_md" ] && grep -qF "$marker" "$agents_md" 2>/dev/null; then
+    ok "~/.codex/AGENTS.md already up to date"
+  else
+    if [ -f "$agents_md" ] && [ -s "$agents_md" ]; then
+      tail -c1 "$agents_md" | grep -q $'\n' || printf '\n' >> "$agents_md"
+      printf '\n' >> "$agents_md"
+    fi
+    cat "$TMP_SCRIPTS/codex/AGENTS.md" >> "$agents_md"
+    ok "~/.codex/AGENTS.md updated"
+  fi
+}
+
 # ── setup: Windsurf ────────────────────────────────────────────────────────────
 
 setup_windsurf() {
@@ -360,14 +415,19 @@ main() {
       setup_windsurf "$mnemo_bin"
       ok "Done. Restart Windsurf to activate mnemo."
       ;;
+    codex)
+      setup_codex "$mnemo_bin"
+      ok "Done. Restart Codex to activate mnemo."
+      ;;
     all)
       setup_claudecode "$mnemo_bin"
       setup_cursor "$mnemo_bin"
       setup_windsurf "$mnemo_bin"
+      setup_codex "$mnemo_bin"
       ok "Done. Restart your editors to activate mnemo."
       ;;
     *)
-      err "Unknown agent: ${AGENT}. Valid options: claudecode | cursor | windsurf | all"
+      err "Unknown agent: ${AGENT}. Valid options: claudecode | cursor | windsurf | codex | all"
       ;;
   esac
 }

--- a/install.sh
+++ b/install.sh
@@ -294,8 +294,13 @@ setup_codex() {
     ok "~/.codex/config.toml: mnemo MCP configured"
   fi
 
-  if grep -q 'codex_hooks' "$codex_config" 2>/dev/null; then
+  if grep -q '^codex_hooks\s*=' "$codex_config" 2>/dev/null; then
     ok "~/.codex/config.toml: codex_hooks already set"
+  elif grep -q '^\[features\]' "$codex_config" 2>/dev/null; then
+    local tmp
+    tmp=$(mktemp)
+    awk '/^\[features\]/{print; print "codex_hooks = true"; next} 1' "$codex_config" > "$tmp" && mv "$tmp" "$codex_config"
+    ok "~/.codex/config.toml: codex_hooks enabled"
   else
     printf '\n[features]\ncodex_hooks = true\n' >> "$codex_config"
     ok "~/.codex/config.toml: codex_hooks enabled"

--- a/install.sh
+++ b/install.sh
@@ -286,24 +286,46 @@ setup_codex() {
 
   touch "$codex_config"
 
-  if grep -q '\[mcp_servers\.mnemo\]' "$codex_config" 2>/dev/null; then
-    ok "~/.codex/config.toml: mnemo MCP already configured"
+  if grep -q '^\[mcp_servers\.mnemo\]' "$codex_config" 2>/dev/null; then
+    local tmp_mcp
+    tmp_mcp=$(mktemp)
+    awk -v bin="$mnemo_bin" '
+      /^\[mcp_servers\.mnemo\]/{
+        print "[mcp_servers.mnemo]"
+        print "command = \"" bin "\""
+        print "args = [\"mcp\", \"--tools=agent\"]"
+        skip=1; next
+      }
+      skip && /^\[/{skip=0}
+      !skip{print}
+    ' "$codex_config" > "$tmp_mcp"
+    if mv "$tmp_mcp" "$codex_config"; then
+      ok "$HOME/.codex/config.toml: mnemo MCP updated"
+    else
+      rm -f "$tmp_mcp"
+      err "Failed to update $HOME/.codex/config.toml"
+    fi
   else
     tail -c1 "$codex_config" | grep -q $'\n' || printf '\n' >> "$codex_config"
     printf '\n[mcp_servers.mnemo]\ncommand = "%s"\nargs = ["mcp", "--tools=agent"]\n' "$mnemo_bin" >> "$codex_config"
-    ok "~/.codex/config.toml: mnemo MCP configured"
+    ok "$HOME/.codex/config.toml: mnemo MCP configured"
   fi
 
   if grep -q '^codex_hooks\s*=' "$codex_config" 2>/dev/null; then
-    ok "~/.codex/config.toml: codex_hooks already set"
+    ok "$HOME/.codex/config.toml: codex_hooks already set"
   elif grep -q '^\[features\]' "$codex_config" 2>/dev/null; then
     local tmp
     tmp=$(mktemp)
-    awk '/^\[features\]/{print; print "codex_hooks = true"; next} 1' "$codex_config" > "$tmp" && mv "$tmp" "$codex_config" || rm -f "$tmp"
-    ok "~/.codex/config.toml: codex_hooks enabled"
+    awk '/^\[features\]/{print; print "codex_hooks = true"; next} 1' "$codex_config" > "$tmp"
+    if mv "$tmp" "$codex_config"; then
+      ok "$HOME/.codex/config.toml: codex_hooks enabled"
+    else
+      rm -f "$tmp"
+      err "Failed to update $HOME/.codex/config.toml"
+    fi
   else
     printf '\n[features]\ncodex_hooks = true\n' >> "$codex_config"
-    ok "~/.codex/config.toml: codex_hooks enabled"
+    ok "$HOME/.codex/config.toml: codex_hooks enabled"
   fi
 
   local result

--- a/scripts/codex/AGENTS.md
+++ b/scripts/codex/AGENTS.md
@@ -22,7 +22,7 @@ Call `mem_save` IMMEDIATELY after ANY of these:
 ### SUBAGENT OUTPUT — required format for passive capture
 When running as a subagent, always end your response with a structured section:
 
-```
+```markdown
 ## Key Learnings
 - <learning 1>
 - <learning 2>

--- a/scripts/codex/AGENTS.md
+++ b/scripts/codex/AGENTS.md
@@ -1,0 +1,41 @@
+## mnemo — Persistent Memory Protocol
+
+You have access to mnemo MCP tools: mem_save, mem_search, mem_context, mem_session_summary.
+
+### PROACTIVE SAVE — do NOT wait for user to ask
+Call `mem_save` IMMEDIATELY after ANY of these:
+- Decision made (architecture, convention, workflow, tool choice)
+- Bug fixed (include root cause)
+- Convention or workflow documented/updated
+- Non-obvious discovery, gotcha, or edge case found
+- Pattern established (naming, structure, approach)
+- User preference or constraint learned
+- Feature implemented with non-obvious approach
+
+**Self-check after EVERY task**: "Did I just make a decision, fix a bug, learn something, or establish a convention? If yes → mem_save NOW."
+
+### SEARCH MEMORY when:
+- User asks to recall anything
+- Starting work on something that might have been done before
+- User mentions a topic you have no context on
+
+### SUBAGENT OUTPUT — required format for passive capture
+When running as a subagent, always end your response with a structured section:
+
+```
+## Key Learnings
+- <learning 1>
+- <learning 2>
+```
+
+This enables mnemo to automatically extract and persist what you discovered.
+Omit the section only if the task produced no learnings worth retaining.
+
+### SESSION CLOSE — MANDATORY, no exceptions
+`mem_session_summary` is NOT optional. It is the final step of every session.
+Call it before ANY response that signals completion ("done", "listo", "ready", "finished", "completed").
+Fields: Goal, Discoveries, Accomplished, Next Steps, Relevant Files.
+
+If nothing was accomplished: call it anyway with Goal and Next Steps.
+If the user says goodbye: call it before responding.
+No session ends without `mem_session_summary`.

--- a/scripts/codex/hooks/mnemo-protocol.md
+++ b/scripts/codex/hooks/mnemo-protocol.md
@@ -1,0 +1,29 @@
+## mnemo — Persistent Memory Protocol
+
+You have access to mnemo MCP tools: mem_save, mem_search, mem_context, mem_session_summary.
+
+### PROACTIVE SAVE — do NOT wait for user to ask
+Call `mem_save` IMMEDIATELY after ANY of these:
+- Decision made (architecture, convention, workflow, tool choice)
+- Bug fixed (include root cause)
+- Convention or workflow documented/updated
+- Non-obvious discovery, gotcha, or edge case found
+- Pattern established (naming, structure, approach)
+- User preference or constraint learned
+- Feature implemented with non-obvious approach
+
+**Self-check after EVERY task**: "Did I just make a decision, fix a bug, learn something, or establish a convention? If yes → mem_save NOW."
+
+### SEARCH MEMORY when:
+- User asks to recall anything
+- Starting work on something that might have been done before
+- User mentions a topic you have no context on
+
+### SESSION CLOSE — MANDATORY, no exceptions
+`mem_session_summary` is NOT optional. It is the final step of every session.
+Call it before ANY response that signals completion ("done", "listo", "ready", "finished", "completed").
+Fields: Goal, Discoveries, Accomplished, Next Steps, Relevant Files.
+
+If nothing was accomplished: call it anyway with Goal and Next Steps.
+If the user says goodbye: call it before responding.
+No session ends without `mem_session_summary`.

--- a/scripts/codex/hooks/session-start.sh
+++ b/scripts/codex/hooks/session-start.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# mnemo — SessionStart hook for Codex CLI
+# Fires on session startup and resume.
+#
+# Input: {
+#   "session_id": "...", "cwd": "...", "hook_event_name": "SessionStart"
+# }
+#
+# Output: { "continue": true, "systemMessage": "..." }
+
+HOOKS_DIR="$(dirname "$0")"
+
+INPUT=$(cat)
+SESSION_ID=$(echo "$INPUT" | mnemo json session_id 2>/dev/null)
+CWD=$(echo "$INPUT" | mnemo json cwd 2>/dev/null)
+
+if [ -z "$SESSION_ID" ]; then
+  printf '{"continue":true}\n'
+  exit 0
+fi
+
+[ -z "$CWD" ] && CWD="$(pwd)"
+
+PROJECT=$(realpath "$CWD" 2>/dev/null | sed "s|^$HOME/||; s|^/||" | tr '/' '-' | tr '[:upper:]' '[:lower:]')
+[ -z "$PROJECT" ] && PROJECT=$(basename "$CWD" | tr '[:upper:]' '[:lower:]')
+
+IS_RESUME=$(mnemo session exists "$SESSION_ID" 2>/dev/null)
+
+if [ "$IS_RESUME" = "true" ]; then
+  STATUS="[mnemo] Session resumed (project: ${PROJECT})"
+else
+  mnemo session start "$SESSION_ID" --project "$PROJECT" --dir "$CWD" 2>/dev/null || true
+  STATUS="[mnemo] New session started (project: ${PROJECT})"
+fi
+
+CONTEXT=$(mnemo context "$PROJECT" 2>/dev/null)
+PROTOCOL=$(cat "${HOOKS_DIR}/mnemo-protocol.md" 2>/dev/null)
+
+MSG=$(printf '%s\n\n%s\n\n%s' "$STATUS" "$CONTEXT" "$PROTOCOL")
+
+MSG_JSON=$(printf '%s' "$MSG" | awk 'BEGIN{ORS=""} NR>1{printf "\\n"} {gsub(/\\/, "\\\\"); gsub(/"/, "\\\""); gsub(/\t/, "\\t"); gsub(/\r/, "\\r"); print}')
+
+printf '{"continue":true,"systemMessage":"%s"}\n' "$MSG_JSON"
+
+exit 0

--- a/scripts/codex/hooks/session-start.sh
+++ b/scripts/codex/hooks/session-start.sh
@@ -21,7 +21,10 @@ fi
 
 [ -z "$CWD" ] && CWD="$(pwd)"
 
-PROJECT=$(realpath "$CWD" 2>/dev/null | sed "s|^$HOME/||; s|^/||" | tr '/' '-' | tr '[:upper:]' '[:lower:]')
+REALPATH_CWD=$(realpath "$CWD" 2>/dev/null)
+PROJECT="${REALPATH_CWD#"$HOME/"}"
+PROJECT="${PROJECT#/}"
+PROJECT=$(printf '%s' "$PROJECT" | tr '/' '-' | tr '[:upper:]' '[:lower:]')
 [ -z "$PROJECT" ] && PROJECT=$(basename "$CWD" | tr '[:upper:]' '[:lower:]')
 
 IS_RESUME=$(mnemo session exists "$SESSION_ID" 2>/dev/null)

--- a/scripts/codex/hooks/stop.sh
+++ b/scripts/codex/hooks/stop.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# mnemo — Stop hook for Codex CLI
+# Fires when the agent stops. Reads transcript for passive capture,
+# then closes the mnemo session.
+#
+# Input: {
+#   "session_id": "...", "transcript_path": "...", "cwd": "...",
+#   "hook_event_name": "Stop", "reason": "...", "turn_id": "..."
+# }
+#
+# Output: { "continue": true }
+
+INPUT=$(cat)
+SESSION_ID=$(echo "$INPUT" | mnemo json session_id 2>/dev/null)
+TRANSCRIPT_PATH=$(echo "$INPUT" | mnemo json transcript_path 2>/dev/null)
+CWD=$(echo "$INPUT" | mnemo json cwd 2>/dev/null)
+
+if [ -z "$SESSION_ID" ]; then
+  printf '{"continue":true}\n'
+  exit 0
+fi
+
+[ -z "$CWD" ] && CWD="$(pwd)"
+
+PROJECT=$(realpath "$CWD" 2>/dev/null | sed "s|^$HOME/||; s|^/||" | tr '/' '-' | tr '[:upper:]' '[:lower:]')
+[ -z "$PROJECT" ] && PROJECT=$(basename "$CWD" | tr '[:upper:]' '[:lower:]')
+
+# Passive capture from transcript if available
+if [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ]; then
+  CONTENT=$(mnemo extract-transcript "$TRANSCRIPT_PATH" 2>/dev/null)
+  if [ -z "$CONTENT" ]; then
+    CONTENT=$(cat "$TRANSCRIPT_PATH" 2>/dev/null)
+  fi
+
+  if [ -n "$CONTENT" ]; then
+    mnemo capture "$CONTENT" --session "$SESSION_ID" --project "$PROJECT" 2>/dev/null || true
+  fi
+fi
+
+OBS_COUNT=$(mnemo session obs-count "$SESSION_ID" 2>/dev/null)
+mnemo session end "$SESSION_ID" 2>/dev/null || true
+
+if [ "${OBS_COUNT:-0}" = "0" ]; then
+  printf '{"continue":true,"systemMessage":"[mnemo] warning: session ended with 0 memories saved."}\n'
+  exit 0
+fi
+
+printf '{"continue":true}\n'
+exit 0

--- a/scripts/codex/hooks/stop.sh
+++ b/scripts/codex/hooks/stop.sh
@@ -22,7 +22,10 @@ fi
 
 [ -z "$CWD" ] && CWD="$(pwd)"
 
-PROJECT=$(realpath "$CWD" 2>/dev/null | sed "s|^$HOME/||; s|^/||" | tr '/' '-' | tr '[:upper:]' '[:lower:]')
+REALPATH_CWD=$(realpath "$CWD" 2>/dev/null)
+PROJECT="${REALPATH_CWD#"$HOME/"}"
+PROJECT="${PROJECT#/}"
+PROJECT=$(printf '%s' "$PROJECT" | tr '/' '-' | tr '[:upper:]' '[:lower:]')
 [ -z "$PROJECT" ] && PROJECT=$(basename "$CWD" | tr '[:upper:]' '[:lower:]')
 
 # Passive capture from transcript if available


### PR DESCRIPTION
Adds support for Codex CLI (OpenAI) following the same pattern as Cursor and Windsurf — everything in `install.sh`, no Go changes.

## What changed

`install.sh` gets a new `setup_codex()` function and a new `--agent=codex` option. The function:

- installs hook scripts to `~/.codex/hooks/`
- configures the mnemo MCP server in `~/.codex/config.toml`
- enables the `codex_hooks = true` feature flag
- merges hook definitions into `~/.codex/hooks.json`
- appends the protocol to `~/.codex/AGENTS.md`

Four new files under `scripts/codex/`:

- `hooks/session-start.sh` — `SessionStart` hook: starts or resumes the session, loads context, injects protocol via `systemMessage`
- `hooks/stop.sh` — `Stop` hook: extracts transcript, runs passive capture, ends session
- `hooks/mnemo-protocol.md` — protocol injected at session start
- `AGENTS.md` — persistent protocol appended to `~/.codex/AGENTS.md`

## Codex-specific differences

Unlike Cursor and Windsurf, Codex hooks must return JSON via stdout:

```json
{"continue": true, "systemMessage": "..."}
```

Context and protocol go in `systemMessage`. The MCP config is TOML, not JSON, so it uses a grep-guarded append instead of `mnemo json-merge`. JSON string encoding uses `awk` — no new dependencies.

## Verification

```bash
# dry-run
MNEMO_DRY_RUN=true bash install.sh --agent=codex

# install
bash install.sh --agent=codex
```

Check after install:
- `~/.codex/hooks/session-start.sh` and `stop.sh` are executable
- `~/.codex/hooks.json` contains `SessionStart` and `Stop` sections
- `~/.codex/config.toml` has `[mcp_servers.mnemo]` and `codex_hooks = true`
- `~/.codex/AGENTS.md` contains the mnemo marker
- Re-running is idempotent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Installer adds Codex agent support with automated Codex setup, installation of session start/stop hooks, passive transcript capture on stop, and merged hooks/configuration support.

* **Documentation**
  * Added persistent-memory protocol and agent guidance covering when to save/search memories, mandatory session-summary behavior, and a recommended response format to improve context retention and session closure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->