### PR TITLE
feat: replace path-derived project keys with UUID-based identity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /dist/
 /build/
 .hybrid-coco
+.mnemo

--- a/.mnemo
+++ b/.mnemo
@@ -1,7 +1,0 @@
-{
-  "version": 1,
-  "id": "c072d66b-4223-5900-b7b9-0842680007e9",
-  "agents": [
-    "claudecode"
-  ]
-}

--- a/.mnemo
+++ b/.mnemo
@@ -1,5 +1,6 @@
 {
   "version": 1,
+  "id": "c072d66b-4223-5900-b7b9-0842680007e9",
   "agents": [
     "claudecode"
   ]

--- a/cmd/mnemo/main.go
+++ b/cmd/mnemo/main.go
@@ -605,6 +605,10 @@ func runInit(s *store.Store) {
 		}
 		fmt.Printf("mnemo init: %s configured in %s\n", a, root)
 	}
+	if err := agentinit.EnsureGitignore(root); err != nil {
+		fmt.Fprintf(os.Stderr, "mnemo init: gitignore: %v\n", err)
+		os.Exit(1)
+	}
 	fmt.Printf("mnemo init: project ID %s\n", projectID)
 }
 
@@ -653,11 +657,16 @@ func runMigrateProjects(s *store.Store) {
 		os.Exit(1)
 	}
 
+	if err := agentinit.EnsureGitignore(root); err != nil {
+		fmt.Fprintf(os.Stderr, "mnemo migrate: gitignore: %v\n", err)
+		os.Exit(1)
+	}
+
 	if result.Migrated {
-		fmt.Printf("migrated: %s → %s (%d obs, %d sessions)\n",
+		fmt.Printf("migrated: %s -> %s (%d obs, %d sessions)\n",
 			legacyKey, projectID, result.ObservationsUpdated, result.SessionsUpdated)
 	} else {
-		fmt.Printf("no legacy data found for %s — project registered as %s\n", legacyKey, projectID)
+		fmt.Printf("no legacy data found for %s, project registered as %s\n", legacyKey, projectID)
 	}
 }
 

--- a/cmd/mnemo/main.go
+++ b/cmd/mnemo/main.go
@@ -637,8 +637,13 @@ func runMigrateProjects(s *store.Store) {
 	}
 	root := agentinit.ProjectRoot(abs)
 
+	legacyRoot := root
+	if resolved, err := filepath.EvalSymlinks(root); err == nil {
+		legacyRoot = resolved
+	}
+
 	projectID := agentinit.ProjectUUIDFromPath(root)
-	legacyKey := deriveLegacyKey(root)
+	legacyKey := deriveLegacyKey(legacyRoot)
 	name := filepath.Base(root)
 
 	result, err := s.MigrateProject(legacyKey, projectID)

--- a/cmd/mnemo/main.go
+++ b/cmd/mnemo/main.go
@@ -36,9 +36,6 @@ func main() {
 	case "extract-transcript":
 		runExtractTranscript()
 		return
-	case "init":
-		runInit()
-		return
 	case "--version", "version":
 		fmt.Printf("mnemo %s\n", version)
 		return
@@ -57,11 +54,14 @@ func main() {
 	defer s.Close()
 
 	switch os.Args[1] {
+	case "init":
+		runInit(s)
+	case "migrate":
+		runMigrateProjects(s)
 	case "mcp":
 		runMCP(s)
 	case "save":
 		runSave(s)
-
 	case "search":
 		runSearch(s)
 	case "context":
@@ -562,7 +562,7 @@ func runExtractTranscript() {
 // ─── init ────────────────────────────────────────────────────────────────────
 
 // runInit configures mnemo for one or more agents in the current project.
-func runInit() {
+func runInit(s *store.Store) {
 	agent := "claudecode"
 	dir := "."
 
@@ -582,6 +582,17 @@ func runInit() {
 	}
 	root := agentinit.ProjectRoot(abs)
 
+	projectID, err := agentinit.EnsureProjectID(root)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mnemo init: project ID: %v\n", err)
+		os.Exit(1)
+	}
+	name := filepath.Base(root)
+	if err := s.EnsureProject(projectID, name); err != nil {
+		fmt.Fprintf(os.Stderr, "mnemo init: register project: %v\n", err)
+		os.Exit(1)
+	}
+
 	agents := []string{agent}
 	if agent == "all" {
 		agents = []string{"claudecode", "cursor", "windsurf", "codex"}
@@ -594,6 +605,75 @@ func runInit() {
 		}
 		fmt.Printf("mnemo init: %s configured in %s\n", a, root)
 	}
+	fmt.Printf("mnemo init: project ID %s\n", projectID)
+}
+
+// runMigrateProjects migrates a project from a legacy path-derived key to a
+// UUID-based ID. Run once per project after upgrading to project-ID-based tracking.
+//
+// Steps:
+//  1. Resolve the current project root.
+//  2. Compute the deterministic UUID v5 from the absolute path.
+//  3. Compute what the legacy derived key would have been for this path.
+//  4. Rekey existing observations/sessions from legacy key → UUID.
+//  5. Register the project in the projects table.
+//  6. Write the UUID to .mnemo.
+func runMigrateProjects(s *store.Store) {
+	dir := "."
+	for _, arg := range os.Args[2:] {
+		if strings.HasPrefix(arg, "--path=") {
+			dir = arg[len("--path="):]
+		}
+	}
+
+	abs, err := absPath(dir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mnemo migrate: %v\n", err)
+		os.Exit(1)
+	}
+	root := agentinit.ProjectRoot(abs)
+
+	projectID := agentinit.ProjectUUIDFromPath(root)
+	legacyKey := deriveLegacyKey(root)
+	name := filepath.Base(root)
+
+	result, err := s.MigrateProject(legacyKey, projectID)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mnemo migrate: rekey: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err := s.EnsureProject(projectID, name); err != nil {
+		fmt.Fprintf(os.Stderr, "mnemo migrate: register: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err := agentinit.EnsureMarkerWithID(root, projectID); err != nil {
+		fmt.Fprintf(os.Stderr, "mnemo migrate: write marker: %v\n", err)
+		os.Exit(1)
+	}
+
+	if result.Migrated {
+		fmt.Printf("migrated: %s → %s (%d obs, %d sessions)\n",
+			legacyKey, projectID, result.ObservationsUpdated, result.SessionsUpdated)
+	} else {
+		fmt.Printf("no legacy data found for %s — project registered as %s\n", legacyKey, projectID)
+	}
+}
+
+// deriveLegacyKey computes what the path-derived project key would have been
+// for the given absolute path under the old hook derivation logic:
+//
+//	realpath | sed "s|^$HOME/||; s|^/||" | tr '/' '-' | tr '[:upper:]' '[:lower:]'
+func deriveLegacyKey(absPath string) string {
+	home, _ := os.UserHomeDir()
+	rel := absPath
+	if home != "" && strings.HasPrefix(rel, home+"/") {
+		rel = rel[len(home)+1:]
+	} else if strings.HasPrefix(rel, "/") {
+		rel = rel[1:]
+	}
+	return strings.ToLower(strings.ReplaceAll(rel, "/", "-"))
 }
 
 func initAgent(root, agent string) error {
@@ -653,6 +733,7 @@ Usage:
   mnemo import <file.json>             Import memories from JSON
   mnemo capture <content>|-            Extract learnings from text (passive capture; "-" reads stdin)
   mnemo init [--agent=AGENT] [--path=DIR]  Configure mnemo in the current project
+  mnemo migrate [--path=DIR]              Migrate project from legacy key to UUID-based identity
   mnemo json KEY [KEY ...]             Extract field from JSON on stdin (used by hooks)
   mnemo json-merge <file>              Deep-merge JSON from stdin into file
   mnemo extract-transcript <file>      Extract assistant text from JSONL transcript

--- a/internal/agentinit/common.go
+++ b/internal/agentinit/common.go
@@ -122,6 +122,32 @@ func EnsureMarkerWithID(root, id string) error {
 	return writeMarker(root, m)
 }
 
+// EnsureGitignore adds .mnemo to the project .gitignore if not already present.
+// Creates .gitignore if it does not exist. Idempotent.
+func EnsureGitignore(root string) error {
+	path := filepath.Join(root, ".gitignore")
+	data, err := os.ReadFile(path)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.TrimSpace(line) == ".mnemo" {
+			return nil
+		}
+	}
+	entry := ".mnemo\n"
+	if len(data) > 0 && data[len(data)-1] != '\n' {
+		entry = "\n" + entry
+	}
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	_, err = f.WriteString(entry)
+	return err
+}
+
 // AddAgent adds agent to the .mnemo marker, creating it if needed. Idempotent.
 func AddAgent(root, agent string) error {
 	m, err := readMarker(root)

--- a/internal/agentinit/common.go
+++ b/internal/agentinit/common.go
@@ -7,9 +7,25 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/google/uuid"
 )
 
 const markerName = ".mnemo"
+
+// mnemoNamespace is the UUID v5 namespace for mnemo project identifiers.
+// Fixed forever — changing this would invalidate all existing project IDs.
+var mnemoNamespace = uuid.MustParse("6f3e4b2a-1c5d-4e7f-8a9b-0c1d2e3f4a5b")
+
+// ProjectUUIDFromPath returns the deterministic UUID v5 for an absolute project path.
+// Same path always produces the same UUID. Used by both init and migrate.
+// Panics if absPath is not absolute to prevent non-deterministic IDs.
+func ProjectUUIDFromPath(absPath string) string {
+	if !filepath.IsAbs(absPath) {
+		panic("ProjectUUIDFromPath: path must be absolute, got: " + absPath)
+	}
+	return uuid.NewSHA1(mnemoNamespace, []byte(absPath)).String()
+}
 const sectionStart = "<!-- mnemo:start -->"
 const sectionEnd = "<!-- mnemo:end -->"
 const claudeSectionStart = "<!-- mnemo:claude-start -->"
@@ -18,6 +34,7 @@ const claudeSectionEnd = "<!-- mnemo:claude-end -->"
 // Marker is the .mnemo file format.
 type Marker struct {
 	Version int      `json:"version"`
+	ID      string   `json:"id,omitempty"`
 	Agents  []string `json:"agents"`
 }
 
@@ -51,6 +68,58 @@ func writeMarker(root string, m *Marker) error {
 		return err
 	}
 	return os.WriteFile(filepath.Join(root, markerName), append(data, '\n'), 0644)
+}
+
+// EnsureProjectID returns the project UUID from .mnemo. If not set, derives it
+// deterministically from the absolute path, persists it, and returns it.
+func EnsureProjectID(root string) (string, error) {
+	m, err := readMarker(root)
+	if err != nil {
+		return "", err
+	}
+	if m.ID != "" {
+		return m.ID, nil
+	}
+	abs, err := filepath.Abs(root)
+	if err != nil {
+		return "", fmt.Errorf("resolve path: %w", err)
+	}
+	m.ID = ProjectUUIDFromPath(abs)
+	if err := writeMarker(root, m); err != nil {
+		return "", fmt.Errorf("write project ID to .mnemo: %w", err)
+	}
+	return m.ID, nil
+}
+
+// ReadProjectID returns the project UUID from .mnemo.
+// Errors if .mnemo does not exist or has no ID set.
+func ReadProjectID(root string) (string, error) {
+	data, err := os.ReadFile(filepath.Join(root, markerName))
+	if os.IsNotExist(err) {
+		return "", fmt.Errorf(".mnemo not found in %s — run mnemo init first", root)
+	}
+	if err != nil {
+		return "", err
+	}
+	var m Marker
+	if err := json.Unmarshal(data, &m); err != nil {
+		return "", fmt.Errorf("malformed .mnemo: %w", err)
+	}
+	if m.ID == "" {
+		return "", fmt.Errorf(".mnemo has no project ID in %s — run mnemo init", root)
+	}
+	return m.ID, nil
+}
+
+// EnsureMarkerWithID writes id into the .mnemo at root, preserving existing
+// fields. Creates the file if absent. Used by migrate-projects.
+func EnsureMarkerWithID(root, id string) error {
+	m, err := readMarker(root)
+	if err != nil {
+		return err
+	}
+	m.ID = id
+	return writeMarker(root, m)
 }
 
 // AddAgent adds agent to the .mnemo marker, creating it if needed. Idempotent.

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -2883,10 +2883,11 @@ func (s *Store) IsProjectEnrolled(project string) (bool, error) {
 // ─── Project Migration ───────────────────────────────────────────────────────
 
 type MigrateResult struct {
-	Migrated            bool  `json:"migrated"`
-	ObservationsUpdated int64 `json:"observations_updated"`
-	SessionsUpdated     int64 `json:"sessions_updated"`
-	PromptsUpdated      int64 `json:"prompts_updated"`
+	Migrated             bool  `json:"migrated"`
+	ObservationsUpdated  int64 `json:"observations_updated"`
+	SessionsUpdated      int64 `json:"sessions_updated"`
+	PromptsUpdated       int64 `json:"prompts_updated"`
+	SyncMutationsUpdated int64 `json:"sync_mutations_updated"`
 }
 
 func (s *Store) MigrateProject(oldName, newName string) (*MigrateResult, error) {
@@ -2903,7 +2904,11 @@ func (s *Store) MigrateProject(oldName, newName string) (*MigrateResult, error) 
 			SELECT 1 FROM sessions WHERE project = ?
 			UNION ALL
 			SELECT 1 FROM user_prompts WHERE project = ?
-		)`, oldName, oldName, oldName,
+			UNION ALL
+			SELECT 1 FROM sync_mutations WHERE project = ?
+			UNION ALL
+			SELECT 1 FROM sync_enrolled_projects WHERE project = ?
+		)`, oldName, oldName, oldName, oldName, oldName,
 	).Scan(&exists)
 	if err != nil {
 		return nil, fmt.Errorf("check old project: %w", err)
@@ -2933,6 +2938,25 @@ func (s *Store) MigrateProject(oldName, newName string) (*MigrateResult, error) 
 			return fmt.Errorf("migrate prompts: %w", err)
 		}
 		result.PromptsUpdated, _ = res.RowsAffected()
+
+		res, err = s.execHook(tx,
+			`UPDATE sync_mutations SET project = ?, payload = json_set(payload, '$.project', ?) WHERE project = ?`,
+			newName, newName, oldName)
+		if err != nil {
+			return fmt.Errorf("migrate sync_mutations: %w", err)
+		}
+		result.SyncMutationsUpdated, _ = res.RowsAffected()
+
+		if _, err = s.execHook(tx,
+			`INSERT OR IGNORE INTO sync_enrolled_projects (project, enrolled_at)
+			 SELECT ?, enrolled_at FROM sync_enrolled_projects WHERE project = ?`,
+			newName, oldName); err != nil {
+			return fmt.Errorf("migrate sync_enrolled_projects insert: %w", err)
+		}
+		if _, err = s.execHook(tx,
+			`DELETE FROM sync_enrolled_projects WHERE project = ?`, oldName); err != nil {
+			return fmt.Errorf("migrate sync_enrolled_projects delete: %w", err)
+		}
 
 		return nil
 	})

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -27,6 +27,12 @@ var openDB = sql.Open
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
+type Project struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	CreatedAt string `json:"created_at"`
+}
+
 type Session struct {
 	ID        string   `json:"id"`
 	Project   string   `json:"project"`
@@ -722,67 +728,106 @@ func (s *Store) migrate() error {
 		return err
 	}
 
-	// Create triggers to keep FTS in sync (idempotent check)
-	var name string
-	err := s.db.QueryRow(
-		"SELECT name FROM sqlite_master WHERE type='trigger' AND name='obs_fts_insert'",
-	).Scan(&name)
-
-	if err == sql.ErrNoRows {
-		triggers := `
-			CREATE TRIGGER obs_fts_insert AFTER INSERT ON observations BEGIN
-				INSERT INTO observations_fts(rowid, title, content, tool_name, type, project)
-				VALUES (new.id, new.title, new.content, new.tool_name, new.type, new.project);
-			END;
-
-			CREATE TRIGGER obs_fts_delete AFTER DELETE ON observations BEGIN
-				INSERT INTO observations_fts(observations_fts, rowid, title, content, tool_name, type, project)
-				VALUES ('delete', old.id, old.title, old.content, old.tool_name, old.type, old.project);
-			END;
-
-			CREATE TRIGGER obs_fts_update AFTER UPDATE ON observations BEGIN
-				INSERT INTO observations_fts(observations_fts, rowid, title, content, tool_name, type, project)
-				VALUES ('delete', old.id, old.title, old.content, old.tool_name, old.type, old.project);
-				INSERT INTO observations_fts(rowid, title, content, tool_name, type, project)
-				VALUES (new.id, new.title, new.content, new.tool_name, new.type, new.project);
-			END;
-		`
-		if _, err := s.execHook(s.db, triggers); err != nil {
-			return err
-		}
+	if err := s.ensureFTSTriggers(); err != nil {
+		return err
 	}
 
-	// Prompts FTS triggers (separate idempotent check)
-	var promptTrigger string
-	err = s.db.QueryRow(
-		"SELECT name FROM sqlite_master WHERE type='trigger' AND name='prompt_fts_insert'",
-	).Scan(&promptTrigger)
-
-	if err == sql.ErrNoRows {
-		promptTriggers := `
-			CREATE TRIGGER prompt_fts_insert AFTER INSERT ON user_prompts BEGIN
-				INSERT INTO prompts_fts(rowid, content, project)
-				VALUES (new.id, new.content, new.project);
-			END;
-
-			CREATE TRIGGER prompt_fts_delete AFTER DELETE ON user_prompts BEGIN
-				INSERT INTO prompts_fts(prompts_fts, rowid, content, project)
-				VALUES ('delete', old.id, old.content, old.project);
-			END;
-
-			CREATE TRIGGER prompt_fts_update AFTER UPDATE ON user_prompts BEGIN
-				INSERT INTO prompts_fts(prompts_fts, rowid, content, project)
-				VALUES ('delete', old.id, old.content, old.project);
-				INSERT INTO prompts_fts(rowid, content, project)
-				VALUES (new.id, new.content, new.project);
-			END;
-		`
-		if _, err := s.execHook(s.db, promptTriggers); err != nil {
-			return err
-		}
+	if _, err := s.execHook(s.db, `
+		CREATE TABLE IF NOT EXISTS projects (
+			id         TEXT PRIMARY KEY,
+			name       TEXT NOT NULL,
+			created_at TEXT NOT NULL DEFAULT (datetime('now'))
+		);
+	`); err != nil {
+		return err
 	}
 
 	return nil
+}
+
+// ensureFTSTriggers creates FTS5 sync triggers using IF NOT EXISTS — idempotent.
+func (s *Store) ensureFTSTriggers() error {
+	_, err := s.execHook(s.db, `
+		CREATE TRIGGER IF NOT EXISTS obs_fts_insert AFTER INSERT ON observations BEGIN
+			INSERT INTO observations_fts(rowid, title, content, tool_name, type, project)
+			VALUES (new.id, new.title, new.content, new.tool_name, new.type, new.project);
+		END;
+
+		CREATE TRIGGER IF NOT EXISTS obs_fts_delete AFTER DELETE ON observations BEGIN
+			INSERT INTO observations_fts(observations_fts, rowid, title, content, tool_name, type, project)
+			VALUES ('delete', old.id, old.title, old.content, old.tool_name, old.type, old.project);
+		END;
+
+		CREATE TRIGGER IF NOT EXISTS obs_fts_update AFTER UPDATE ON observations BEGIN
+			INSERT INTO observations_fts(observations_fts, rowid, title, content, tool_name, type, project)
+			VALUES ('delete', old.id, old.title, old.content, old.tool_name, old.type, old.project);
+			INSERT INTO observations_fts(rowid, title, content, tool_name, type, project)
+			VALUES (new.id, new.title, new.content, new.tool_name, new.type, new.project);
+		END;
+
+		CREATE TRIGGER IF NOT EXISTS prompt_fts_insert AFTER INSERT ON user_prompts BEGIN
+			INSERT INTO prompts_fts(rowid, content, project)
+			VALUES (new.id, new.content, new.project);
+		END;
+
+		CREATE TRIGGER IF NOT EXISTS prompt_fts_delete AFTER DELETE ON user_prompts BEGIN
+			INSERT INTO prompts_fts(prompts_fts, rowid, content, project)
+			VALUES ('delete', old.id, old.content, old.project);
+		END;
+
+		CREATE TRIGGER IF NOT EXISTS prompt_fts_update AFTER UPDATE ON user_prompts BEGIN
+			INSERT INTO prompts_fts(prompts_fts, rowid, content, project)
+			VALUES ('delete', old.id, old.content, old.project);
+			INSERT INTO prompts_fts(rowid, content, project)
+			VALUES (new.id, new.content, new.project);
+		END;
+	`)
+	return err
+}
+
+// ─── Projects ────────────────────────────────────────────────────────────────
+
+// EnsureProject inserts a project row if it does not already exist. Idempotent.
+func (s *Store) EnsureProject(id, name string) error {
+	_, err := s.execHook(s.db,
+		`INSERT OR IGNORE INTO projects (id, name) VALUES (?, ?)`,
+		id, name,
+	)
+	return err
+}
+
+// GetProjectByID returns the project with the given ID, or nil if not found.
+func (s *Store) GetProjectByID(id string) (*Project, error) {
+	row := s.db.QueryRow(
+		`SELECT id, name, created_at FROM projects WHERE id = ?`, id,
+	)
+	var p Project
+	if err := row.Scan(&p.ID, &p.Name, &p.CreatedAt); err == sql.ErrNoRows {
+		return nil, nil
+	} else if err != nil {
+		return nil, err
+	}
+	return &p, nil
+}
+
+// ListProjects returns all projects ordered by creation time.
+func (s *Store) ListProjects() ([]Project, error) {
+	rows, err := s.queryItHook(s.db,
+		`SELECT id, name, created_at FROM projects ORDER BY created_at ASC`,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var projects []Project
+	for rows.Next() {
+		var p Project
+		if err := rows.Scan(&p.ID, &p.Name, &p.CreatedAt); err != nil {
+			return nil, err
+		}
+		projects = append(projects, p)
+	}
+	return projects, rows.Err()
 }
 
 // ─── Sessions ────────────────────────────────────────────────────────────────

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -409,26 +409,47 @@ func TestNewMigratesLegacyObservationIDSchema(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = s.Close() })
 
+	// Observation ID schema migration (NULL ids, duplicates) runs automatically
+	// in New(). Legacy data stays under the old project key "mnemo" until the
+	// user runs explicit migration.
 	obs, err := s.AllObservations("mnemo", "", 20)
 	if err != nil {
-		t.Fatalf("all observations after migration: %v", err)
+		t.Fatalf("all observations after open: %v", err)
 	}
 	if len(obs) != 3 {
-		t.Fatalf("expected 3 migrated observations, got %d", len(obs))
+		t.Fatalf("expected 3 observations under legacy key, got %d", len(obs))
 	}
 
 	seen := make(map[int64]bool)
 	for _, o := range obs {
 		if o.ID <= 0 {
-			t.Fatalf("expected migrated observation id > 0, got %d", o.ID)
+			t.Fatalf("expected observation id > 0, got %d", o.ID)
 		}
 		if seen[o.ID] {
-			t.Fatalf("expected unique migrated ids, duplicate %d", o.ID)
+			t.Fatalf("expected unique ids, duplicate %d", o.ID)
 		}
 		seen[o.ID] = true
 	}
 
-	results, err := s.Search("legacy", SearchOptions{Project: "mnemo", Limit: 10})
+	// Explicit migration: rekey legacy "mnemo" data to a UUID.
+	newUUID := "11111111-2222-3333-4444-555555555555"
+	result, err := s.MigrateProject("mnemo", newUUID)
+	if err != nil {
+		t.Fatalf("MigrateProject: %v", err)
+	}
+	if !result.Migrated {
+		t.Fatal("expected MigrateProject to report migration occurred")
+	}
+
+	obs, err = s.AllObservations(newUUID, "", 20)
+	if err != nil {
+		t.Fatalf("all observations after MigrateProject: %v", err)
+	}
+	if len(obs) != 3 {
+		t.Fatalf("expected 3 observations after rekey, got %d", len(obs))
+	}
+
+	results, err := s.Search("legacy", SearchOptions{Project: newUUID, Limit: 10})
 	if err != nil {
 		t.Fatalf("search after migration: %v", err)
 	}
@@ -441,7 +462,7 @@ func TestNewMigratesLegacyObservationIDSchema(t *testing.T) {
 		Type:      "bugfix",
 		Title:     "post migration",
 		Content:   "new row should get id",
-		Project:   "mnemo",
+		Project:   newUUID,
 		Scope:     "project",
 	})
 	if err != nil {
@@ -2011,7 +2032,7 @@ func TestMigrationInternalErrorAndNoopBranches(t *testing.T) {
 
 		origExec := s.hooks.exec
 		s.hooks.exec = func(db execer, query string, args ...any) (sql.Result, error) {
-			if strings.Contains(query, "CREATE TRIGGER obs_fts_insert") {
+			if strings.Contains(query, "CREATE TRIGGER IF NOT EXISTS obs_fts_insert") {
 				return nil, errors.New("forced obs trigger failure")
 			}
 			return origExec(db, query, args...)
@@ -2353,12 +2374,12 @@ func TestStoreUncoveredBranchesPushToHundred(t *testing.T) {
 			"UPDATE observations SET duplicate_count = 1",
 			"UPDATE observations SET updated_at = created_at",
 			"UPDATE user_prompts SET project = ''",
-			"CREATE TRIGGER prompt_fts_insert",
+			"CREATE TRIGGER IF NOT EXISTS prompt_fts_insert",
 		}
 		for _, needle := range failCases {
 			t.Run(needle, func(t *testing.T) {
 				s := newTestStore(t)
-				if strings.Contains(needle, "CREATE TRIGGER prompt_fts_insert") {
+				if strings.Contains(needle, "CREATE TRIGGER IF NOT EXISTS prompt_fts_insert") {
 					if _, err := s.db.Exec(`
 						DROP TRIGGER IF EXISTS prompt_fts_insert;
 						DROP TRIGGER IF EXISTS prompt_fts_update;
@@ -6112,3 +6133,4 @@ func TestRelatedTagsIncludeFlags(t *testing.T) {
 		t.Error("sess-only should not appear when IncludeSessions=false")
 	}
 }
+

--- a/plugin/claude-code/scripts/post-compact-resume.sh
+++ b/plugin/claude-code/scripts/post-compact-resume.sh
@@ -13,10 +13,8 @@ CWD=$(echo "$INPUT" | mnemo json cwd 2>/dev/null)
 [ -z "$CWD" ] && CWD="$(pwd)"
 
 PROJECT_ROOT=$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null || echo "$CWD")
-[ ! -f "${PROJECT_ROOT}/.mnemo" ] && exit 0
-
-PROJECT=$(realpath "$PROJECT_ROOT" 2>/dev/null | sed "s|^$HOME/||; s|^/||" | tr '/' '-' | tr '[:upper:]' '[:lower:]')
-[ -z "$PROJECT" ] && PROJECT=$(basename "$PROJECT_ROOT" | tr '[:upper:]' '[:lower:]')
+PROJECT=$(mnemo json id < "${PROJECT_ROOT}/.mnemo" 2>/dev/null)
+[ -z "$PROJECT" ] && exit 0
 
 printf "\n[mnemo] Context restored after compaction (project: %s)\n" "$PROJECT"
 

--- a/plugin/claude-code/scripts/post-compact-resume.sh
+++ b/plugin/claude-code/scripts/post-compact-resume.sh
@@ -13,7 +13,8 @@ CWD=$(echo "$INPUT" | mnemo json cwd 2>/dev/null)
 [ -z "$CWD" ] && CWD="$(pwd)"
 
 PROJECT_ROOT=$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null || echo "$CWD")
-PROJECT=$(mnemo json id < "${PROJECT_ROOT}/.mnemo" 2>/dev/null)
+MNEMO_FILE="${PROJECT_ROOT}/.mnemo"
+[ -f "$MNEMO_FILE" ] && PROJECT=$(mnemo json id < "$MNEMO_FILE" 2>/dev/null)
 [ -z "$PROJECT" ] && exit 0
 
 printf "\n[mnemo] Context restored after compaction (project: %s)\n" "$PROJECT"

--- a/plugin/claude-code/scripts/post-compact.sh
+++ b/plugin/claude-code/scripts/post-compact.sh
@@ -12,7 +12,8 @@ CWD=$(echo "$INPUT" | mnemo json cwd 2>/dev/null)
 [ -z "$CWD" ] && CWD="$(pwd)"
 
 PROJECT_ROOT=$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null || echo "$CWD")
-PROJECT=$(mnemo json id < "${PROJECT_ROOT}/.mnemo" 2>/dev/null)
+MNEMO_FILE="${PROJECT_ROOT}/.mnemo"
+[ -f "$MNEMO_FILE" ] && PROJECT=$(mnemo json id < "$MNEMO_FILE" 2>/dev/null)
 [ -z "$PROJECT" ] && exit 0
 
 if [ -n "$SESSION_ID" ] && [ -n "$PROJECT" ]; then

--- a/plugin/claude-code/scripts/post-compact.sh
+++ b/plugin/claude-code/scripts/post-compact.sh
@@ -12,10 +12,8 @@ CWD=$(echo "$INPUT" | mnemo json cwd 2>/dev/null)
 [ -z "$CWD" ] && CWD="$(pwd)"
 
 PROJECT_ROOT=$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null || echo "$CWD")
-[ ! -f "${PROJECT_ROOT}/.mnemo" ] && exit 0
-
-PROJECT=$(realpath "$PROJECT_ROOT" 2>/dev/null | sed "s|^$HOME/||; s|^/||" | tr '/' '-' | tr '[:upper:]' '[:lower:]')
-[ -z "$PROJECT" ] && PROJECT=$(basename "$PROJECT_ROOT" | tr '[:upper:]' '[:lower:]')
+PROJECT=$(mnemo json id < "${PROJECT_ROOT}/.mnemo" 2>/dev/null)
+[ -z "$PROJECT" ] && exit 0
 
 if [ -n "$SESSION_ID" ] && [ -n "$PROJECT" ]; then
   mnemo session start "$SESSION_ID" --project "$PROJECT" --dir "$CWD" 2>/dev/null || true

--- a/plugin/claude-code/scripts/session-start.sh
+++ b/plugin/claude-code/scripts/session-start.sh
@@ -13,7 +13,8 @@ CWD=$(echo "$INPUT" | mnemo json cwd 2>/dev/null)
 [ -z "$CWD" ] && CWD="$(pwd)"
 
 PROJECT_ROOT=$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null || echo "$CWD")
-PROJECT=$(mnemo json id < "${PROJECT_ROOT}/.mnemo" 2>/dev/null)
+MNEMO_FILE="${PROJECT_ROOT}/.mnemo"
+[ -f "$MNEMO_FILE" ] && PROJECT=$(mnemo json id < "$MNEMO_FILE" 2>/dev/null)
 [ -z "$PROJECT" ] && exit 0
 
 IS_RESUME=$(mnemo session exists "$SESSION_ID" 2>/dev/null)

--- a/plugin/claude-code/scripts/session-start.sh
+++ b/plugin/claude-code/scripts/session-start.sh
@@ -13,10 +13,8 @@ CWD=$(echo "$INPUT" | mnemo json cwd 2>/dev/null)
 [ -z "$CWD" ] && CWD="$(pwd)"
 
 PROJECT_ROOT=$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null || echo "$CWD")
-[ ! -f "${PROJECT_ROOT}/.mnemo" ] && exit 0
-
-PROJECT=$(realpath "$PROJECT_ROOT" 2>/dev/null | sed "s|^$HOME/||; s|^/||" | tr '/' '-' | tr '[:upper:]' '[:lower:]')
-[ -z "$PROJECT" ] && PROJECT=$(basename "$PROJECT_ROOT" | tr '[:upper:]' '[:lower:]')
+PROJECT=$(mnemo json id < "${PROJECT_ROOT}/.mnemo" 2>/dev/null)
+[ -z "$PROJECT" ] && exit 0
 
 IS_RESUME=$(mnemo session exists "$SESSION_ID" 2>/dev/null)
 

--- a/plugin/claude-code/scripts/session-stop.sh
+++ b/plugin/claude-code/scripts/session-stop.sh
@@ -9,7 +9,8 @@ CWD=$(echo "$INPUT" | mnemo json cwd 2>/dev/null)
 [ -z "$SESSION_ID" ] && exit 0
 
 PROJECT_ROOT=$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null || echo "$CWD")
-[ ! -f "${PROJECT_ROOT}/.mnemo" ] && exit 0
+PROJECT=$(mnemo json id < "${PROJECT_ROOT}/.mnemo" 2>/dev/null)
+[ -z "$PROJECT" ] && exit 0
 
 OBS_COUNT=$(mnemo session obs-count "$SESSION_ID" 2>/dev/null)
 

--- a/plugin/claude-code/scripts/session-stop.sh
+++ b/plugin/claude-code/scripts/session-stop.sh
@@ -9,7 +9,8 @@ CWD=$(echo "$INPUT" | mnemo json cwd 2>/dev/null)
 [ -z "$SESSION_ID" ] && exit 0
 
 PROJECT_ROOT=$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null || echo "$CWD")
-PROJECT=$(mnemo json id < "${PROJECT_ROOT}/.mnemo" 2>/dev/null)
+MNEMO_FILE="${PROJECT_ROOT}/.mnemo"
+[ -f "$MNEMO_FILE" ] && PROJECT=$(mnemo json id < "$MNEMO_FILE" 2>/dev/null)
 [ -z "$PROJECT" ] && exit 0
 
 OBS_COUNT=$(mnemo session obs-count "$SESSION_ID" 2>/dev/null)

--- a/plugin/claude-code/scripts/subagent-stop.sh
+++ b/plugin/claude-code/scripts/subagent-stop.sh
@@ -12,7 +12,8 @@ OUTPUT=$(echo "$INPUT" | mnemo json stdout 2>/dev/null)
 [ -z "$CWD" ] && CWD="$(pwd)"
 
 PROJECT_ROOT=$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null || echo "$CWD")
-PROJECT=$(mnemo json id < "${PROJECT_ROOT}/.mnemo" 2>/dev/null)
+MNEMO_FILE="${PROJECT_ROOT}/.mnemo"
+[ -f "$MNEMO_FILE" ] && PROJECT=$(mnemo json id < "$MNEMO_FILE" 2>/dev/null)
 [ -z "$PROJECT" ] && exit 0
 
 mnemo capture "$OUTPUT" --session "$SESSION_ID" --project "$PROJECT" 2>/dev/null || true

--- a/plugin/claude-code/scripts/subagent-stop.sh
+++ b/plugin/claude-code/scripts/subagent-stop.sh
@@ -12,10 +12,8 @@ OUTPUT=$(echo "$INPUT" | mnemo json stdout 2>/dev/null)
 [ -z "$CWD" ] && CWD="$(pwd)"
 
 PROJECT_ROOT=$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null || echo "$CWD")
-[ ! -f "${PROJECT_ROOT}/.mnemo" ] && exit 0
-
-PROJECT=$(realpath "$PROJECT_ROOT" 2>/dev/null | sed "s|^$HOME/||; s|^/||" | tr '/' '-' | tr '[:upper:]' '[:lower:]')
-[ -z "$PROJECT" ] && PROJECT=$(basename "$PROJECT_ROOT" | tr '[:upper:]' '[:lower:]')
+PROJECT=$(mnemo json id < "${PROJECT_ROOT}/.mnemo" 2>/dev/null)
+[ -z "$PROJECT" ] && exit 0
 
 mnemo capture "$OUTPUT" --session "$SESSION_ID" --project "$PROJECT" 2>/dev/null || true
 

--- a/scripts/codex/hooks/session-start.sh
+++ b/scripts/codex/hooks/session-start.sh
@@ -22,16 +22,11 @@ fi
 [ -z "$CWD" ] && CWD="$(pwd)"
 
 PROJECT_ROOT=$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null || echo "$CWD")
-if [ ! -f "${PROJECT_ROOT}/.mnemo" ]; then
+PROJECT=$(mnemo json id < "${PROJECT_ROOT}/.mnemo" 2>/dev/null)
+if [ -z "$PROJECT" ]; then
   printf '{"continue":true}\n'
   exit 0
 fi
-
-REALPATH_CWD=$(realpath "$CWD" 2>/dev/null)
-PROJECT="${REALPATH_CWD#"$HOME/"}"
-PROJECT="${PROJECT#/}"
-PROJECT=$(printf '%s' "$PROJECT" | tr '/' '-' | tr '[:upper:]' '[:lower:]')
-[ -z "$PROJECT" ] && PROJECT=$(basename "$CWD" | tr '[:upper:]' '[:lower:]')
 
 IS_RESUME=$(mnemo session exists "$SESSION_ID" 2>/dev/null)
 

--- a/scripts/codex/hooks/session-start.sh
+++ b/scripts/codex/hooks/session-start.sh
@@ -22,7 +22,8 @@ fi
 [ -z "$CWD" ] && CWD="$(pwd)"
 
 PROJECT_ROOT=$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null || echo "$CWD")
-PROJECT=$(mnemo json id < "${PROJECT_ROOT}/.mnemo" 2>/dev/null)
+MNEMO_FILE="${PROJECT_ROOT}/.mnemo"
+[ -f "$MNEMO_FILE" ] && PROJECT=$(mnemo json id < "$MNEMO_FILE" 2>/dev/null)
 if [ -z "$PROJECT" ]; then
   printf '{"continue":true}\n'
   exit 0

--- a/scripts/codex/hooks/stop.sh
+++ b/scripts/codex/hooks/stop.sh
@@ -23,21 +23,20 @@ fi
 [ -z "$CWD" ] && CWD="$(pwd)"
 
 PROJECT_ROOT=$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null || echo "$CWD")
+PROJECT=$(mnemo json id < "${PROJECT_ROOT}/.mnemo" 2>/dev/null)
+if [ -z "$PROJECT" ]; then
+  printf '{"continue":true}\n'
+  exit 0
+fi
 
-PROJECT=$(realpath "$PROJECT_ROOT" 2>/dev/null | sed "s|^$HOME/||; s|^/||" | tr '/' '-' | tr '[:upper:]' '[:lower:]')
-[ -z "$PROJECT" ] && PROJECT=$(basename "$PROJECT_ROOT" | tr '[:upper:]' '[:lower:]')
+if [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ]; then
+  CONTENT=$(mnemo extract-transcript "$TRANSCRIPT_PATH" 2>/dev/null)
+  if [ -z "$CONTENT" ]; then
+    CONTENT=$(cat "$TRANSCRIPT_PATH" 2>/dev/null)
+  fi
 
-# Passive capture only if project has mnemo configured
-if [ -f "${PROJECT_ROOT}/.mnemo" ]; then
-  if [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ]; then
-    CONTENT=$(mnemo extract-transcript "$TRANSCRIPT_PATH" 2>/dev/null)
-    if [ -z "$CONTENT" ]; then
-      CONTENT=$(cat "$TRANSCRIPT_PATH" 2>/dev/null)
-    fi
-
-    if [ -n "$CONTENT" ]; then
-      printf '%s' "$CONTENT" | mnemo capture - --session "$SESSION_ID" --project "$PROJECT" 2>/dev/null || true
-    fi
+  if [ -n "$CONTENT" ]; then
+    printf '%s' "$CONTENT" | mnemo capture - --session "$SESSION_ID" --project "$PROJECT" 2>/dev/null || true
   fi
 fi
 

--- a/scripts/cursor/hooks/before-submit-prompt.sh
+++ b/scripts/cursor/hooks/before-submit-prompt.sh
@@ -19,10 +19,8 @@ PROMPT=$(echo "$INPUT" | mnemo json prompt 2>/dev/null)
 [ -z "$WORKSPACE" ] && WORKSPACE="$(pwd)"
 
 PROJECT_ROOT=$(git -C "$WORKSPACE" rev-parse --show-toplevel 2>/dev/null || echo "$WORKSPACE")
-[ ! -f "${PROJECT_ROOT}/.mnemo" ] && exit 0
-
-PROJECT=$(realpath "$PROJECT_ROOT" 2>/dev/null | sed "s|^$HOME/||; s|^/||" | tr '/' '-' | tr '[:upper:]' '[:lower:]')
-[ -z "$PROJECT" ] && PROJECT=$(basename "$PROJECT_ROOT" | tr '[:upper:]' '[:lower:]')
+PROJECT=$(mnemo json id < "${PROJECT_ROOT}/.mnemo" 2>/dev/null)
+[ -z "$PROJECT" ] && exit 0
 
 # Only act on the first prompt of a conversation (session start)
 IS_KNOWN=$(mnemo session exists "$CONVERSATION_ID" 2>/dev/null)

--- a/scripts/cursor/hooks/before-submit-prompt.sh
+++ b/scripts/cursor/hooks/before-submit-prompt.sh
@@ -19,7 +19,8 @@ PROMPT=$(echo "$INPUT" | mnemo json prompt 2>/dev/null)
 [ -z "$WORKSPACE" ] && WORKSPACE="$(pwd)"
 
 PROJECT_ROOT=$(git -C "$WORKSPACE" rev-parse --show-toplevel 2>/dev/null || echo "$WORKSPACE")
-PROJECT=$(mnemo json id < "${PROJECT_ROOT}/.mnemo" 2>/dev/null)
+MNEMO_FILE="${PROJECT_ROOT}/.mnemo"
+[ -f "$MNEMO_FILE" ] && PROJECT=$(mnemo json id < "$MNEMO_FILE" 2>/dev/null)
 [ -z "$PROJECT" ] && exit 0
 
 # Only act on the first prompt of a conversation (session start)

--- a/scripts/cursor/hooks/stop.sh
+++ b/scripts/cursor/hooks/stop.sh
@@ -18,10 +18,8 @@ WORKSPACE=$(echo "$INPUT" | mnemo json workspace_roots 0 2>/dev/null)
 [ -z "$WORKSPACE" ] && WORKSPACE="$(pwd)"
 
 PROJECT_ROOT=$(git -C "$WORKSPACE" rev-parse --show-toplevel 2>/dev/null || echo "$WORKSPACE")
-[ ! -f "${PROJECT_ROOT}/.mnemo" ] && exit 0
-
-PROJECT=$(realpath "$PROJECT_ROOT" 2>/dev/null | sed "s|^$HOME/||; s|^/||" | tr '/' '-' | tr '[:upper:]' '[:lower:]')
-[ -z "$PROJECT" ] && PROJECT=$(basename "$PROJECT_ROOT" | tr '[:upper:]' '[:lower:]')
+PROJECT=$(mnemo json id < "${PROJECT_ROOT}/.mnemo" 2>/dev/null)
+[ -z "$PROJECT" ] && exit 0
 
 # Passive capture from transcript if available
 if [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ]; then

--- a/scripts/cursor/hooks/stop.sh
+++ b/scripts/cursor/hooks/stop.sh
@@ -18,7 +18,8 @@ WORKSPACE=$(echo "$INPUT" | mnemo json workspace_roots 0 2>/dev/null)
 [ -z "$WORKSPACE" ] && WORKSPACE="$(pwd)"
 
 PROJECT_ROOT=$(git -C "$WORKSPACE" rev-parse --show-toplevel 2>/dev/null || echo "$WORKSPACE")
-PROJECT=$(mnemo json id < "${PROJECT_ROOT}/.mnemo" 2>/dev/null)
+MNEMO_FILE="${PROJECT_ROOT}/.mnemo"
+[ -f "$MNEMO_FILE" ] && PROJECT=$(mnemo json id < "$MNEMO_FILE" 2>/dev/null)
 [ -z "$PROJECT" ] && exit 0
 
 # Passive capture from transcript if available

--- a/scripts/windsurf/hooks/post-cascade-response.sh
+++ b/scripts/windsurf/hooks/post-cascade-response.sh
@@ -17,7 +17,8 @@ TRANSCRIPT_PATH=$(echo "$INPUT" | mnemo json tool_info transcript_path 2>/dev/nu
 
 WORKSPACE="$(pwd)"
 PROJECT_ROOT=$(git -C "$WORKSPACE" rev-parse --show-toplevel 2>/dev/null || echo "$WORKSPACE")
-PROJECT=$(mnemo json id < "${PROJECT_ROOT}/.mnemo" 2>/dev/null)
+MNEMO_FILE="${PROJECT_ROOT}/.mnemo"
+[ -f "$MNEMO_FILE" ] && PROJECT=$(mnemo json id < "$MNEMO_FILE" 2>/dev/null)
 [ -z "$PROJECT" ] && exit 0
 
 # Passive capture from transcript if available

--- a/scripts/windsurf/hooks/post-cascade-response.sh
+++ b/scripts/windsurf/hooks/post-cascade-response.sh
@@ -17,10 +17,8 @@ TRANSCRIPT_PATH=$(echo "$INPUT" | mnemo json tool_info transcript_path 2>/dev/nu
 
 WORKSPACE="$(pwd)"
 PROJECT_ROOT=$(git -C "$WORKSPACE" rev-parse --show-toplevel 2>/dev/null || echo "$WORKSPACE")
-[ ! -f "${PROJECT_ROOT}/.mnemo" ] && exit 0
-
-PROJECT=$(realpath "$PROJECT_ROOT" 2>/dev/null | sed "s|^$HOME/||; s|^/||" | tr '/' '-' | tr '[:upper:]' '[:lower:]')
-[ -z "$PROJECT" ] && PROJECT=$(basename "$PROJECT_ROOT" | tr '[:upper:]' '[:lower:]')
+PROJECT=$(mnemo json id < "${PROJECT_ROOT}/.mnemo" 2>/dev/null)
+[ -z "$PROJECT" ] && exit 0
 
 # Passive capture from transcript if available
 if [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ]; then

--- a/scripts/windsurf/hooks/pre-user-prompt.sh
+++ b/scripts/windsurf/hooks/pre-user-prompt.sh
@@ -18,10 +18,8 @@ PROMPT=$(echo "$INPUT" | mnemo json tool_info user_prompt 2>/dev/null)
 
 WORKSPACE="$(pwd)"
 PROJECT_ROOT=$(git -C "$WORKSPACE" rev-parse --show-toplevel 2>/dev/null || echo "$WORKSPACE")
-[ ! -f "${PROJECT_ROOT}/.mnemo" ] && exit 0
-
-PROJECT=$(realpath "$PROJECT_ROOT" 2>/dev/null | sed "s|^$HOME/||; s|^/||" | tr '/' '-' | tr '[:upper:]' '[:lower:]')
-[ -z "$PROJECT" ] && PROJECT=$(basename "$PROJECT_ROOT" | tr '[:upper:]' '[:lower:]')
+PROJECT=$(mnemo json id < "${PROJECT_ROOT}/.mnemo" 2>/dev/null)
+[ -z "$PROJECT" ] && exit 0
 
 # Only act on the first prompt of a conversation (session start)
 IS_KNOWN=$(mnemo session exists "$TRAJECTORY_ID" 2>/dev/null)


### PR DESCRIPTION
## Summary

- Projects now have a stable UUID stored in `.mnemo` instead of a path-derived string. Path derivation was fragile: different agents produced different keys for the same project, fragmenting stored memory.
- UUID is deterministic (v5, SHA1-based) from the absolute project path. Same path always produces the same UUID.
- All hook scripts (Claude Code, Cursor, Windsurf, Codex) read the project ID from `.mnemo` via `mnemo json id`. No fallback derivation.
- New `mnemo migrate` command rekeys existing observations and sessions from the legacy path-derived key to the UUID, then writes the UUID to `.mnemo`.

## Changes

- `internal/agentinit/common.go`: added `ProjectUUIDFromPath`, fixed `EnsureProjectID` to use UUID v5
- `internal/store/store.go`: added `projects` table, `EnsureProject`, `GetProjectByID`, `ListProjects`; removed automatic `migrateProjectKeys` on startup
- `cmd/mnemo/main.go`: added `mnemo migrate` command with `deriveLegacyKey` helper
- All hook scripts: replaced path derivation with `mnemo json id < .mnemo`

## Migration path

Users upgrading from a previous version run `mnemo migrate` once in each project directory. The command locates legacy data by the old derived key, rekeys it, and writes the UUID to `.mnemo`. Running it a second time is a no-op.

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./...` passes
- [ ] `mnemo migrate` in a project with legacy data rekeys observations and sessions and writes UUID to `.mnemo`
- [ ] Running `mnemo migrate` a second time reports no legacy data and exits cleanly
- [ ] `mnemo init` on a new project writes a deterministic UUID to `.mnemo`
- [ ] Hooks read UUID from `.mnemo` and exit cleanly when not present

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Projects now have stable UUIDs stored in .mnemo.
  * Added a migrate command to rekey legacy project data to UUIDs.
  * CLI prints and persists project IDs and ensures .gitignore entries.

* **Refactor**
  * Hooks and scripts now read project IDs from .mnemo instead of deriving from paths.
  * CLI init/migrate now run with store initialized.
  * Database exposes project listing and lookup operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->