### PR TITLE
fix: use OR semantics in FTS5 search queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /mnemo
 /dist/
 /build/
+.hybrid-coco

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -4132,7 +4132,7 @@ func sanitizeFTS(query string) string {
 		w = strings.Trim(w, `"`)
 		words[i] = `"` + w + `"`
 	}
-	return strings.Join(words, " ")
+	return strings.Join(words, " OR ")
 }
 
 // ─── Passive Capture ─────────────────────────────────────────────────────────


### PR DESCRIPTION
Multi-word queries used AND semantics all terms had to appear in the indexed fields. A query like `"profiles" "discovery" "refactor"` returned zero results if any single term was missing from title or content.

Changed `sanitizeFTS` to join tokens with `OR` instead of a plain space. FTS5 now returns a result if any term matches, ranked by how many terms match via `fts.rank`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced multi-word search queries to return broader and more comprehensive search results.

* **Chores**
  * Updated repository configuration to ignore additional system paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jmeiracorbal/mnemo/pull/22?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->