### PR TITLE
feat: use marker to use mnemo on a project and remove global install

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-lightgrey)](https://github.com/jmeiracorbal/mnemo)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue)](LICENSE)
 
-Persistent memory for AI coding agents. mnemo stores decisions, bugs, conventions, and discoveries across sessions in a local SQLite database. A one-command setup wires it into Claude Code, Cursor, Windsurf, or Codex via hooks and MCP.
+Persistent memory for AI coding agents. mnemo stores decisions, bugs, conventions, and discoveries across sessions in a local SQLite database.
+
+The integration is **per-project and opt-in**. Hooks fire globally on every session, but they only activate when the project contains a `.mnemo` marker. Run `mnemo init` once from a project root to enable mnemo there. Projects without the marker are unaffected.
 
 ## Prerequisite: binary in PATH
 
@@ -48,28 +50,127 @@ mnemo --version
 - **Own storage:** isolated `~/.mnemo/memory.db`, created automatically on first run
 - **Claude Code + Cursor + Windsurf + Codex:** native integration for all four agents via their respective hook systems
 
-## Agent setup
+## Setup: two phases
+
+**Phase 1 — install globally (once per machine):**
+
+```bash
+# Claude Code (via plugin — recommended)
+claude plugin marketplace add jmeiracorbal/mnemo
+claude plugin install mnemo@mnemo
+
+# or via install.sh for any agent:
+curl -sSf https://raw.githubusercontent.com/jmeiracorbal/mnemo/main/install.sh | bash -s -- --agent=claudecode
+curl -sSf https://raw.githubusercontent.com/jmeiracorbal/mnemo/main/install.sh | bash -s -- --agent=cursor
+curl -sSf https://raw.githubusercontent.com/jmeiracorbal/mnemo/main/install.sh | bash -s -- --agent=windsurf
+curl -sSf https://raw.githubusercontent.com/jmeiracorbal/mnemo/main/install.sh | bash -s -- --agent=codex
+```
+
+This installs hook scripts to the agent's global directory and registers the MCP server. Hooks are wired up once here, but they will do nothing in projects without a `.mnemo` marker.
+
+**Phase 2 — enable per project (once per project):**
+
+Run from the project root:
+
+```bash
+mnemo init --agent=claudecode   # or cursor, windsurf, codex, all
+```
+
+This creates a `.mnemo` marker, writes the agent protocol file, and configures per-project hook settings where the agent supports it. From this point on, hooks will fire when working in this project.
+
+## Agent capabilities
+
+Not all agents support per-project hook configuration. The table below shows what each phase can configure per agent.
+
+| | Claude Code | Cursor | Windsurf | Codex |
+|---|---|---|---|---|
+| **Hook scripts (global)** | via plugin | `~/.cursor/hooks/` | `~/.codeium/windsurf/hooks/` | `~/.codex/hooks/` |
+| **MCP (always global)** | `~/.claude/.mcp.json` | `~/.cursor/mcp.json` | `~/.codeium/windsurf/mcp_config.json` | `~/.codex/config.toml` |
+| **Per-project hook config** | `.claude/settings.json` | `.cursor/hooks.json` | `.windsurf/hooks.json` | ❌ global only |
+| **Per-project protocol** | `AGENTS.md` + `CLAUDE.md` symlink | `.cursor/rules/mnemo.mdc` | `.windsurf/rules/mnemo.md` | `AGENTS.md` |
+
+Codex does not support per-project hook configuration. Its hooks are registered globally in `~/.codex/hooks.json` and check for `.mnemo` at runtime before acting.
+
+## What `mnemo init` creates per agent
 
 ### Claude Code
 
-Two installation paths:
+```
+project/
+├── .mnemo                   ← {"version":1,"agents":["claudecode"]}
+├── AGENTS.md                ← mnemo protocol section appended here
+├── CLAUDE.md -> AGENTS.md   ← symlink (existing content migrated to AGENTS.md)
+└── .claude/
+    └── settings.json        ← hook entries (SessionStart, Stop, PostCompact, SubagentStop)
+```
+
+`CLAUDE.md` becomes a symlink to `AGENTS.md`. If `CLAUDE.md` already exists as a regular file, its content is moved to `AGENTS.md` before the symlink is created. This keeps all project config in a single file that works for both Claude Code and Codex.
+
+### Cursor
+
+```
+project/
+├── .mnemo                        ← marker (agents includes "cursor")
+└── .cursor/
+    ├── hooks.json                ← beforeSubmitPrompt + stop hooks
+    └── rules/
+        └── mnemo.mdc             ← protocol as a Cursor rule (alwaysApply: true)
+```
+
+`hooks.json` references the global scripts installed to `~/.cursor/hooks/` with their absolute paths.
+
+### Windsurf
+
+```
+project/
+├── .mnemo                        ← marker (agents includes "windsurf")
+└── .windsurf/
+    ├── hooks.json                ← pre_user_prompt + post_cascade_response_with_transcript hooks
+    └── rules/
+        └── mnemo.md              ← protocol as a Windsurf workspace rule
+```
+
+`hooks.json` references the global scripts installed to `~/.codeium/windsurf/hooks/`.
+
+### Codex
+
+```
+project/
+├── .mnemo                        ← marker (agents includes "codex")
+└── AGENTS.md                     ← mnemo protocol section appended here
+```
+
+Hooks remain in `~/.codex/hooks.json`. The session-start and stop scripts check for `.mnemo` at runtime and skip if the marker is absent.
+
+## The `.mnemo` marker
+
+The `.mnemo` file at the project root is what activates mnemo for a project. It is a small JSON file:
+
+```json
+{
+  "version": 1,
+  "agents": ["claudecode", "cursor"]
+}
+```
+
+`agents` lists which agents have been configured via `mnemo init`. All hooks — including the global-only Codex hooks — read this file before acting. If the file is absent, the hook exits silently.
+
+`mnemo init` creates and updates this file automatically. You can commit it to the repository if you want the rest of your team to know mnemo is in use.
+
+## Claude Code plugin notes
 
 **Via plugin (recommended):**
-
-Requires the `mnemo` binary in PATH — install it first following the [prerequisite step](#prerequisite-binary-in-path).
 
 ```bash
 claude plugin marketplace add jmeiracorbal/mnemo
 claude plugin install mnemo@mnemo
 ```
 
-The plugin registers the MCP server, hooks (SessionStart, Stop, SubagentStop, PostCompact), and writes the memory protocol to `~/.claude/mnemo.md` and `~/.claude/CLAUDE.md` on first session start.
-
-Restart Claude Code after installing.
+Requires the `mnemo` binary in PATH. Restart Claude Code after installing. Then run `mnemo init --agent=claudecode` from each project.
 
 **Updating the plugin:**
 
-The marketplace cache can go stale and report an outdated version as the latest. If `claude plugin update mnemo@mnemo` says the plugin is already up to date but the binary is newer, refresh the marketplace first:
+The marketplace cache can go stale. If `claude plugin update mnemo@mnemo` says the plugin is already up to date but the binary is newer, refresh first:
 
 ```bash
 claude plugin marketplace update mnemo
@@ -77,80 +178,6 @@ claude plugin update mnemo@mnemo
 ```
 
 Restart Claude Code after updating.
-
-**Via install script:**
-
-```bash
-curl -sSf https://raw.githubusercontent.com/jmeiracorbal/mnemo/main/install.sh | bash
-```
-
-Writes `~/.claude/mnemo.md` and appends `@mnemo.md` to `~/.claude/CLAUDE.md`. The plugin (above) is still the recommended path for Claude Code since it also handles MCP registration and hook injection automatically.
-
-### Cursor
-
-```bash
-curl -sSf https://raw.githubusercontent.com/jmeiracorbal/mnemo/main/install.sh | bash -s -- --agent=cursor
-```
-
-Writes hook scripts to `~/.cursor/hooks/`, registers the MCP server in `~/.cursor/mcp.json`, adds hooks to `~/.cursor/hooks.json` (beforeSubmitPrompt, stop), and writes `~/.cursor/rules/mnemo.mdc` (memory protocol, `alwaysApply: true`).
-
-Restart Cursor after setup.
-
-### Windsurf
-
-```bash
-curl -sSf https://raw.githubusercontent.com/jmeiracorbal/mnemo/main/install.sh | bash -s -- --agent=windsurf
-```
-
-Writes hook scripts to `~/.codeium/windsurf/hooks/`, registers the MCP server in `~/.codeium/windsurf/mcp_config.json`, adds hooks to `~/.codeium/windsurf/hooks.json` (pre_user_prompt, post_cascade_response_with_transcript), and appends the memory protocol to `~/.codeium/windsurf/memories/global_rules.md`.
-
-Restart Windsurf after setup.
-
-### Codex
-
-```bash
-curl -sSf https://raw.githubusercontent.com/jmeiracorbal/mnemo/main/install.sh | bash -s -- --agent=codex
-```
-
-Writes hook scripts to `~/.codex/hooks/`, registers the MCP server in `~/.codex/config.toml`, adds hooks to `~/.codex/hooks.json` (SessionStart, Stop), and appends the memory protocol to `~/.codex/AGENTS.md`. Also enables `codex_hooks = true` in the `[features]` section of `config.toml`.
-
-Restart Codex after setup.
-
-## Verification checklist
-
-Run this after every installation or update.
-
-Check that the binary is accessible:
-
-```bash
-mnemo --version
-```
-
-Validate the plugin (Claude Code):
-
-```bash
-claude plugin validate plugin/claude-code
-```
-
-Check that protocol files exist with the right content:
-
-```bash
-cat ~/.claude/CLAUDE.md                          # must contain: @mnemo.md
-head -1 ~/.claude/mnemo.md                      # must be: ## mnemo — Persistent Memory Protocol
-head -3 ~/.cursor/rules/mnemo.mdc               # must have: alwaysApply: true
-grep "mnemo — Persistent Memory Protocol" \
-  ~/.codeium/windsurf/memories/global_rules.md  # must match
-grep "mnemo — Persistent Memory Protocol" \
-  ~/.codex/AGENTS.md                            # must match
-```
-
-Check idempotency — running setup again must report "already up to date":
-
-```bash
-curl -sSf https://raw.githubusercontent.com/jmeiracorbal/mnemo/main/install.sh | bash -s -- --agent=cursor
-curl -sSf https://raw.githubusercontent.com/jmeiracorbal/mnemo/main/install.sh | bash -s -- --agent=windsurf
-curl -sSf https://raw.githubusercontent.com/jmeiracorbal/mnemo/main/install.sh | bash -s -- --agent=codex
-```
 
 ## How it works
 
@@ -185,7 +212,7 @@ curl -sSf https://raw.githubusercontent.com/jmeiracorbal/mnemo/main/install.sh |
 | `SessionStart` (startup/resume) | Session starts or resumes | Registers session, injects memory context via `systemMessage` |
 | `Stop` | Agent stops | Reads transcript for passive capture, closes session |
 
-On session start, mnemo detects the project from the git root directory name and emits relevant memories from previous sessions into the context.
+On session start, mnemo derives the project identifier from the git root and emits relevant memories from previous sessions into the context. All hooks derive the project the same way — from the git root, not the current working directory — so the project ID is consistent regardless of which subdirectory the editor opens.
 
 ## MCP tools
 
@@ -240,6 +267,7 @@ claude mcp add -s user mnemo-admin -- ~/.local/bin/mnemo mcp --tools=admin
 
 ```
 mnemo mcp [--tools=PROFILE]          Start MCP server (stdio)
+mnemo init [--agent=AGENT]           Configure mnemo in the current project
 mnemo save <title> <content>         Save a memory
 mnemo search <query>                 Search memories
 mnemo context [project]              Show context from previous sessions
@@ -254,6 +282,16 @@ mnemo capture <content>              Extract learnings from text (passive captur
 mnemo json <key> [key...]            Extract a field from JSON read from stdin (key path, array index supported)
 mnemo extract-transcript <file>      Extract assistant text blocks from a JSONL transcript
 mnemo version                        Show version
+```
+
+Agents for `mnemo init`:
+
+```
+--agent=claudecode   AGENTS.md + CLAUDE.md symlink + .claude/settings.json (default)
+--agent=cursor       .cursor/hooks.json + .cursor/rules/mnemo.mdc
+--agent=windsurf     .windsurf/hooks.json + .windsurf/rules/mnemo.md
+--agent=codex        AGENTS.md append only (hooks stay global)
+--agent=all          All agents
 ```
 
 ### Examples
@@ -280,6 +318,47 @@ Export everything to JSON:
 
 ```bash
 mnemo export backup.json
+```
+
+## Verification
+
+After installing globally, confirm the binary is accessible:
+
+```bash
+mnemo --version
+```
+
+After running `mnemo init`, check the project files exist:
+
+```bash
+# Claude Code
+cat .mnemo                          # must contain agents list
+ls -la CLAUDE.md                    # must be a symlink to AGENTS.md
+grep "mnemo" .claude/settings.json  # must have hook entries
+
+# Cursor
+cat .cursor/hooks.json              # must have beforeSubmitPrompt + stop
+head -3 .cursor/rules/mnemo.mdc    # must have: alwaysApply: true
+
+# Windsurf
+cat .windsurf/hooks.json            # must have pre_user_prompt + post_cascade_response_with_transcript
+ls .windsurf/rules/mnemo.md
+
+# Codex
+grep "mnemo" AGENTS.md             # must have the protocol section
+```
+
+Validate the Claude Code plugin:
+
+```bash
+claude plugin validate plugin/claude-code
+```
+
+Check idempotency — running `mnemo init` again in the same project must produce no duplicates in `AGENTS.md` and must not overwrite the symlink:
+
+```bash
+mnemo init --agent=claudecode
+mnemo init --agent=claudecode  # second run: no changes
 ```
 
 ## Storage

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ claude plugin install mnemo@mnemo
 
 The plugin registers the MCP server, hooks (SessionStart, Stop, SubagentStop, PostCompact), and writes the memory protocol to `~/.claude/mnemo.md` and `~/.claude/CLAUDE.md` on first session start.
 
+Restart Claude Code after installing.
+
 **Updating the plugin:**
 
 The marketplace cache can go stale and report an outdated version as the latest. If `claude plugin update mnemo@mnemo` says the plugin is already up to date but the binary is newer, refresh the marketplace first:

--- a/cmd/mnemo/main.go
+++ b/cmd/mnemo/main.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/jmeiracorbal/mnemo/internal/agentinit"
 	mcpserver "github.com/jmeiracorbal/mnemo/internal/mcp"
 	"github.com/jmeiracorbal/mnemo/internal/jsonmerge"
 	"github.com/jmeiracorbal/mnemo/internal/store"
@@ -32,6 +33,9 @@ func main() {
 		return
 	case "extract-transcript":
 		runExtractTranscript()
+		return
+	case "init":
+		runInit()
 		return
 	case "--version", "version":
 		fmt.Printf("mnemo %s\n", version)
@@ -543,6 +547,65 @@ func runExtractTranscript() {
 	fmt.Println(strings.Join(lines, "\n"))
 }
 
+// ─── init ────────────────────────────────────────────────────────────────────
+
+// runInit configures mnemo for one or more agents in the current project.
+func runInit() {
+	agent := "claudecode"
+	dir := "."
+
+	for _, arg := range os.Args[2:] {
+		switch {
+		case strings.HasPrefix(arg, "--agent="):
+			agent = arg[len("--agent="):]
+		case strings.HasPrefix(arg, "--path="):
+			dir = arg[len("--path="):]
+		}
+	}
+
+	abs, err := absPath(dir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mnemo init: %v\n", err)
+		os.Exit(1)
+	}
+	root := agentinit.ProjectRoot(abs)
+
+	agents := []string{agent}
+	if agent == "all" {
+		agents = []string{"claudecode", "cursor", "windsurf", "codex"}
+	}
+
+	for _, a := range agents {
+		if err := initAgent(root, a); err != nil {
+			fmt.Fprintf(os.Stderr, "mnemo init: %s: %v\n", a, err)
+			os.Exit(1)
+		}
+		fmt.Printf("mnemo init: %s configured in %s\n", a, root)
+	}
+}
+
+func initAgent(root, agent string) error {
+	switch agent {
+	case "claudecode":
+		return agentinit.InitClaudeCode(root)
+	case "cursor":
+		return agentinit.InitCursor(root)
+	case "windsurf":
+		return agentinit.InitWindsurf(root)
+	case "codex":
+		return agentinit.InitCodex(root)
+	default:
+		return fmt.Errorf("unknown agent %q — valid: claudecode | cursor | windsurf | codex | all", agent)
+	}
+}
+
+func absPath(dir string) (string, error) {
+	if dir == "." {
+		return os.Getwd()
+	}
+	return dir, nil
+}
+
 // ─── json-merge ──────────────────────────────────────────────────────────────
 
 // runJSONMerge reads a JSON patch from stdin and deep-merges it into FILE.
@@ -580,10 +643,18 @@ Usage:
   mnemo export [file]                  Export all memories to JSON
   mnemo import <file.json>             Import memories from JSON
   mnemo capture <content>              Extract learnings from text (passive capture)
+  mnemo init [--agent=AGENT]           Configure mnemo in the current project
   mnemo json KEY [KEY ...]             Extract field from JSON on stdin (used by hooks)
   mnemo json-merge <file>              Deep-merge JSON from stdin into file
   mnemo extract-transcript <file>      Extract assistant text from JSONL transcript
   mnemo version                        Show version
+
+Agents for init:
+  --agent=claudecode   AGENTS.md + CLAUDE.md symlink (default)
+  --agent=cursor       .cursor/hooks.json + .cursor/rules/mnemo.mdc
+  --agent=windsurf     .windsurf/hooks.json + .windsurf/rules/mnemo.md
+  --agent=codex        AGENTS.md append
+  --agent=all          All agents
 
 Tool profiles for mcp:
   --tools=agent    11 tools for AI agents (default when using plugin)

--- a/cmd/mnemo/main.go
+++ b/cmd/mnemo/main.go
@@ -641,7 +641,7 @@ Usage:
   mnemo export [file]                  Export all memories to JSON
   mnemo import <file.json>             Import memories from JSON
   mnemo capture <content>              Extract learnings from text (passive capture)
-  mnemo init [--agent=AGENT]           Configure mnemo in the current project
+  mnemo init [--agent=AGENT] [--path=DIR]  Configure mnemo in the current project
   mnemo json KEY [KEY ...]             Extract field from JSON on stdin (used by hooks)
   mnemo json-merge <file>              Deep-merge JSON from stdin into file
   mnemo extract-transcript <file>      Extract assistant text from JSONL transcript
@@ -653,6 +653,7 @@ Agents for init:
   --agent=windsurf     .windsurf/hooks.json + .windsurf/rules/mnemo.md
   --agent=codex        AGENTS.md append
   --agent=all          All agents
+  --path=DIR           Target project directory (default: current directory)
 
 Tool profiles for mcp:
   --tools=agent    11 tools for AI agents (default when using plugin)

--- a/cmd/mnemo/main.go
+++ b/cmd/mnemo/main.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -600,10 +601,7 @@ func initAgent(root, agent string) error {
 }
 
 func absPath(dir string) (string, error) {
-	if dir == "." {
-		return os.Getwd()
-	}
-	return dir, nil
+	return filepath.Abs(dir)
 }
 
 // ─── json-merge ──────────────────────────────────────────────────────────────

--- a/install.sh
+++ b/install.sh
@@ -212,25 +212,17 @@ download_scripts() {
 setup_claudecode() {
   local mnemo_bin="$1"
   local claude_dir="$HOME/.claude"
-  local mnemo_md="$claude_dir/mnemo.md"
-  local claude_md="$claude_dir/CLAUDE.md"
-  local reference="@mnemo.md"
+  local mcp_json="$claude_dir/.mcp.json"
 
   info "Configuring Claude Code..."
   mkdir -p "$claude_dir"
 
-  cp "$TMP_SCRIPTS/claudecode/mnemo.md" "$mnemo_md"
-  ok "~/.claude/mnemo.md written"
+  local result
+  result=$(printf '{"mcpServers":{"mnemo":{"command":"%s","args":["mcp","--tools=agent"]}}}' \
+    "$mnemo_bin" | "$mnemo_bin" json-merge "$mcp_json")
+  ok "~/.claude/.mcp.json: ${result}"
 
-  if [ -f "$claude_md" ] && grep -qF "$reference" "$claude_md" 2>/dev/null; then
-    ok "~/.claude/CLAUDE.md already up to date"
-  else
-    if [ -f "$claude_md" ] && [ -s "$claude_md" ]; then
-      tail -c1 "$claude_md" | grep -q $'\n' || printf '\n' >> "$claude_md"
-    fi
-    printf '%s\n' "$reference" >> "$claude_md"
-    ok "~/.claude/CLAUDE.md updated"
-  fi
+  ok "Run 'mnemo init --agent=claudecode' from each project to enable mnemo there."
 }
 
 # ── setup: Cursor ──────────────────────────────────────────────────────────────
@@ -255,13 +247,7 @@ setup_cursor() {
     "$mnemo_bin" | "$mnemo_bin" json-merge "$mcp_json")
   ok "~/.cursor/mcp.json: ${result}"
 
-  result=$(printf '{"version":1,"hooks":{"beforeSubmitPrompt":[{"command":"%s/before-submit-prompt.sh"}],"stop":[{"command":"%s/stop.sh"}]}}' \
-    "$hooks_dir" "$hooks_dir" | "$mnemo_bin" json-merge "$hooks_json")
-  ok "~/.cursor/hooks.json: ${result}"
-
-  mkdir -p "$rules_dir"
-  cp "$TMP_SCRIPTS/cursor/rules/mnemo.mdc" "$rules_dir/"
-  ok "~/.cursor/rules/mnemo.mdc written"
+  ok "Run 'mnemo init --agent=cursor' from each project to enable hooks and rules there."
 }
 
 # ── setup: Codex ──────────────────────────────────────────────────────────────
@@ -333,16 +319,7 @@ setup_codex() {
     "$hooks_dir" "$hooks_dir" | "$mnemo_bin" json-merge "$hooks_json")
   ok "~/.codex/hooks.json: ${result}"
 
-  if [ -f "$agents_md" ] && grep -qF "$marker" "$agents_md" 2>/dev/null; then
-    ok "~/.codex/AGENTS.md already up to date"
-  else
-    if [ -f "$agents_md" ] && [ -s "$agents_md" ]; then
-      tail -c1 "$agents_md" | grep -q $'\n' || printf '\n' >> "$agents_md"
-      printf '\n' >> "$agents_md"
-    fi
-    cat "$TMP_SCRIPTS/codex/AGENTS.md" >> "$agents_md"
-    ok "~/.codex/AGENTS.md updated"
-  fi
+  ok "Run 'mnemo init --agent=codex' from each project to enable mnemo there."
 }
 
 # ── setup: Windsurf ────────────────────────────────────────────────────────────
@@ -369,21 +346,7 @@ setup_windsurf() {
     "$mnemo_bin" | "$mnemo_bin" json-merge "$mcp_json")
   ok "~/.codeium/windsurf/mcp_config.json: ${result}"
 
-  result=$(printf '{"hooks":{"pre_user_prompt":[{"command":"%s/pre-user-prompt.sh"}],"post_cascade_response_with_transcript":[{"command":"%s/post-cascade-response.sh"}]}}' \
-    "$hooks_dir" "$hooks_dir" | "$mnemo_bin" json-merge "$hooks_json")
-  ok "~/.codeium/windsurf/hooks.json: ${result}"
-
-  mkdir -p "$memories_dir"
-  if [ -f "$global_rules" ] && grep -qF "$marker" "$global_rules" 2>/dev/null; then
-    ok "~/.codeium/windsurf/memories/global_rules.md already up to date"
-  else
-    if [ -f "$global_rules" ] && [ -s "$global_rules" ]; then
-      tail -c1 "$global_rules" | grep -q $'\n' || printf '\n' >> "$global_rules"
-      printf '\n' >> "$global_rules"
-    fi
-    cat "$TMP_SCRIPTS/windsurf/templates/global_rules.md" >> "$global_rules"
-    ok "~/.codeium/windsurf/memories/global_rules.md updated"
-  fi
+  ok "Run 'mnemo init --agent=windsurf' from each project to enable hooks and rules there."
 }
 
 # ── main ───────────────────────────────────────────────────────────────────────
@@ -432,26 +395,26 @@ main() {
   case "$AGENT" in
     claudecode)
       setup_claudecode "$mnemo_bin"
-      ok "Done. Restart Claude Code to activate mnemo."
+      ok "Done. Run 'mnemo init --agent=claudecode' from each project to activate mnemo there."
       ;;
     cursor)
       setup_cursor "$mnemo_bin"
-      ok "Done. Restart Cursor to activate mnemo."
+      ok "Done. Run 'mnemo init --agent=cursor' from each project to activate mnemo there."
       ;;
     windsurf)
       setup_windsurf "$mnemo_bin"
-      ok "Done. Restart Windsurf to activate mnemo."
+      ok "Done. Run 'mnemo init --agent=windsurf' from each project to activate mnemo there."
       ;;
     codex)
       setup_codex "$mnemo_bin"
-      ok "Done. Restart Codex to activate mnemo."
+      ok "Done. Run 'mnemo init --agent=codex' from each project to activate mnemo there."
       ;;
     all)
       setup_claudecode "$mnemo_bin"
       setup_cursor "$mnemo_bin"
       setup_windsurf "$mnemo_bin"
       setup_codex "$mnemo_bin"
-      ok "Done. Restart your editors to activate mnemo."
+      ok "Done. Run 'mnemo init --agent=all' from each project to activate mnemo there."
       ;;
     *)
       err "Unknown agent: ${AGENT}. Valid options: claudecode | cursor | windsurf | codex | all"

--- a/internal/agentinit/claudecode.go
+++ b/internal/agentinit/claudecode.go
@@ -1,0 +1,59 @@
+package agentinit
+
+import (
+	_ "embed"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+//go:embed templates/claudecode.md
+var claudeProtocol string
+
+// InitClaudeCode configures mnemo for Claude Code in the given project root.
+//
+// Creates AGENTS.md with the mnemo protocol section and makes CLAUDE.md a
+// symlink to AGENTS.md. If CLAUDE.md already exists as a regular file, its
+// content is moved to AGENTS.md before the symlink is created.
+func InitClaudeCode(root string) error {
+	agentsPath := filepath.Join(root, "AGENTS.md")
+	claudePath := filepath.Join(root, "CLAUDE.md")
+
+	if err := AppendSection(agentsPath, claudeProtocol); err != nil {
+		return fmt.Errorf("AGENTS.md: %w", err)
+	}
+
+	info, err := os.Lstat(claudePath)
+	if err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			target, linkErr := os.Readlink(claudePath)
+			if linkErr == nil && (target == "AGENTS.md" || target == agentsPath) {
+				return AddAgent(root, "claudecode")
+			}
+			if err := os.Remove(claudePath); err != nil {
+				return fmt.Errorf("CLAUDE.md: remove stale symlink: %w", err)
+			}
+		} else {
+			existing, err := os.ReadFile(claudePath)
+			if err != nil {
+				return fmt.Errorf("CLAUDE.md: read: %w", err)
+			}
+			if len(existing) > 0 {
+				if err := prependToFile(agentsPath, string(existing)); err != nil {
+					return fmt.Errorf("AGENTS.md: prepend CLAUDE.md content: %w", err)
+				}
+			}
+			if err := os.Remove(claudePath); err != nil {
+				return fmt.Errorf("CLAUDE.md: remove: %w", err)
+			}
+		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("CLAUDE.md: stat: %w", err)
+	}
+
+	if err := os.Symlink("AGENTS.md", claudePath); err != nil {
+		return fmt.Errorf("CLAUDE.md: create symlink: %w", err)
+	}
+
+	return AddAgent(root, "claudecode")
+}

--- a/internal/agentinit/codex.go
+++ b/internal/agentinit/codex.go
@@ -1,0 +1,22 @@
+package agentinit
+
+import (
+	_ "embed"
+	"fmt"
+	"path/filepath"
+)
+
+//go:embed templates/codex.md
+var codexProtocol string
+
+// InitCodex configures mnemo for Codex in the given project root.
+//
+// Appends the mnemo protocol section to AGENTS.md. Hooks for Codex are global
+// (registered by install.sh); they check for the .mnemo marker at runtime.
+func InitCodex(root string) error {
+	agentsPath := filepath.Join(root, "AGENTS.md")
+	if err := AppendSection(agentsPath, codexProtocol); err != nil {
+		return fmt.Errorf("codex init: AGENTS.md: %w", err)
+	}
+	return AddAgent(root, "codex")
+}

--- a/internal/agentinit/common.go
+++ b/internal/agentinit/common.go
@@ -91,9 +91,12 @@ func AppendSection(path, content string) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
-	_, err = f.WriteString(section)
-	return err
+	_, writeErr := f.WriteString(section)
+	closeErr := f.Close()
+	if writeErr != nil {
+		return writeErr
+	}
+	return closeErr
 }
 
 // WriteFile writes data to path, creating parent directories. Overwrites if exists.
@@ -115,7 +118,7 @@ func prependToFile(path, content string) error {
 		if !strings.HasSuffix(combined, "\n") {
 			combined += "\n"
 		}
-		combined += "\n" + string(existing)
+		combined += string(existing)
 	}
 	return os.WriteFile(path, []byte(combined), 0644)
 }

--- a/internal/agentinit/common.go
+++ b/internal/agentinit/common.go
@@ -1,0 +1,120 @@
+package agentinit
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const markerName = ".mnemo"
+const sectionStart = "<!-- mnemo:start -->"
+const sectionEnd = "<!-- mnemo:end -->"
+
+// Marker is the .mnemo file format.
+type Marker struct {
+	Version int      `json:"version"`
+	Agents  []string `json:"agents"`
+}
+
+// ProjectRoot returns the git root of dir, or dir itself if not in a git repo.
+func ProjectRoot(dir string) string {
+	out, err := exec.Command("git", "-C", dir, "rev-parse", "--show-toplevel").Output()
+	if err == nil {
+		return strings.TrimSpace(string(out))
+	}
+	return dir
+}
+
+func readMarker(root string) (*Marker, error) {
+	data, err := os.ReadFile(filepath.Join(root, markerName))
+	if os.IsNotExist(err) {
+		return &Marker{Version: 1}, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var m Marker
+	if err := json.Unmarshal(data, &m); err != nil {
+		return &Marker{Version: 1}, nil
+	}
+	return &m, nil
+}
+
+func writeMarker(root string, m *Marker) error {
+	data, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(root, markerName), append(data, '\n'), 0644)
+}
+
+// AddAgent adds agent to the .mnemo marker, creating it if needed. Idempotent.
+func AddAgent(root, agent string) error {
+	m, err := readMarker(root)
+	if err != nil {
+		return err
+	}
+	for _, a := range m.Agents {
+		if a == agent {
+			return nil
+		}
+	}
+	m.Agents = append(m.Agents, agent)
+	return writeMarker(root, m)
+}
+
+// AppendSection appends a mnemo protocol section to path, creating the file if
+// needed. Idempotent: does nothing if the section marker is already present.
+func AppendSection(path, content string) error {
+	existing, err := os.ReadFile(path)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+
+	if strings.Contains(string(existing), sectionStart) {
+		return nil
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return err
+	}
+
+	section := "\n" + sectionStart + "\n" + content + "\n" + sectionEnd + "\n"
+	if len(existing) > 0 && !strings.HasSuffix(string(existing), "\n") {
+		section = "\n" + section
+	}
+
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	_, err = f.WriteString(section)
+	return err
+}
+
+// WriteFile writes data to path, creating parent directories. Overwrites if exists.
+func WriteFile(path string, data []byte) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0644)
+}
+
+// prependToFile prepends content before the existing content of path.
+func prependToFile(path, content string) error {
+	existing, err := os.ReadFile(path)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	combined := content
+	if len(existing) > 0 {
+		if !strings.HasSuffix(combined, "\n") {
+			combined += "\n"
+		}
+		combined += "\n" + string(existing)
+	}
+	return os.WriteFile(path, []byte(combined), 0644)
+}

--- a/internal/agentinit/common.go
+++ b/internal/agentinit/common.go
@@ -2,6 +2,7 @@ package agentinit
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -37,7 +38,7 @@ func readMarker(root string) (*Marker, error) {
 	}
 	var m Marker
 	if err := json.Unmarshal(data, &m); err != nil {
-		return &Marker{Version: 1}, nil
+		return nil, fmt.Errorf("malformed .mnemo file: %w", err)
 	}
 	return &m, nil
 }

--- a/internal/agentinit/cursor.go
+++ b/internal/agentinit/cursor.go
@@ -25,11 +25,17 @@ func InitCursor(root string) error {
 	beforeSubmit := filepath.Join(hooksDir, "before-submit-prompt.sh")
 	stop := filepath.Join(hooksDir, "stop.sh")
 
-	if _, err := os.Stat(beforeSubmit); os.IsNotExist(err) {
-		return fmt.Errorf("cursor init: hook script not found: %s\nRun install.sh --agent=cursor first", beforeSubmit)
+	if _, err := os.Stat(beforeSubmit); err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("cursor init: hook script not found: %s\nRun install.sh --agent=cursor first", beforeSubmit)
+		}
+		return fmt.Errorf("cursor init: stat %s: %w", beforeSubmit, err)
 	}
-	if _, err := os.Stat(stop); os.IsNotExist(err) {
-		return fmt.Errorf("cursor init: hook script not found: %s\nRun install.sh --agent=cursor first", stop)
+	if _, err := os.Stat(stop); err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("cursor init: hook script not found: %s\nRun install.sh --agent=cursor first", stop)
+		}
+		return fmt.Errorf("cursor init: stat %s: %w", stop, err)
 	}
 
 	hooksData := map[string]any{

--- a/internal/agentinit/cursor.go
+++ b/internal/agentinit/cursor.go
@@ -1,0 +1,51 @@
+package agentinit
+
+import (
+	_ "embed"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+//go:embed templates/cursor.mdc
+var cursorProtocol []byte
+
+// InitCursor configures mnemo for Cursor in the given project root.
+//
+// Writes .cursor/hooks.json referencing the global hook scripts and
+// .cursor/rules/mnemo.mdc with the mnemo protocol.
+func InitCursor(root string) error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("cursor init: could not determine HOME: %w", err)
+	}
+
+	hooksDir := filepath.Join(home, ".cursor", "hooks")
+	beforeSubmit := filepath.Join(hooksDir, "before-submit-prompt.sh")
+	stop := filepath.Join(hooksDir, "stop.sh")
+
+	if _, err := os.Stat(beforeSubmit); os.IsNotExist(err) {
+		return fmt.Errorf("cursor init: hook script not found: %s\nRun install.sh --agent=cursor first", beforeSubmit)
+	}
+
+	hooksJSON := fmt.Sprintf(`{
+  "version": 1,
+  "hooks": {
+    "beforeSubmitPrompt": [{"command": "%s"}],
+    "stop": [{"command": "%s"}]
+  }
+}
+`, beforeSubmit, stop)
+
+	hooksPath := filepath.Join(root, ".cursor", "hooks.json")
+	if err := WriteFile(hooksPath, []byte(hooksJSON)); err != nil {
+		return fmt.Errorf("cursor init: .cursor/hooks.json: %w", err)
+	}
+
+	rulesPath := filepath.Join(root, ".cursor", "rules", "mnemo.mdc")
+	if err := WriteFile(rulesPath, cursorProtocol); err != nil {
+		return fmt.Errorf("cursor init: .cursor/rules/mnemo.mdc: %w", err)
+	}
+
+	return AddAgent(root, "cursor")
+}

--- a/internal/agentinit/cursor.go
+++ b/internal/agentinit/cursor.go
@@ -2,6 +2,7 @@ package agentinit
 
 import (
 	_ "embed"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -27,18 +28,24 @@ func InitCursor(root string) error {
 	if _, err := os.Stat(beforeSubmit); os.IsNotExist(err) {
 		return fmt.Errorf("cursor init: hook script not found: %s\nRun install.sh --agent=cursor first", beforeSubmit)
 	}
+	if _, err := os.Stat(stop); os.IsNotExist(err) {
+		return fmt.Errorf("cursor init: hook script not found: %s\nRun install.sh --agent=cursor first", stop)
+	}
 
-	hooksJSON := fmt.Sprintf(`{
-  "version": 1,
-  "hooks": {
-    "beforeSubmitPrompt": [{"command": "%s"}],
-    "stop": [{"command": "%s"}]
-  }
-}
-`, beforeSubmit, stop)
+	hooksData := map[string]any{
+		"version": 1,
+		"hooks": map[string]any{
+			"beforeSubmitPrompt": []map[string]string{{"command": beforeSubmit}},
+			"stop":               []map[string]string{{"command": stop}},
+		},
+	}
+	hooksJSON, err := json.MarshalIndent(hooksData, "", "  ")
+	if err != nil {
+		return fmt.Errorf("cursor init: marshal hooks.json: %w", err)
+	}
 
 	hooksPath := filepath.Join(root, ".cursor", "hooks.json")
-	if err := WriteFile(hooksPath, []byte(hooksJSON)); err != nil {
+	if err := WriteFile(hooksPath, append(hooksJSON, '\n')); err != nil {
 		return fmt.Errorf("cursor init: .cursor/hooks.json: %w", err)
 	}
 

--- a/internal/agentinit/templates/claudecode.md
+++ b/internal/agentinit/templates/claudecode.md
@@ -1,0 +1,45 @@
+## mnemo — Persistent Memory Protocol
+
+You have access to mnemo memory tools (mem_save, mem_search, mem_context, mem_session_summary).
+
+### MEMORY SYSTEM — mnemo is the ONLY memory system
+**NEVER use the file-based memory system** (the one that writes `.md` files to `~/.claude/projects/*/memory/` and maintains a `MEMORY.md` index). That system is DISABLED for this workspace.
+When asked to "save to memory", "remember this", or "guardar en memoria" — ALWAYS use `mem_save`. Never write files.
+
+### PROACTIVE SAVE — do NOT wait for user to ask
+Call `mem_save` IMMEDIATELY after ANY of these:
+- Decision made (architecture, convention, workflow, tool choice)
+- Bug fixed (include root cause)
+- Convention or workflow documented/updated
+- Non-obvious discovery, gotcha, or edge case found
+- Pattern established (naming, structure, approach)
+- User preference or constraint learned
+- Feature implemented with non-obvious approach
+
+**Self-check after EVERY task**: "Did I just make a decision, fix a bug, learn something, or establish a convention? If yes → mem_save NOW."
+
+### SEARCH MEMORY when:
+- User asks to recall anything
+- Starting work on something that might have been done before
+- User mentions a topic you have no context on
+
+### SUBAGENT OUTPUT — required format for passive capture
+When running as a subagent, always end your response with a structured section:
+
+```
+## Key Learnings
+- <learning 1>
+- <learning 2>
+```
+
+This enables mnemo to automatically extract and persist what you discovered.
+Omit the section only if the task produced no learnings worth retaining.
+
+### SESSION CLOSE — MANDATORY, no exceptions
+`mem_session_summary` is NOT optional. It is the final step of every session, like a `defer` — it always runs.
+Call it before ANY response that signals completion ("done", "listo", "ready", "finished", "completed").
+Fields: Goal, Discoveries, Accomplished, Next Steps, Relevant Files.
+
+If nothing was accomplished: call it anyway with Goal and Next Steps.
+If the user says goodbye: call it before responding.
+No session ends without `mem_session_summary`.

--- a/internal/agentinit/templates/claudecode.md
+++ b/internal/agentinit/templates/claudecode.md
@@ -23,6 +23,13 @@ Call `mem_save` IMMEDIATELY after ANY of these:
 - Starting work on something that might have been done before
 - User mentions a topic you have no context on
 
+### RECOVER CONTEXT with mem_context when:
+- A new session starts in a project you have worked on before
+- The context window was just compacted (PostCompact hook fires this automatically)
+- You need a broad overview of recent session history before acting
+
+`mem_context` returns the most recent observations and session summaries for the project. Use it to orient yourself at the start of a session before doing any significant work.
+
 ### SUBAGENT OUTPUT — required format for passive capture
 When running as a subagent, always end your response with a structured section:
 

--- a/internal/agentinit/templates/codex.md
+++ b/internal/agentinit/templates/codex.md
@@ -1,0 +1,41 @@
+## mnemo — Persistent Memory Protocol
+
+You have access to mnemo MCP tools: mem_save, mem_search, mem_context, mem_session_summary.
+
+### PROACTIVE SAVE — do NOT wait for user to ask
+Call `mem_save` IMMEDIATELY after ANY of these:
+- Decision made (architecture, convention, workflow, tool choice)
+- Bug fixed (include root cause)
+- Convention or workflow documented/updated
+- Non-obvious discovery, gotcha, or edge case found
+- Pattern established (naming, structure, approach)
+- User preference or constraint learned
+- Feature implemented with non-obvious approach
+
+**Self-check after EVERY task**: "Did I just make a decision, fix a bug, learn something, or establish a convention? If yes → mem_save NOW."
+
+### SEARCH MEMORY when:
+- User asks to recall anything
+- Starting work on something that might have been done before
+- User mentions a topic you have no context on
+
+### SUBAGENT OUTPUT — required format for passive capture
+When running as a subagent, always end your response with a structured section:
+
+```markdown
+## Key Learnings
+- <learning 1>
+- <learning 2>
+```
+
+This enables mnemo to automatically extract and persist what you discovered.
+Omit the section only if the task produced no learnings worth retaining.
+
+### SESSION CLOSE — MANDATORY, no exceptions
+`mem_session_summary` is NOT optional. It is the final step of every session.
+Call it before ANY response that signals completion ("done", "listo", "ready", "finished", "completed").
+Fields: Goal, Discoveries, Accomplished, Next Steps, Relevant Files.
+
+If nothing was accomplished: call it anyway with Goal and Next Steps.
+If the user says goodbye: call it before responding.
+No session ends without `mem_session_summary`.

--- a/internal/agentinit/templates/cursor.mdc
+++ b/internal/agentinit/templates/cursor.mdc
@@ -1,0 +1,45 @@
+---
+description: mnemo persistent memory protocol
+alwaysApply: true
+---
+
+## mnemo — Persistent Memory Protocol
+
+You have access to mnemo memory tools (mem_save, mem_search, mem_context, mem_session_summary).
+
+### PROACTIVE SAVE — do NOT wait for user to ask
+Call `mem_save` IMMEDIATELY after ANY of these:
+- Decision made (architecture, convention, workflow, tool choice)
+- Bug fixed (include root cause)
+- Convention or workflow documented/updated
+- Non-obvious discovery, gotcha, or edge case found
+- Pattern established (naming, structure, approach)
+- User preference or constraint learned
+- Feature implemented with non-obvious approach
+
+**Self-check after EVERY task**: "Did I just make a decision, fix a bug, learn something, or establish a convention? If yes → mem_save NOW."
+
+### SEARCH MEMORY when:
+- User asks to recall anything
+- Starting work on something that might have been done before
+- User mentions a topic you have no context on
+
+### SUBAGENT OUTPUT — required format for passive capture
+When running as a subagent, always end your response with a structured section:
+
+```
+## Key Learnings
+- <learning 1>
+- <learning 2>
+```
+
+Omit the section only if the task produced no learnings worth retaining.
+
+### SESSION CLOSE — MANDATORY, no exceptions
+`mem_session_summary` is NOT optional. It is the final step of every session.
+Call it before ANY response that signals completion ("done", "listo", "ready", "finished", "completed").
+Fields: Goal, Discoveries, Accomplished, Next Steps, Relevant Files.
+
+If nothing was accomplished: call it anyway with Goal and Next Steps.
+If the user says goodbye: call it before responding.
+No session ends without `mem_session_summary`.

--- a/internal/agentinit/templates/windsurf.md
+++ b/internal/agentinit/templates/windsurf.md
@@ -1,0 +1,28 @@
+## mnemo — Persistent Memory Protocol
+
+You have access to mnemo memory tools (mem_save, mem_search, mem_context, mem_session_summary).
+
+### PROACTIVE SAVE — do NOT wait for user to ask
+Call `mem_save` IMMEDIATELY after ANY of these:
+- Decision made (architecture, convention, workflow, tool choice)
+- Bug fixed (include root cause)
+- Convention or workflow documented/updated
+- Non-obvious discovery, gotcha, or edge case found
+- Pattern established (naming, structure, approach)
+- User preference or constraint learned
+- Feature implemented with non-obvious approach
+
+**Self-check after EVERY task**: "Did I just make a decision, fix a bug, learn something, or establish a convention? If yes → mem_save NOW."
+
+### SEARCH MEMORY when:
+- User asks to recall anything
+- Starting work on something that might have been done before
+- User mentions a topic you have no context on
+
+### SESSION CLOSE — MANDATORY, no exceptions
+`mem_session_summary` is NOT optional. It is the final step of every session.
+Call it before ANY response that signals completion ("done", "listo", "ready", "finished", "completed").
+Fields: Goal, Discoveries, Accomplished, Next Steps, Relevant Files.
+
+If nothing was accomplished: call it anyway with Goal and Next Steps.
+No session ends without `mem_session_summary`.

--- a/internal/agentinit/windsurf.go
+++ b/internal/agentinit/windsurf.go
@@ -25,11 +25,17 @@ func InitWindsurf(root string) error {
 	prePrompt := filepath.Join(hooksDir, "pre-user-prompt.sh")
 	postCascade := filepath.Join(hooksDir, "post-cascade-response.sh")
 
-	if _, err := os.Stat(prePrompt); os.IsNotExist(err) {
-		return fmt.Errorf("windsurf init: hook script not found: %s\nRun install.sh --agent=windsurf first", prePrompt)
+	if _, err := os.Stat(prePrompt); err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("windsurf init: hook script not found: %s\nRun install.sh --agent=windsurf first", prePrompt)
+		}
+		return fmt.Errorf("windsurf init: stat %s: %w", prePrompt, err)
 	}
-	if _, err := os.Stat(postCascade); os.IsNotExist(err) {
-		return fmt.Errorf("windsurf init: hook script not found: %s\nRun install.sh --agent=windsurf first", postCascade)
+	if _, err := os.Stat(postCascade); err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("windsurf init: hook script not found: %s\nRun install.sh --agent=windsurf first", postCascade)
+		}
+		return fmt.Errorf("windsurf init: stat %s: %w", postCascade, err)
 	}
 
 	hooksData := map[string]any{

--- a/internal/agentinit/windsurf.go
+++ b/internal/agentinit/windsurf.go
@@ -1,0 +1,50 @@
+package agentinit
+
+import (
+	_ "embed"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+//go:embed templates/windsurf.md
+var windsurfProtocol []byte
+
+// InitWindsurf configures mnemo for Windsurf in the given project root.
+//
+// Writes .windsurf/hooks.json referencing the global hook scripts and
+// .windsurf/rules/mnemo.md with the mnemo protocol.
+func InitWindsurf(root string) error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("windsurf init: could not determine HOME: %w", err)
+	}
+
+	hooksDir := filepath.Join(home, ".codeium", "windsurf", "hooks")
+	prePrompt := filepath.Join(hooksDir, "pre-user-prompt.sh")
+	postCascade := filepath.Join(hooksDir, "post-cascade-response.sh")
+
+	if _, err := os.Stat(prePrompt); os.IsNotExist(err) {
+		return fmt.Errorf("windsurf init: hook script not found: %s\nRun install.sh --agent=windsurf first", prePrompt)
+	}
+
+	hooksJSON := fmt.Sprintf(`{
+  "hooks": {
+    "pre_user_prompt": [{"command": "%s"}],
+    "post_cascade_response_with_transcript": [{"command": "%s"}]
+  }
+}
+`, prePrompt, postCascade)
+
+	hooksPath := filepath.Join(root, ".windsurf", "hooks.json")
+	if err := WriteFile(hooksPath, []byte(hooksJSON)); err != nil {
+		return fmt.Errorf("windsurf init: .windsurf/hooks.json: %w", err)
+	}
+
+	rulesPath := filepath.Join(root, ".windsurf", "rules", "mnemo.md")
+	if err := WriteFile(rulesPath, windsurfProtocol); err != nil {
+		return fmt.Errorf("windsurf init: .windsurf/rules/mnemo.md: %w", err)
+	}
+
+	return AddAgent(root, "windsurf")
+}

--- a/internal/agentinit/windsurf.go
+++ b/internal/agentinit/windsurf.go
@@ -2,6 +2,7 @@ package agentinit
 
 import (
 	_ "embed"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -27,17 +28,23 @@ func InitWindsurf(root string) error {
 	if _, err := os.Stat(prePrompt); os.IsNotExist(err) {
 		return fmt.Errorf("windsurf init: hook script not found: %s\nRun install.sh --agent=windsurf first", prePrompt)
 	}
+	if _, err := os.Stat(postCascade); os.IsNotExist(err) {
+		return fmt.Errorf("windsurf init: hook script not found: %s\nRun install.sh --agent=windsurf first", postCascade)
+	}
 
-	hooksJSON := fmt.Sprintf(`{
-  "hooks": {
-    "pre_user_prompt": [{"command": "%s"}],
-    "post_cascade_response_with_transcript": [{"command": "%s"}]
-  }
-}
-`, prePrompt, postCascade)
+	hooksData := map[string]any{
+		"hooks": map[string]any{
+			"pre_user_prompt":                       []map[string]string{{"command": prePrompt}},
+			"post_cascade_response_with_transcript": []map[string]string{{"command": postCascade}},
+		},
+	}
+	hooksJSON, err := json.MarshalIndent(hooksData, "", "  ")
+	if err != nil {
+		return fmt.Errorf("windsurf init: marshal hooks.json: %w", err)
+	}
 
 	hooksPath := filepath.Join(root, ".windsurf", "hooks.json")
-	if err := WriteFile(hooksPath, []byte(hooksJSON)); err != nil {
+	if err := WriteFile(hooksPath, append(hooksJSON, '\n')); err != nil {
 		return fmt.Errorf("windsurf init: .windsurf/hooks.json: %w", err)
 	}
 

--- a/plugin/claude-code/scripts/post-compact-resume.sh
+++ b/plugin/claude-code/scripts/post-compact-resume.sh
@@ -12,6 +12,9 @@ CWD=$(echo "$INPUT" | mnemo json cwd 2>/dev/null)
 [ -z "$SESSION_ID" ] && exit 0
 [ -z "$CWD" ] && CWD="$(pwd)"
 
+PROJECT_ROOT=$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null || echo "$CWD")
+[ ! -f "${PROJECT_ROOT}/.mnemo" ] && exit 0
+
 PROJECT=$(realpath "$CWD" 2>/dev/null | sed "s|^$HOME/||; s|^/||" | tr '/' '-' | tr '[:upper:]' '[:lower:]')
 [ -z "$PROJECT" ] && PROJECT=$(basename "$CWD" | tr '[:upper:]' '[:lower:]')
 

--- a/plugin/claude-code/scripts/post-compact-resume.sh
+++ b/plugin/claude-code/scripts/post-compact-resume.sh
@@ -15,8 +15,8 @@ CWD=$(echo "$INPUT" | mnemo json cwd 2>/dev/null)
 PROJECT_ROOT=$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null || echo "$CWD")
 [ ! -f "${PROJECT_ROOT}/.mnemo" ] && exit 0
 
-PROJECT=$(realpath "$CWD" 2>/dev/null | sed "s|^$HOME/||; s|^/||" | tr '/' '-' | tr '[:upper:]' '[:lower:]')
-[ -z "$PROJECT" ] && PROJECT=$(basename "$CWD" | tr '[:upper:]' '[:lower:]')
+PROJECT=$(realpath "$PROJECT_ROOT" 2>/dev/null | sed "s|^$HOME/||; s|^/||" | tr '/' '-' | tr '[:upper:]' '[:lower:]')
+[ -z "$PROJECT" ] && PROJECT=$(basename "$PROJECT_ROOT" | tr '[:upper:]' '[:lower:]')
 
 printf "\n[mnemo] Context restored after compaction (project: %s)\n" "$PROJECT"
 

--- a/plugin/claude-code/scripts/post-compact.sh
+++ b/plugin/claude-code/scripts/post-compact.sh
@@ -14,8 +14,8 @@ CWD=$(echo "$INPUT" | mnemo json cwd 2>/dev/null)
 PROJECT_ROOT=$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null || echo "$CWD")
 [ ! -f "${PROJECT_ROOT}/.mnemo" ] && exit 0
 
-PROJECT=$(realpath "$CWD" 2>/dev/null | sed "s|^$HOME/||; s|^/||" | tr '/' '-' | tr '[:upper:]' '[:lower:]')
-[ -z "$PROJECT" ] && PROJECT=$(basename "$CWD" | tr '[:upper:]' '[:lower:]')
+PROJECT=$(realpath "$PROJECT_ROOT" 2>/dev/null | sed "s|^$HOME/||; s|^/||" | tr '/' '-' | tr '[:upper:]' '[:lower:]')
+[ -z "$PROJECT" ] && PROJECT=$(basename "$PROJECT_ROOT" | tr '[:upper:]' '[:lower:]')
 
 if [ -n "$SESSION_ID" ] && [ -n "$PROJECT" ]; then
   mnemo session start "$SESSION_ID" --project "$PROJECT" --dir "$CWD" 2>/dev/null || true

--- a/plugin/claude-code/scripts/post-compact.sh
+++ b/plugin/claude-code/scripts/post-compact.sh
@@ -11,6 +11,9 @@ CWD=$(echo "$INPUT" | mnemo json cwd 2>/dev/null)
 
 [ -z "$CWD" ] && CWD="$(pwd)"
 
+PROJECT_ROOT=$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null || echo "$CWD")
+[ ! -f "${PROJECT_ROOT}/.mnemo" ] && exit 0
+
 PROJECT=$(realpath "$CWD" 2>/dev/null | sed "s|^$HOME/||; s|^/||" | tr '/' '-' | tr '[:upper:]' '[:lower:]')
 [ -z "$PROJECT" ] && PROJECT=$(basename "$CWD" | tr '[:upper:]' '[:lower:]')
 

--- a/plugin/claude-code/scripts/session-start.sh
+++ b/plugin/claude-code/scripts/session-start.sh
@@ -12,6 +12,9 @@ CWD=$(echo "$INPUT" | mnemo json cwd 2>/dev/null)
 [ -z "$SESSION_ID" ] && exit 0
 [ -z "$CWD" ] && CWD="$(pwd)"
 
+PROJECT_ROOT=$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null || echo "$CWD")
+[ ! -f "${PROJECT_ROOT}/.mnemo" ] && exit 0
+
 PROJECT=$(realpath "$CWD" 2>/dev/null | sed "s|^$HOME/||; s|^/||" | tr '/' '-' | tr '[:upper:]' '[:lower:]')
 [ -z "$PROJECT" ] && PROJECT=$(basename "$CWD" | tr '[:upper:]' '[:lower:]')
 

--- a/plugin/claude-code/scripts/session-start.sh
+++ b/plugin/claude-code/scripts/session-start.sh
@@ -15,8 +15,8 @@ CWD=$(echo "$INPUT" | mnemo json cwd 2>/dev/null)
 PROJECT_ROOT=$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null || echo "$CWD")
 [ ! -f "${PROJECT_ROOT}/.mnemo" ] && exit 0
 
-PROJECT=$(realpath "$CWD" 2>/dev/null | sed "s|^$HOME/||; s|^/||" | tr '/' '-' | tr '[:upper:]' '[:lower:]')
-[ -z "$PROJECT" ] && PROJECT=$(basename "$CWD" | tr '[:upper:]' '[:lower:]')
+PROJECT=$(realpath "$PROJECT_ROOT" 2>/dev/null | sed "s|^$HOME/||; s|^/||" | tr '/' '-' | tr '[:upper:]' '[:lower:]')
+[ -z "$PROJECT" ] && PROJECT=$(basename "$PROJECT_ROOT" | tr '[:upper:]' '[:lower:]')
 
 IS_RESUME=$(mnemo session exists "$SESSION_ID" 2>/dev/null)
 

--- a/plugin/claude-code/scripts/session-stop.sh
+++ b/plugin/claude-code/scripts/session-stop.sh
@@ -3,8 +3,13 @@
 
 INPUT=$(cat)
 SESSION_ID=$(echo "$INPUT" | mnemo json session_id 2>/dev/null)
+CWD=$(echo "$INPUT" | mnemo json cwd 2>/dev/null)
+[ -z "$CWD" ] && CWD="$(pwd)"
 
 [ -z "$SESSION_ID" ] && exit 0
+
+PROJECT_ROOT=$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null || echo "$CWD")
+[ ! -f "${PROJECT_ROOT}/.mnemo" ] && exit 0
 
 OBS_COUNT=$(mnemo session obs-count "$SESSION_ID" 2>/dev/null)
 

--- a/plugin/claude-code/scripts/subagent-stop.sh
+++ b/plugin/claude-code/scripts/subagent-stop.sh
@@ -10,6 +10,10 @@ OUTPUT=$(echo "$INPUT" | mnemo json stdout 2>/dev/null)
 [ -z "$OUTPUT" ] && exit 0
 
 [ -z "$CWD" ] && CWD="$(pwd)"
+
+PROJECT_ROOT=$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null || echo "$CWD")
+[ ! -f "${PROJECT_ROOT}/.mnemo" ] && exit 0
+
 PROJECT=$(realpath "$CWD" 2>/dev/null | sed "s|^$HOME/||; s|^/||" | tr '/' '-' | tr '[:upper:]' '[:lower:]')
 [ -z "$PROJECT" ] && PROJECT=$(basename "$CWD" | tr '[:upper:]' '[:lower:]')
 

--- a/plugin/claude-code/scripts/subagent-stop.sh
+++ b/plugin/claude-code/scripts/subagent-stop.sh
@@ -14,8 +14,8 @@ OUTPUT=$(echo "$INPUT" | mnemo json stdout 2>/dev/null)
 PROJECT_ROOT=$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null || echo "$CWD")
 [ ! -f "${PROJECT_ROOT}/.mnemo" ] && exit 0
 
-PROJECT=$(realpath "$CWD" 2>/dev/null | sed "s|^$HOME/||; s|^/||" | tr '/' '-' | tr '[:upper:]' '[:lower:]')
-[ -z "$PROJECT" ] && PROJECT=$(basename "$CWD" | tr '[:upper:]' '[:lower:]')
+PROJECT=$(realpath "$PROJECT_ROOT" 2>/dev/null | sed "s|^$HOME/||; s|^/||" | tr '/' '-' | tr '[:upper:]' '[:lower:]')
+[ -z "$PROJECT" ] && PROJECT=$(basename "$PROJECT_ROOT" | tr '[:upper:]' '[:lower:]')
 
 mnemo capture "$OUTPUT" --session "$SESSION_ID" --project "$PROJECT" 2>/dev/null || true
 

--- a/scripts/codex/hooks/session-start.sh
+++ b/scripts/codex/hooks/session-start.sh
@@ -21,6 +21,12 @@ fi
 
 [ -z "$CWD" ] && CWD="$(pwd)"
 
+PROJECT_ROOT=$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null || echo "$CWD")
+if [ ! -f "${PROJECT_ROOT}/.mnemo" ]; then
+  printf '{"continue":true}\n'
+  exit 0
+fi
+
 REALPATH_CWD=$(realpath "$CWD" 2>/dev/null)
 PROJECT="${REALPATH_CWD#"$HOME/"}"
 PROJECT="${PROJECT#/}"

--- a/scripts/codex/hooks/stop.sh
+++ b/scripts/codex/hooks/stop.sh
@@ -22,6 +22,12 @@ fi
 
 [ -z "$CWD" ] && CWD="$(pwd)"
 
+PROJECT_ROOT=$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null || echo "$CWD")
+if [ ! -f "${PROJECT_ROOT}/.mnemo" ]; then
+  printf '{"continue":true}\n'
+  exit 0
+fi
+
 REALPATH_CWD=$(realpath "$CWD" 2>/dev/null)
 PROJECT="${REALPATH_CWD#"$HOME/"}"
 PROJECT="${PROJECT#/}"

--- a/scripts/codex/hooks/stop.sh
+++ b/scripts/codex/hooks/stop.sh
@@ -23,26 +23,21 @@ fi
 [ -z "$CWD" ] && CWD="$(pwd)"
 
 PROJECT_ROOT=$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null || echo "$CWD")
-if [ ! -f "${PROJECT_ROOT}/.mnemo" ]; then
-  printf '{"continue":true}\n'
-  exit 0
-fi
 
-REALPATH_CWD=$(realpath "$CWD" 2>/dev/null)
-PROJECT="${REALPATH_CWD#"$HOME/"}"
-PROJECT="${PROJECT#/}"
-PROJECT=$(printf '%s' "$PROJECT" | tr '/' '-' | tr '[:upper:]' '[:lower:]')
-[ -z "$PROJECT" ] && PROJECT=$(basename "$CWD" | tr '[:upper:]' '[:lower:]')
+PROJECT=$(realpath "$PROJECT_ROOT" 2>/dev/null | sed "s|^$HOME/||; s|^/||" | tr '/' '-' | tr '[:upper:]' '[:lower:]')
+[ -z "$PROJECT" ] && PROJECT=$(basename "$PROJECT_ROOT" | tr '[:upper:]' '[:lower:]')
 
-# Passive capture from transcript if available
-if [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ]; then
-  CONTENT=$(mnemo extract-transcript "$TRANSCRIPT_PATH" 2>/dev/null)
-  if [ -z "$CONTENT" ]; then
-    CONTENT=$(cat "$TRANSCRIPT_PATH" 2>/dev/null)
-  fi
+# Passive capture only if project has mnemo configured
+if [ -f "${PROJECT_ROOT}/.mnemo" ]; then
+  if [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ]; then
+    CONTENT=$(mnemo extract-transcript "$TRANSCRIPT_PATH" 2>/dev/null)
+    if [ -z "$CONTENT" ]; then
+      CONTENT=$(cat "$TRANSCRIPT_PATH" 2>/dev/null)
+    fi
 
-  if [ -n "$CONTENT" ]; then
-    mnemo capture "$CONTENT" --session "$SESSION_ID" --project "$PROJECT" 2>/dev/null || true
+    if [ -n "$CONTENT" ]; then
+      mnemo capture "$CONTENT" --session "$SESSION_ID" --project "$PROJECT" 2>/dev/null || true
+    fi
   fi
 fi
 

--- a/scripts/cursor/hooks/before-submit-prompt.sh
+++ b/scripts/cursor/hooks/before-submit-prompt.sh
@@ -21,8 +21,8 @@ PROMPT=$(echo "$INPUT" | mnemo json prompt 2>/dev/null)
 PROJECT_ROOT=$(git -C "$WORKSPACE" rev-parse --show-toplevel 2>/dev/null || echo "$WORKSPACE")
 [ ! -f "${PROJECT_ROOT}/.mnemo" ] && exit 0
 
-PROJECT=$(realpath "$WORKSPACE" 2>/dev/null | sed "s|^$HOME/||; s|^/||" | tr '/' '-' | tr '[:upper:]' '[:lower:]')
-[ -z "$PROJECT" ] && PROJECT=$(basename "$WORKSPACE" | tr '[:upper:]' '[:lower:]')
+PROJECT=$(realpath "$PROJECT_ROOT" 2>/dev/null | sed "s|^$HOME/||; s|^/||" | tr '/' '-' | tr '[:upper:]' '[:lower:]')
+[ -z "$PROJECT" ] && PROJECT=$(basename "$PROJECT_ROOT" | tr '[:upper:]' '[:lower:]')
 
 # Only act on the first prompt of a conversation (session start)
 IS_KNOWN=$(mnemo session exists "$CONVERSATION_ID" 2>/dev/null)

--- a/scripts/cursor/hooks/before-submit-prompt.sh
+++ b/scripts/cursor/hooks/before-submit-prompt.sh
@@ -18,6 +18,9 @@ PROMPT=$(echo "$INPUT" | mnemo json prompt 2>/dev/null)
 [ -z "$CONVERSATION_ID" ] && exit 0
 [ -z "$WORKSPACE" ] && WORKSPACE="$(pwd)"
 
+PROJECT_ROOT=$(git -C "$WORKSPACE" rev-parse --show-toplevel 2>/dev/null || echo "$WORKSPACE")
+[ ! -f "${PROJECT_ROOT}/.mnemo" ] && exit 0
+
 PROJECT=$(realpath "$WORKSPACE" 2>/dev/null | sed "s|^$HOME/||; s|^/||" | tr '/' '-' | tr '[:upper:]' '[:lower:]')
 [ -z "$PROJECT" ] && PROJECT=$(basename "$WORKSPACE" | tr '[:upper:]' '[:lower:]')
 

--- a/scripts/cursor/hooks/stop.sh
+++ b/scripts/cursor/hooks/stop.sh
@@ -20,8 +20,8 @@ WORKSPACE=$(echo "$INPUT" | mnemo json workspace_roots 0 2>/dev/null)
 PROJECT_ROOT=$(git -C "$WORKSPACE" rev-parse --show-toplevel 2>/dev/null || echo "$WORKSPACE")
 [ ! -f "${PROJECT_ROOT}/.mnemo" ] && exit 0
 
-PROJECT=$(realpath "$WORKSPACE" 2>/dev/null | sed "s|^$HOME/||; s|^/||" | tr '/' '-' | tr '[:upper:]' '[:lower:]')
-[ -z "$PROJECT" ] && PROJECT=$(basename "$WORKSPACE" | tr '[:upper:]' '[:lower:]')
+PROJECT=$(realpath "$PROJECT_ROOT" 2>/dev/null | sed "s|^$HOME/||; s|^/||" | tr '/' '-' | tr '[:upper:]' '[:lower:]')
+[ -z "$PROJECT" ] && PROJECT=$(basename "$PROJECT_ROOT" | tr '[:upper:]' '[:lower:]')
 
 # Passive capture from transcript if available
 if [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ]; then

--- a/scripts/cursor/hooks/stop.sh
+++ b/scripts/cursor/hooks/stop.sh
@@ -17,6 +17,9 @@ WORKSPACE=$(echo "$INPUT" | mnemo json workspace_roots 0 2>/dev/null)
 [ -z "$CONVERSATION_ID" ] && exit 0
 [ -z "$WORKSPACE" ] && WORKSPACE="$(pwd)"
 
+PROJECT_ROOT=$(git -C "$WORKSPACE" rev-parse --show-toplevel 2>/dev/null || echo "$WORKSPACE")
+[ ! -f "${PROJECT_ROOT}/.mnemo" ] && exit 0
+
 PROJECT=$(realpath "$WORKSPACE" 2>/dev/null | sed "s|^$HOME/||; s|^/||" | tr '/' '-' | tr '[:upper:]' '[:lower:]')
 [ -z "$PROJECT" ] && PROJECT=$(basename "$WORKSPACE" | tr '[:upper:]' '[:lower:]')
 

--- a/scripts/windsurf/hooks/post-cascade-response.sh
+++ b/scripts/windsurf/hooks/post-cascade-response.sh
@@ -16,6 +16,9 @@ TRANSCRIPT_PATH=$(echo "$INPUT" | mnemo json tool_info transcript_path 2>/dev/nu
 [ -z "$TRAJECTORY_ID" ] && exit 0
 
 WORKSPACE="$(pwd)"
+PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "$WORKSPACE")
+[ ! -f "${PROJECT_ROOT}/.mnemo" ] && exit 0
+
 PROJECT=$(realpath "$WORKSPACE" 2>/dev/null | sed "s|^$HOME/||; s|^/||" | tr '/' '-' | tr '[:upper:]' '[:lower:]')
 [ -z "$PROJECT" ] && PROJECT=$(basename "$WORKSPACE" | tr '[:upper:]' '[:lower:]')
 

--- a/scripts/windsurf/hooks/post-cascade-response.sh
+++ b/scripts/windsurf/hooks/post-cascade-response.sh
@@ -16,11 +16,11 @@ TRANSCRIPT_PATH=$(echo "$INPUT" | mnemo json tool_info transcript_path 2>/dev/nu
 [ -z "$TRAJECTORY_ID" ] && exit 0
 
 WORKSPACE="$(pwd)"
-PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "$WORKSPACE")
+PROJECT_ROOT=$(git -C "$WORKSPACE" rev-parse --show-toplevel 2>/dev/null || echo "$WORKSPACE")
 [ ! -f "${PROJECT_ROOT}/.mnemo" ] && exit 0
 
-PROJECT=$(realpath "$WORKSPACE" 2>/dev/null | sed "s|^$HOME/||; s|^/||" | tr '/' '-' | tr '[:upper:]' '[:lower:]')
-[ -z "$PROJECT" ] && PROJECT=$(basename "$WORKSPACE" | tr '[:upper:]' '[:lower:]')
+PROJECT=$(realpath "$PROJECT_ROOT" 2>/dev/null | sed "s|^$HOME/||; s|^/||" | tr '/' '-' | tr '[:upper:]' '[:lower:]')
+[ -z "$PROJECT" ] && PROJECT=$(basename "$PROJECT_ROOT" | tr '[:upper:]' '[:lower:]')
 
 # Passive capture from transcript if available
 if [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ]; then

--- a/scripts/windsurf/hooks/pre-user-prompt.sh
+++ b/scripts/windsurf/hooks/pre-user-prompt.sh
@@ -17,11 +17,11 @@ PROMPT=$(echo "$INPUT" | mnemo json tool_info user_prompt 2>/dev/null)
 [ -z "$TRAJECTORY_ID" ] && exit 0
 
 WORKSPACE="$(pwd)"
-PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "$WORKSPACE")
+PROJECT_ROOT=$(git -C "$WORKSPACE" rev-parse --show-toplevel 2>/dev/null || echo "$WORKSPACE")
 [ ! -f "${PROJECT_ROOT}/.mnemo" ] && exit 0
 
-PROJECT=$(realpath "$WORKSPACE" 2>/dev/null | sed "s|^$HOME/||; s|^/||" | tr '/' '-' | tr '[:upper:]' '[:lower:]')
-[ -z "$PROJECT" ] && PROJECT=$(basename "$WORKSPACE" | tr '[:upper:]' '[:lower:]')
+PROJECT=$(realpath "$PROJECT_ROOT" 2>/dev/null | sed "s|^$HOME/||; s|^/||" | tr '/' '-' | tr '[:upper:]' '[:lower:]')
+[ -z "$PROJECT" ] && PROJECT=$(basename "$PROJECT_ROOT" | tr '[:upper:]' '[:lower:]')
 
 # Only act on the first prompt of a conversation (session start)
 IS_KNOWN=$(mnemo session exists "$TRAJECTORY_ID" 2>/dev/null)

--- a/scripts/windsurf/hooks/pre-user-prompt.sh
+++ b/scripts/windsurf/hooks/pre-user-prompt.sh
@@ -17,6 +17,9 @@ PROMPT=$(echo "$INPUT" | mnemo json tool_info user_prompt 2>/dev/null)
 [ -z "$TRAJECTORY_ID" ] && exit 0
 
 WORKSPACE="$(pwd)"
+PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "$WORKSPACE")
+[ ! -f "${PROJECT_ROOT}/.mnemo" ] && exit 0
+
 PROJECT=$(realpath "$WORKSPACE" 2>/dev/null | sed "s|^$HOME/||; s|^/||" | tr '/' '-' | tr '[:upper:]' '[:lower:]')
 [ -z "$PROJECT" ] && PROJECT=$(basename "$WORKSPACE" | tr '[:upper:]' '[:lower:]')
 


### PR DESCRIPTION
Closes #16.

## What

Replaces the global installation model with a per-project opt-in. Running `mnemo init` from a project root configures mnemo only for that project.

## Why

The previous approach injected the mnemo protocol into global agent config files (`~/.claude/CLAUDE.md`, `~/.cursor/rules/mnemo.mdc`, etc.), loading instructions into every session regardless of whether the project used mnemo.

## Changes

**New command: `mnemo init [--agent=claudecode|cursor|windsurf|codex|all]`**

Run from the project root. Each agent writes different files:

- `claudecode`: creates `AGENTS.md` with the protocol, converts `CLAUDE.md` to a symlink pointing to `AGENTS.md`, writes `.mnemo`
- `cursor`: writes `.cursor/hooks.json` and `.cursor/rules/mnemo.mdc`, writes `.mnemo`
- `windsurf`: writes `.windsurf/hooks.json` and `.windsurf/rules/mnemo.md`, writes `.mnemo`
- `codex`: appends the protocol to `AGENTS.md`, writes `.mnemo`

**Hook scripts**

All hook scripts check for `.mnemo` at the project root before acting. Projects without the marker are skipped silently.

**`install.sh`**

Now only installs the binary, global hook scripts, and global MCP config. No longer injects protocol into any user-level config file.

**`.mnemo` marker**

```json
{
  "version": 1,
  "agents": ["claudecode", "cursor"]
}
```

Tracks which agents are configured. All operations are idempotent: running `mnemo init` twice produces no duplicates.

## Notes

- MCP config stays global for all agents. Windsurf and Codex have no per-project MCP support.
- Codex has no per-project hook config; the `.mnemo` marker check handles the opt-in at runtime.
- Cursor and Windsurf hook configs are per-project; the generated `hooks.json` references the globally installed scripts by absolute path.
- `AGENTS.md` sections are delimited by `<!-- mnemo:start -->` and `<!-- mnemo:end -->` to prevent duplicates.

## Test plan

- [ ] `go build ./...` and `go test ./...` pass
- [ ] `claude plugin validate plugin/claude-code` passes
- [ ] `mnemo init --agent=claudecode` creates `.mnemo`, `AGENTS.md`, and `CLAUDE.md` symlink
- [ ] `mnemo init --agent=cursor` creates `.cursor/hooks.json` and `.cursor/rules/mnemo.mdc`
- [ ] Running `mnemo init` twice produces no duplicates in `AGENTS.md` or `.mnemo`
- [ ] Session in a project without `.mnemo` produces no mnemo output
- [ ] Session in a project with `.mnemo` works normally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `mnemo init` for opt-in, per-project activation and multi-agent initialization.
  * Agent hooks now derive project root from the repository and only run when a project `.mnemo` marker exists.
  * New agent templates require structured "Key Learnings" blocks and mandatory session summaries to standardize memory persistence.

* **Documentation**
  * Reworked setup into a two-phase global + per-project flow, added an agent capabilities matrix and expanded CLI `mnemo init` reference.
  * Installer guidance updated to instruct running `mnemo init` within each project.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->