### PR TITLE
fix: read capture content from stdin

### DIFF
--- a/cmd/mnemo/main.go
+++ b/cmd/mnemo/main.go
@@ -651,7 +651,7 @@ Usage:
   mnemo stats                          Show memory statistics
   mnemo export [file]                  Export all memories to JSON
   mnemo import <file.json>             Import memories from JSON
-  mnemo capture <content>              Extract learnings from text (passive capture)
+  mnemo capture <content>|-            Extract learnings from text (passive capture; "-" reads stdin)
   mnemo init [--agent=AGENT] [--path=DIR]  Configure mnemo in the current project
   mnemo json KEY [KEY ...]             Extract field from JSON on stdin (used by hooks)
   mnemo json-merge <file>              Deep-merge JSON from stdin into file

--- a/cmd/mnemo/main.go
+++ b/cmd/mnemo/main.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -385,11 +386,21 @@ func runImport(s *store.Store) {
 func runCapture(s *store.Store) {
 	args := os.Args[2:]
 	if len(args) == 0 {
-		fmt.Fprintln(os.Stderr, "usage: mnemo capture <content> [--session SESSION_ID] [--project PROJECT]")
+		fmt.Fprintln(os.Stderr, "usage: mnemo capture <content>|- [--session SESSION_ID] [--project PROJECT]")
 		os.Exit(1)
 	}
 
-	content := args[0]
+	var content string
+	if args[0] == "-" {
+		data, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "mnemo: failed to read stdin: %v\n", err)
+			os.Exit(1)
+		}
+		content = string(data)
+	} else {
+		content = args[0]
+	}
 	sessionID := ""
 	project := ""
 

--- a/scripts/codex/hooks/stop.sh
+++ b/scripts/codex/hooks/stop.sh
@@ -36,7 +36,7 @@ if [ -f "${PROJECT_ROOT}/.mnemo" ]; then
     fi
 
     if [ -n "$CONTENT" ]; then
-      mnemo capture "$CONTENT" --session "$SESSION_ID" --project "$PROJECT" 2>/dev/null || true
+      printf '%s' "$CONTENT" | mnemo capture - --session "$SESSION_ID" --project "$PROJECT" 2>/dev/null || true
     fi
   fi
 fi

--- a/scripts/cursor/hooks/stop.sh
+++ b/scripts/cursor/hooks/stop.sh
@@ -28,7 +28,7 @@ if [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ]; then
   CONTENT=$(mnemo extract-transcript "$TRANSCRIPT_PATH" 2>/dev/null)
 
   if [ -n "$CONTENT" ]; then
-    mnemo capture "$CONTENT" --session "$CONVERSATION_ID" --project "$PROJECT" 2>/dev/null || true
+    printf '%s' "$CONTENT" | mnemo capture - --session "$CONVERSATION_ID" --project "$PROJECT" 2>/dev/null || true
   fi
 fi
 

--- a/scripts/windsurf/hooks/post-cascade-response.sh
+++ b/scripts/windsurf/hooks/post-cascade-response.sh
@@ -27,7 +27,7 @@ if [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ]; then
   CONTENT=$(mnemo extract-transcript "$TRANSCRIPT_PATH" 2>/dev/null)
 
   if [ -n "$CONTENT" ]; then
-    mnemo capture "$CONTENT" --session "$TRAJECTORY_ID" --project "$PROJECT" 2>/dev/null || true
+    printf '%s' "$CONTENT" | mnemo capture - --session "$TRAJECTORY_ID" --project "$PROJECT" 2>/dev/null || true
   fi
 fi
 


### PR DESCRIPTION
Closes #18

## Summary

- `mnemo capture "$CONTENT"` exceeds ARG_MAX (~1 MB on macOS) on long sessions, failing silently because of `|| true` in hook scripts
- Added `-` stdin support to `runCapture` in `cmd/mnemo/main.go`
- Updated all three hook scripts to pipe content: `printf '%s' "$CONTENT" | mnemo capture -`
- Positional argument mode stays intact

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./...` passes
- [ ] `claude plugin validate plugin/claude-code` passes
- [ ] `printf 'test' | mnemo capture - --project test` returns `Captured: ...`
- [ ] `mnemo capture "test" --project test` still works (backward compat)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `capture` command now supports reading content from standard input using the `-` option, providing an alternative to passing content as a direct argument.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->