### PR TITLE
feat: add mnemo-memory installable skill and managed block upserts

### DIFF
--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -1,10 +1,15 @@
 {
-  "version": 1,
   "hooks": {
-    "beforeShellExecution": [{"command": "/tmp/mnemo-cursor-debug.sh"}],
-    "beforeMCPExecution": [{"command": "/tmp/mnemo-cursor-debug.sh"}],
-    "afterFileEdit": [{"command": "/tmp/mnemo-cursor-debug.sh"}],
-    "beforeSubmitPrompt": [{"command": "/tmp/mnemo-cursor-debug.sh"}],
-    "stop": [{"command": "/tmp/mnemo-cursor-debug.sh"}]
-  }
+    "beforeSubmitPrompt": [
+      {
+        "command": "/Users/dankkomcg/.cursor/hooks/before-submit-prompt.sh"
+      }
+    ],
+    "stop": [
+      {
+        "command": "/Users/dankkomcg/.cursor/hooks/stop.sh"
+      }
+    ]
+  },
+  "version": 1
 }

--- a/.cursor/rules/mnemo.mdc
+++ b/.cursor/rules/mnemo.mdc
@@ -1,0 +1,50 @@
+---
+description: mnemo persistent memory protocol
+alwaysApply: true
+---
+
+## mnemo
+
+You have access to mnemo MCP tools: mem_save, mem_search, mem_context, mem_session_summary.
+
+### PROACTIVE SAVE
+
+Call `mem_save` immediately after any of these:
+- Decision made (architecture, convention, workflow, tool choice)
+- Bug fixed (include root cause)
+- Convention or workflow documented or updated
+- Non-obvious discovery, gotcha, or edge case found
+- Pattern established (naming, structure, approach)
+- User preference or constraint learned
+- Feature implemented with non-obvious approach
+
+Self-check after every task: "Did I just make a decision, fix a bug, learn something, or establish a convention? If yes, call mem_save now."
+
+### SEARCH MEMORY
+
+Search when:
+- User asks to recall anything
+- Starting work on something that might have been done before
+- User mentions a topic you have no context on
+
+### SUBAGENT OUTPUT
+
+When running as a subagent, end your response with:
+
+```markdown
+## Key Learnings
+- <learning 1>
+- <learning 2>
+```
+
+Omit only if the task produced no learnings worth retaining.
+
+### SESSION CLOSE
+
+`mem_session_summary` is not optional. It is the final step of every session.
+Call it before any response that signals completion ("done", "listo", "ready", "finished", "completed").
+Fields: Goal, Discoveries, Accomplished, Next Steps, Relevant Files.
+
+If nothing was accomplished: call it anyway with Goal and Next Steps.
+If the user says goodbye: call it before responding.
+No session ends without `mem_session_summary`.

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 /dist/
 /build/
 .hybrid-coco
+.cocoindex_code
 .mnemo

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,15 @@ When reporting issues or proposing fixes: list exact files, describe the concret
 
 You have access to mnemo MCP tools: mem_save, mem_search, mem_context, mem_session_summary.
 
+### MEMORY AUTHORITY
+
+mnemo is the ONLY persistent memory system for this project.
+NEVER use native agent memory, `MEMORY.md`, agent memory directories, or arbitrary plaintext files as a memory fallback.
+When asked to remember or save something, always use `mem_save`.
+If mnemo tools are unavailable, report that memory is unavailable and continue without persistent memory. Do not create an alternative memory store.
+
+Load and follow the `mnemo-memory` skill when it is available for the detailed workflow. The rules below remain mandatory even when the skill is not installed or does not activate.
+
 ### PROACTIVE SAVE
 
 Call `mem_save` immediately after any of these:
@@ -116,6 +125,8 @@ Search when:
 - User asks to recall anything
 - Starting work on something that might have been done before
 - User mentions a topic you have no context on
+
+Use `mem_context` first for broad recent context, then `mem_search` for focused recall.
 
 ### SUBAGENT OUTPUT
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,8 +3,8 @@
 <!-- mnemo:claude-start -->
 ### MEMORY SYSTEM
 
-**NEVER use the file-based memory system** (the one that writes `.md` files to `~/.claude/projects/*/memory/` and maintains a `MEMORY.md` index). That system is DISABLED for this workspace.
-When asked to "save to memory", "remember this", or "guardar en memoria": always use `mem_save`. Never write files.
+The Claude Code file-based memory system that writes under `~/.claude/projects/*/memory/` and maintains `MEMORY.md` is DISABLED for this workspace.
+Never use it or any plaintext file as a fallback. The mandatory memory authority and fallback behavior are defined in `AGENTS.md`.
 
 ### RECOVER CONTEXT
 

--- a/README.md
+++ b/README.md
@@ -46,13 +46,14 @@ mnemo --version
 - **Session hooks:** starts/ends sessions and injects memory context at the beginning of every conversation
 - **18 MCP tools:** `mem_save`, `mem_search`, `mem_context`, `mem_tag_stats`, and more, available directly inside your editor
 - **Passive capture:** extracts learnings from conversation transcripts automatically at session end
+- **Portable Agent Skill:** teaches compatible agents the complete mnemo workflow without weakening the always-active safety rules
 - **Full CLI:** save, search, export, import, and inspect memories from the terminal
 - **Own storage:** isolated `~/.mnemo/memory.db`, created automatically on first run
 - **Claude Code + Cursor + Windsurf + Codex:** native integration for all four agents via their respective hook systems
 
-## Setup: two phases
+## Setup
 
-**Phase 1 — install globally (once per machine):**
+### 1. Install the binary and agent integration
 
 ```bash
 # Claude Code (via plugin — recommended)
@@ -68,7 +69,21 @@ curl -sSf https://raw.githubusercontent.com/jmeiracorbal/mnemo/main/install.sh |
 
 This installs hook scripts to the agent's global directory and registers the MCP server. Hooks are wired up once here, but they will do nothing in projects without a `.mnemo` marker.
 
-**Phase 2 — enable per project (once per project):**
+### 2. Install the Agent Skill globally
+
+For the best agent behavior, install the portable `mnemo-memory` skill:
+
+```bash
+npx skills add jmeiracorbal/mnemo --skill mnemo-memory --global
+```
+
+The [skills CLI](https://github.com/vercel-labs/skills) keeps the canonical copy at `~/.agents/skills/mnemo-memory/`. Codex and Cursor read that universal location directly; agent-specific consumers such as Claude Code and Windsurf receive symlinks to it.
+
+The skill is global, but it is guarded by the project marker. Its first step is to locate and validate `.mnemo`; outside an initialized project it performs no memory operation and never falls back to native or plaintext memory.
+
+The skill is recommended rather than required. Hooks, MCP, and the always-active project protocol remain functional without it. `mnemo init` prints the installation command when the canonical global skill is missing.
+
+### 3. Enable mnemo per project
 
 Run from the project root:
 
@@ -86,8 +101,9 @@ Not all agents support per-project hook configuration. The table below shows wha
 |---|---|---|---|---|
 | **Hook scripts (global)** | via plugin | `~/.cursor/hooks/` | `~/.codeium/windsurf/hooks/` | `~/.codex/hooks/` |
 | **MCP (always global)** | `~/.claude/.mcp.json` | `~/.cursor/mcp.json` | `~/.codeium/windsurf/mcp_config.json` | `~/.codex/config.toml` |
-| **Per-project hook config** | `.claude/settings.json` | `.cursor/hooks.json` | `.windsurf/hooks.json` | ❌ global only |
-| **Per-project protocol** | `AGENTS.md` + `CLAUDE.md` symlink | `.cursor/rules/mnemo.mdc` | `.windsurf/rules/mnemo.md` | `AGENTS.md` |
+| **Per-project hook config** | plugin hooks check `.mnemo` | `.cursor/hooks.json` | `.windsurf/hooks.json` | global hooks check `.mnemo` |
+| **Per-project protocol** | `AGENTS.md` + `CLAUDE.md` | `.cursor/rules/mnemo.mdc` | `.windsurf/rules/mnemo.md` | `AGENTS.md` |
+| **Global skill access** | symlink at `~/.claude/skills/mnemo-memory` | canonical `~/.agents/skills/mnemo-memory` | symlink at `~/.codeium/windsurf/skills/mnemo-memory` | canonical `~/.agents/skills/mnemo-memory` |
 
 Codex does not support per-project hook configuration. Its hooks are registered globally in `~/.codex/hooks.json` and check for `.mnemo` at runtime before acting.
 
@@ -97,14 +113,12 @@ Codex does not support per-project hook configuration. Its hooks are registered 
 
 ```
 project/
-├── .mnemo                   ← {"version":1,"agents":["claudecode"]}
+├── .mnemo                   ← project ID + configured agents
 ├── AGENTS.md                ← mnemo protocol section appended here
-├── CLAUDE.md -> AGENTS.md   ← symlink (existing content migrated to AGENTS.md)
-└── .claude/
-    └── settings.json        ← hook entries (SessionStart, Stop, PostCompact, SubagentStop)
+└── CLAUDE.md                ← @AGENTS.md include + Claude-specific additions
 ```
 
-`CLAUDE.md` becomes a symlink to `AGENTS.md`. If `CLAUDE.md` already exists as a regular file, its content is moved to `AGENTS.md` before the symlink is created. This keeps all project config in a single file that works for both Claude Code and Codex.
+`CLAUDE.md` is a regular file. Existing user content is preserved, and mnemo manages only its marked section. Session hooks come from the globally installed Claude Code plugin and activate only when `.mnemo` exists.
 
 ### Cursor
 
@@ -149,13 +163,14 @@ The `.mnemo` file at the project root is what activates mnemo for a project. It 
 ```json
 {
   "version": 1,
+  "id": "8ec0f7ec-7cf8-5f6c-a4dc-bb247f75c543",
   "agents": ["claudecode", "cursor"]
 }
 ```
 
-`agents` lists which agents have been configured via `mnemo init`. All hooks — including the global-only Codex hooks — read this file before acting. If the file is absent, the hook exits silently.
+`id` is the deterministic project identifier used by every integration. `agents` lists which agents have been configured via `mnemo init`. All hooks, including the global-only Codex hooks, read this file before acting. If the file is absent or has no ID, the hook exits silently.
 
-`mnemo init` creates and updates this file automatically. You can commit it to the repository if you want the rest of your team to know mnemo is in use.
+`mnemo init` creates and updates this file automatically and adds it to `.gitignore`. Do not commit it: each clone derives its own identifier from its local path.
 
 ## Claude Code plugin notes
 
@@ -212,7 +227,7 @@ Restart Claude Code after updating.
 | `SessionStart` (startup/resume) | Session starts or resumes | Registers session, injects memory context via `systemMessage` |
 | `Stop` | Agent stops | Reads transcript for passive capture, closes session |
 
-On session start, mnemo derives the project identifier from the git root and emits relevant memories from previous sessions into the context. All hooks derive the project the same way — from the git root, not the current working directory — so the project ID is consistent regardless of which subdirectory the editor opens.
+On session start, every hook resolves the Git root and reads the project identifier from its `.mnemo` marker. This keeps the same identity regardless of which subdirectory the editor opens.
 
 ## MCP tools
 
@@ -287,7 +302,7 @@ mnemo version                        Show version
 Agents for `mnemo init`:
 
 ```
---agent=claudecode   AGENTS.md + CLAUDE.md symlink + .claude/settings.json (default)
+--agent=claudecode   AGENTS.md + CLAUDE.md managed sections (default)
 --agent=cursor       .cursor/hooks.json + .cursor/rules/mnemo.mdc
 --agent=windsurf     .windsurf/hooks.json + .windsurf/rules/mnemo.md
 --agent=codex        AGENTS.md append only (hooks stay global)
@@ -328,13 +343,23 @@ After installing globally, confirm the binary is accessible:
 mnemo --version
 ```
 
+Confirm the canonical Agent Skill and agent symlinks:
+
+```bash
+test -f ~/.agents/skills/mnemo-memory/SKILL.md
+ls -l ~/.claude/skills/mnemo-memory \
+  ~/.codeium/windsurf/skills/mnemo-memory
+```
+
+Only symlinks for agent-specific consumers selected during `npx skills add` are expected to exist. Codex and Cursor use the canonical `.agents/skills` path directly.
+
 After running `mnemo init`, check the project files exist:
 
 ```bash
 # Claude Code
 cat .mnemo                          # must contain agents list
-ls -la CLAUDE.md                    # must be a symlink to AGENTS.md
-grep "mnemo" .claude/settings.json  # must have hook entries
+grep "@AGENTS.md" CLAUDE.md         # must include shared project instructions
+grep "mnemo:claude-start" CLAUDE.md # must contain the managed Claude section
 
 # Cursor
 cat .cursor/hooks.json              # must have beforeSubmitPrompt + stop
@@ -354,7 +379,7 @@ Validate the Claude Code plugin:
 claude plugin validate plugin/claude-code
 ```
 
-Check idempotency — running `mnemo init` again in the same project must produce no duplicates in `AGENTS.md` and must not overwrite the symlink:
+Check idempotency. Running `mnemo init` again must refresh the managed sections without duplicating them or changing surrounding user content:
 
 ```bash
 mnemo init --agent=claudecode

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,18 @@
+# Roadmap
+
+This file tracks planned capabilities that are not yet released. Released behavior belongs in release notes, not here.
+
+## mnemo-curate
+
+Add a separate, explicitly invoked Agent Skill for memory maintenance. It should use the admin and tag-management tools without expanding the normal `mnemo-memory` workflow.
+
+Planned responsibilities:
+
+- inspect memory statistics and timelines;
+- identify duplicate, stale, or low-value observations;
+- merge inconsistent tags and review tag usage;
+- consolidate evolving topics safely;
+- propose deletions before performing destructive operations;
+- produce a concise curation report.
+
+The skill must require a valid `.mnemo` marker, default to read-only analysis, and request explicit confirmation before deletion or broad mutation.

--- a/cmd/mnemo/main.go
+++ b/cmd/mnemo/main.go
@@ -619,8 +619,8 @@ func printSkillRecommendation(w io.Writer, home string) {
 	if agentinit.GlobalSkillInstalled(home) {
 		return
 	}
-	fmt.Fprintln(w, "mnemo init: for a better agent experience, install the global mnemo-memory skill:")
-	fmt.Fprintln(w, "  npx skills add jmeiracorbal/mnemo --skill mnemo-memory --global")
+	_, _ = fmt.Fprintln(w, "mnemo init: for a better agent experience, install the global mnemo-memory skill:")
+	_, _ = fmt.Fprintln(w, "  npx skills add jmeiracorbal/mnemo --skill mnemo-memory --global")
 }
 
 // runMigrateProjects migrates a project from a legacy path-derived key to a

--- a/cmd/mnemo/main.go
+++ b/cmd/mnemo/main.go
@@ -11,8 +11,8 @@ import (
 	"strings"
 
 	"github.com/jmeiracorbal/mnemo/internal/agentinit"
-	mcpserver "github.com/jmeiracorbal/mnemo/internal/mcp"
 	"github.com/jmeiracorbal/mnemo/internal/jsonmerge"
+	mcpserver "github.com/jmeiracorbal/mnemo/internal/mcp"
 	"github.com/jmeiracorbal/mnemo/internal/store"
 	"github.com/mark3labs/mcp-go/server"
 )
@@ -610,6 +610,17 @@ func runInit(s *store.Store) {
 		os.Exit(1)
 	}
 	fmt.Printf("mnemo init: project ID %s\n", projectID)
+	if home, err := os.UserHomeDir(); err == nil {
+		printSkillRecommendation(os.Stdout, home)
+	}
+}
+
+func printSkillRecommendation(w io.Writer, home string) {
+	if agentinit.GlobalSkillInstalled(home) {
+		return
+	}
+	fmt.Fprintln(w, "mnemo init: for a better agent experience, install the global mnemo-memory skill:")
+	fmt.Fprintln(w, "  npx skills add jmeiracorbal/mnemo --skill mnemo-memory --global")
 }
 
 // runMigrateProjects migrates a project from a legacy path-derived key to a
@@ -762,7 +773,7 @@ Agents for init:
   --path=DIR           Target project directory (default: current directory)
 
 Tool profiles for mcp:
-  --tools=agent    11 tools for AI agents (default when using plugin)
+  --tools=agent    15 tools for AI agents (default when using plugin)
   --tools=admin    3 tools for curation (delete, stats, timeline)
   --tools=all      All tools
 

--- a/cmd/mnemo/plugin_integrity_test.go
+++ b/cmd/mnemo/plugin_integrity_test.go
@@ -68,3 +68,54 @@ func TestShippedHooksReferenceRealScripts(t *testing.T) {
 		t.Fatalf("no script references were validated from hooks.json")
 	}
 }
+
+func TestShippedProtocolsForbidFallbackMemory(t *testing.T) {
+	files := []string{
+		filepath.Join("..", "..", "templates", "rules", "generic.md"),
+		filepath.Join("..", "..", "templates", "rules", "cursor.mdc"),
+		filepath.Join("..", "..", "templates", "rules", "windsurf.md"),
+		filepath.Join("..", "..", "plugin", "claude-code", "scripts", "mnemo.md"),
+		filepath.Join("..", "..", "plugin", "claude-code", "scripts", "session-start-protocol.md"),
+		filepath.Join("..", "..", "plugin", "claude-code", "scripts", "post-compact-protocol-header.md"),
+		filepath.Join("..", "..", "scripts", "codex", "hooks", "mnemo-protocol.md"),
+		filepath.Join("..", "..", "scripts", "cursor", "rules", "mnemo.mdc"),
+		filepath.Join("..", "..", "scripts", "windsurf", "templates", "global_rules.md"),
+	}
+
+	for _, path := range files {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Errorf("read %s: %v", path, err)
+			continue
+		}
+		content := string(data)
+		if !strings.Contains(content, "mnemo is the ONLY persistent memory system") {
+			t.Errorf("%s does not declare mnemo as the only persistent memory", path)
+		}
+		if !strings.Contains(content, "plaintext files as a memory fallback") {
+			t.Errorf("%s does not forbid plaintext memory fallback", path)
+		}
+	}
+}
+
+func TestShippedMnemoMemorySkill(t *testing.T) {
+	path := filepath.Join("..", "..", "skills", "mnemo-memory", "SKILL.md")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read shipped skill: %v", err)
+	}
+	content := string(data)
+	required := []string{
+		"name: mnemo-memory",
+		"description:",
+		"<root>/.mnemo",
+		"non-empty `id`",
+		"Never create `MEMORY.md`",
+		"`mem_session_summary`",
+	}
+	for _, value := range required {
+		if !strings.Contains(content, value) {
+			t.Errorf("shipped skill missing %q", value)
+		}
+	}
+}

--- a/cmd/mnemo/skill_recommendation_test.go
+++ b/cmd/mnemo/skill_recommendation_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jmeiracorbal/mnemo/internal/agentinit"
+)
+
+func TestPrintSkillRecommendationWhenMissing(t *testing.T) {
+	var out bytes.Buffer
+	printSkillRecommendation(&out, t.TempDir())
+	if !strings.Contains(out.String(), "npx skills add jmeiracorbal/mnemo --skill mnemo-memory --global") {
+		t.Fatalf("missing installation recommendation: %q", out.String())
+	}
+}
+
+func TestPrintSkillRecommendationWhenInstalled(t *testing.T) {
+	home := t.TempDir()
+	path := agentinit.GlobalSkillPath(home)
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("installed"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	printSkillRecommendation(&out, home)
+	if out.Len() != 0 {
+		t.Fatalf("unexpected recommendation for installed skill: %q", out.String())
+	}
+}

--- a/internal/agentinit/common.go
+++ b/internal/agentinit/common.go
@@ -26,10 +26,12 @@ func ProjectUUIDFromPath(absPath string) string {
 	}
 	return uuid.NewSHA1(mnemoNamespace, []byte(absPath)).String()
 }
+
 const sectionStart = "<!-- mnemo:start -->"
 const sectionEnd = "<!-- mnemo:end -->"
 const claudeSectionStart = "<!-- mnemo:claude-start -->"
 const claudeSectionEnd = "<!-- mnemo:claude-end -->"
+const globalSkillName = "mnemo-memory"
 
 // Marker is the .mnemo file format.
 type Marker struct {
@@ -163,71 +165,95 @@ func AddAgent(root, agent string) error {
 	return writeMarker(root, m)
 }
 
-// AppendSection appends a mnemo protocol section to path, creating the file if
-// needed. Idempotent: does nothing if the section marker is already present.
-func AppendSection(path, content string) error {
-	existing, err := os.ReadFile(path)
-	if err != nil && !os.IsNotExist(err) {
-		return err
-	}
-
-	if strings.Contains(string(existing), sectionStart) {
-		return nil
-	}
-
-	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
-		return err
-	}
-
-	section := "\n" + sectionStart + "\n" + content + "\n" + sectionEnd + "\n"
-	if len(existing) > 0 && !strings.HasSuffix(string(existing), "\n") {
-		section = "\n" + section
-	}
-
-	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0644)
-	if err != nil {
-		return err
-	}
-	_, writeErr := f.WriteString(section)
-	closeErr := f.Close()
-	if writeErr != nil {
-		return writeErr
-	}
-	return closeErr
+// GlobalSkillPath returns the canonical path used by the skills CLI for a
+// globally installed mnemo-memory skill.
+func GlobalSkillPath(home string) string {
+	return filepath.Join(home, ".agents", "skills", globalSkillName, "SKILL.md")
 }
 
-// AppendClaudeSection appends an @AGENTS.md include and the Claude-specific mnemo
-// section to path, creating the file if needed. Idempotent: does nothing if the
-// Claude section marker is already present.
+// GlobalSkillInstalled reports whether the canonical global skill file exists.
+func GlobalSkillInstalled(home string) bool {
+	info, err := os.Stat(GlobalSkillPath(home))
+	return err == nil && !info.IsDir()
+}
+
+// AppendSection creates or updates the managed mnemo protocol section in path.
+// Content outside the markers is preserved.
+func AppendSection(path, content string) error {
+	return upsertManagedSection(path, sectionStart, sectionEnd, content, "")
+}
+
+// AppendClaudeSection creates or updates the Claude-specific managed section.
+// It also adds @AGENTS.md once when creating the section.
 func AppendClaudeSection(path, content string) error {
+	return upsertManagedSection(path, claudeSectionStart, claudeSectionEnd, content, "@AGENTS.md")
+}
+
+func upsertManagedSection(path, startMarker, endMarker, content, prelude string) error {
 	existing, err := os.ReadFile(path)
 	if err != nil && !os.IsNotExist(err) {
 		return err
 	}
 
-	if strings.Contains(string(existing), claudeSectionStart) {
+	current := string(existing)
+	startCount := strings.Count(current, startMarker)
+	endCount := strings.Count(current, endMarker)
+	if startCount != endCount || startCount > 1 {
+		return fmt.Errorf(
+			"malformed managed section: found %d %q marker(s) and %d %q marker(s)",
+			startCount, startMarker, endCount, endMarker,
+		)
+	}
+
+	block := startMarker + "\n" + strings.TrimRight(content, "\n") + "\n" + endMarker
+	var updated string
+
+	if startCount == 1 {
+		start := strings.Index(current, startMarker)
+		end := strings.Index(current, endMarker)
+		if end < start {
+			return fmt.Errorf("malformed managed section: %q appears before %q", endMarker, startMarker)
+		}
+		end += len(endMarker)
+		updated = current[:start] + block + current[end:]
+	} else {
+		addition := block
+		if prelude != "" && !containsLine(current, prelude) {
+			addition = prelude + "\n\n" + addition
+		}
+		updated = appendSection(current, addition)
+	}
+
+	if updated == current {
 		return nil
 	}
 
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		return err
 	}
+	return os.WriteFile(path, []byte(updated), 0644)
+}
 
-	section := "\n@AGENTS.md\n\n" + claudeSectionStart + "\n" + content + "\n" + claudeSectionEnd + "\n"
-	if len(existing) > 0 && !strings.HasSuffix(string(existing), "\n") {
-		section = "\n" + section
+func containsLine(content, target string) bool {
+	for _, line := range strings.Split(content, "\n") {
+		if strings.TrimSpace(line) == target {
+			return true
+		}
 	}
+	return false
+}
 
-	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0644)
-	if err != nil {
-		return err
+func appendSection(existing, addition string) string {
+	if existing == "" {
+		return addition + "\n"
 	}
-	_, writeErr := f.WriteString(section)
-	closeErr := f.Close()
-	if writeErr != nil {
-		return writeErr
+	if strings.HasSuffix(existing, "\n\n") {
+		return existing + addition + "\n"
 	}
-	return closeErr
+	if strings.HasSuffix(existing, "\n") {
+		return existing + "\n" + addition + "\n"
+	}
+	return existing + "\n\n" + addition + "\n"
 }
 
 // WriteFile writes data to path, creating parent directories. Overwrites if exists.

--- a/internal/agentinit/common_test.go
+++ b/internal/agentinit/common_test.go
@@ -1,0 +1,103 @@
+package agentinit
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestAppendSectionCreatesAndUpdatesManagedBlock(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "AGENTS.md")
+	if err := os.WriteFile(path, []byte("# Project\n\nUser content.\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := AppendSection(path, "first protocol"); err != nil {
+		t.Fatalf("create section: %v", err)
+	}
+	if err := AppendSection(path, "updated protocol"); err != nil {
+		t.Fatalf("update section: %v", err)
+	}
+	if err := AppendSection(path, "updated protocol"); err != nil {
+		t.Fatalf("idempotent update: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(data)
+	if !strings.Contains(got, "# Project\n\nUser content.\n") {
+		t.Fatalf("user content was not preserved:\n%s", got)
+	}
+	if strings.Contains(got, "first protocol") {
+		t.Fatalf("old managed content remains:\n%s", got)
+	}
+	if strings.Count(got, sectionStart) != 1 || strings.Count(got, sectionEnd) != 1 {
+		t.Fatalf("managed markers duplicated:\n%s", got)
+	}
+	if strings.Count(got, "updated protocol") != 1 {
+		t.Fatalf("updated content missing or duplicated:\n%s", got)
+	}
+}
+
+func TestAppendSectionRejectsMalformedMarkersWithoutChangingFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "AGENTS.md")
+	original := "before\n" + sectionStart + "\nmissing end\n"
+	if err := os.WriteFile(path, []byte(original), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := AppendSection(path, "replacement")
+	if err == nil || !strings.Contains(err.Error(), "malformed managed section") {
+		t.Fatalf("expected malformed marker error, got %v", err)
+	}
+	data, readErr := os.ReadFile(path)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if string(data) != original {
+		t.Fatalf("file changed after malformed marker error:\n%s", data)
+	}
+}
+
+func TestAppendClaudeSectionAddsIncludeOnceAndUpdates(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "CLAUDE.md")
+	if err := AppendClaudeSection(path, "first"); err != nil {
+		t.Fatalf("create Claude section: %v", err)
+	}
+	if err := AppendClaudeSection(path, "second"); err != nil {
+		t.Fatalf("update Claude section: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(data)
+	if strings.Count(got, "@AGENTS.md") != 1 {
+		t.Fatalf("@AGENTS.md include duplicated or missing:\n%s", got)
+	}
+	if strings.Contains(got, "first") || strings.Count(got, "second") != 1 {
+		t.Fatalf("Claude section was not replaced:\n%s", got)
+	}
+}
+
+func TestGlobalSkillInstalled(t *testing.T) {
+	home := t.TempDir()
+	if GlobalSkillInstalled(home) {
+		t.Fatal("skill reported installed before file exists")
+	}
+
+	path := GlobalSkillPath(home)
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("---\nname: mnemo-memory\n---\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if !GlobalSkillInstalled(home) {
+		t.Fatal("skill not detected at canonical global path")
+	}
+}

--- a/plugin/claude-code/scripts/mnemo.md
+++ b/plugin/claude-code/scripts/mnemo.md
@@ -2,9 +2,13 @@
 
 You have access to mnemo memory tools (mem_save, mem_search, mem_context, mem_session_summary).
 
-### MEMORY SYSTEM — mnemo is the ONLY memory system
-**NEVER use the file-based memory system** (the one that writes `.md` files to `~/.claude/projects/*/memory/` and maintains a `MEMORY.md` index). That system is DISABLED for this workspace.
-When asked to "save to memory", "remember this", or "guardar en memoria" — ALWAYS use `mem_save`. Never write files.
+### MEMORY AUTHORITY
+mnemo is the ONLY persistent memory system for this project.
+NEVER use native agent memory, `MEMORY.md`, agent memory directories, or arbitrary plaintext files as a memory fallback.
+When asked to remember or save something, always use `mem_save`.
+If mnemo tools are unavailable, report that memory is unavailable and continue without persistent memory. Do not create an alternative memory store.
+
+Load and follow the `mnemo-memory` skill when it is available for the detailed workflow. These rules remain mandatory even when the skill is not installed or does not activate.
 
 ### PROACTIVE SAVE — do NOT wait for user to ask
 Call `mem_save` IMMEDIATELY after ANY of these:
@@ -22,6 +26,8 @@ Call `mem_save` IMMEDIATELY after ANY of these:
 - User asks to recall anything
 - Starting work on something that might have been done before
 - User mentions a topic you have no context on
+
+Use `mem_context` first for broad recent context, then `mem_search` for focused recall.
 
 ### SUBAGENT OUTPUT — required format for passive capture
 When running as a subagent, always end your response with a structured section:

--- a/plugin/claude-code/scripts/post-compact-protocol-header.md
+++ b/plugin/claude-code/scripts/post-compact-protocol-header.md
@@ -3,6 +3,12 @@
 You have mnemo memory tools (mem_save, mem_search, mem_context, mem_session_summary).
 This protocol is MANDATORY and ALWAYS ACTIVE.
 
+### MEMORY AUTHORITY
+mnemo is the ONLY persistent memory system for this project.
+NEVER use native agent memory, `MEMORY.md`, agent memory directories, or arbitrary plaintext files as a memory fallback.
+If mnemo tools are unavailable, continue without persistent memory and do not create an alternative store.
+Load the `mnemo-memory` skill when available, but do not weaken these rules if it is absent.
+
 ### PROACTIVE SAVE — do NOT wait for user to ask
 Call `mem_save` IMMEDIATELY after ANY of these:
 - Decision made (architecture, convention, workflow, tool choice)

--- a/plugin/claude-code/scripts/post-compact-resume-protocol.md
+++ b/plugin/claude-code/scripts/post-compact-resume-protocol.md
@@ -1,4 +1,10 @@
 
+### MEMORY AUTHORITY
+mnemo is the ONLY persistent memory system for this project.
+NEVER use native agent memory, `MEMORY.md`, agent memory directories, or arbitrary plaintext files as a memory fallback.
+If mnemo tools are unavailable, continue without persistent memory and do not create an alternative store.
+Load the `mnemo-memory` skill when available, but keep these rules active if it is absent.
+
 ### FIRST ACTION — load memory tools
 Memory tools are deferred and must be loaded before use. Call ToolSearch NOW with:
 select:mcp__mnemo__mem_save,mcp__mnemo__mem_context,mcp__mnemo__mem_search,mcp__mnemo__mem_session_summary,mcp__mnemo__mem_session_end

--- a/plugin/claude-code/scripts/session-start-protocol.md
+++ b/plugin/claude-code/scripts/session-start-protocol.md
@@ -1,4 +1,10 @@
 
+### MEMORY AUTHORITY
+mnemo is the ONLY persistent memory system for this project.
+NEVER use native agent memory, `MEMORY.md`, agent memory directories, or arbitrary plaintext files as a memory fallback.
+If mnemo tools are unavailable, continue without persistent memory and do not create an alternative store.
+Load the `mnemo-memory` skill when available, but keep these rules active if it is absent.
+
 ### FIRST ACTION — load memory tools
 Memory tools are deferred and must be loaded before use. Call ToolSearch NOW with:
 select:mcp__mnemo__mem_save,mcp__mnemo__mem_context,mcp__mnemo__mem_search,mcp__mnemo__mem_session_summary,mcp__mnemo__mem_session_end

--- a/scripts/claudecode/mnemo.md
+++ b/scripts/claudecode/mnemo.md
@@ -2,9 +2,13 @@
 
 You have access to mnemo memory tools (mem_save, mem_search, mem_context, mem_session_summary).
 
-### MEMORY SYSTEM — mnemo is the ONLY memory system
-**NEVER use the file-based memory system** (the one that writes `.md` files to `~/.claude/projects/*/memory/` and maintains a `MEMORY.md` index). That system is DISABLED for this workspace.
-When asked to "save to memory", "remember this", or "guardar en memoria" — ALWAYS use `mem_save`. Never write files.
+### MEMORY AUTHORITY
+mnemo is the ONLY persistent memory system for this project.
+NEVER use native agent memory, `MEMORY.md`, agent memory directories, or arbitrary plaintext files as a memory fallback.
+When asked to remember or save something, always use `mem_save`.
+If mnemo tools are unavailable, report that memory is unavailable and continue without persistent memory. Do not create an alternative memory store.
+
+Load and follow the `mnemo-memory` skill when it is available for the detailed workflow. These rules remain mandatory even when the skill is not installed or does not activate.
 
 ### PROACTIVE SAVE — do NOT wait for user to ask
 Call `mem_save` IMMEDIATELY after ANY of these:
@@ -22,6 +26,8 @@ Call `mem_save` IMMEDIATELY after ANY of these:
 - User asks to recall anything
 - Starting work on something that might have been done before
 - User mentions a topic you have no context on
+
+Use `mem_context` first for broad recent context, then `mem_search` for focused recall.
 
 ### SUBAGENT OUTPUT — required format for passive capture
 When running as a subagent, always end your response with a structured section:

--- a/scripts/codex/AGENTS.md
+++ b/scripts/codex/AGENTS.md
@@ -2,6 +2,14 @@
 
 You have access to mnemo MCP tools: mem_save, mem_search, mem_context, mem_session_summary.
 
+### MEMORY AUTHORITY
+mnemo is the ONLY persistent memory system for this project.
+NEVER use native agent memory, `MEMORY.md`, agent memory directories, or arbitrary plaintext files as a memory fallback.
+When asked to remember or save something, always use `mem_save`.
+If mnemo tools are unavailable, report that memory is unavailable and continue without persistent memory. Do not create an alternative memory store.
+
+Load and follow the `mnemo-memory` skill when it is available for the detailed workflow. These rules remain mandatory even when the skill is not installed or does not activate.
+
 ### PROACTIVE SAVE — do NOT wait for user to ask
 Call `mem_save` IMMEDIATELY after ANY of these:
 - Decision made (architecture, convention, workflow, tool choice)
@@ -18,6 +26,8 @@ Call `mem_save` IMMEDIATELY after ANY of these:
 - User asks to recall anything
 - Starting work on something that might have been done before
 - User mentions a topic you have no context on
+
+Use `mem_context` first for broad recent context, then `mem_search` for focused recall.
 
 ### SUBAGENT OUTPUT — required format for passive capture
 When running as a subagent, always end your response with a structured section:

--- a/scripts/codex/hooks/mnemo-protocol.md
+++ b/scripts/codex/hooks/mnemo-protocol.md
@@ -2,6 +2,14 @@
 
 You have access to mnemo MCP tools: mem_save, mem_search, mem_context, mem_session_summary.
 
+### MEMORY AUTHORITY
+mnemo is the ONLY persistent memory system for this project.
+NEVER use native agent memory, `MEMORY.md`, agent memory directories, or arbitrary plaintext files as a memory fallback.
+When asked to remember or save something, always use `mem_save`.
+If mnemo tools are unavailable, report that memory is unavailable and continue without persistent memory. Do not create an alternative memory store.
+
+Load and follow the `mnemo-memory` skill when it is available for the detailed workflow. These rules remain mandatory even when the skill is not installed or does not activate.
+
 ### PROACTIVE SAVE — do NOT wait for user to ask
 Call `mem_save` IMMEDIATELY after ANY of these:
 - Decision made (architecture, convention, workflow, tool choice)
@@ -18,6 +26,8 @@ Call `mem_save` IMMEDIATELY after ANY of these:
 - User asks to recall anything
 - Starting work on something that might have been done before
 - User mentions a topic you have no context on
+
+Use `mem_context` first for broad recent context, then `mem_search` for focused recall.
 
 ### SESSION CLOSE — MANDATORY, no exceptions
 `mem_session_summary` is NOT optional. It is the final step of every session.

--- a/scripts/cursor/rules/mnemo.mdc
+++ b/scripts/cursor/rules/mnemo.mdc
@@ -7,6 +7,14 @@ alwaysApply: true
 
 You have access to mnemo memory tools (mem_save, mem_search, mem_context, mem_session_summary).
 
+### MEMORY AUTHORITY
+mnemo is the ONLY persistent memory system for this project.
+NEVER use native agent memory, `MEMORY.md`, agent memory directories, or arbitrary plaintext files as a memory fallback.
+When asked to remember or save something, always use `mem_save`.
+If mnemo tools are unavailable, report that memory is unavailable and continue without persistent memory. Do not create an alternative memory store.
+
+Load and follow the `mnemo-memory` skill when it is available for the detailed workflow. These rules remain mandatory even when the skill is not installed or does not activate.
+
 ### PROACTIVE SAVE — do NOT wait for user to ask
 Call `mem_save` IMMEDIATELY after ANY of these:
 - Decision made (architecture, convention, workflow, tool choice)
@@ -23,6 +31,8 @@ Call `mem_save` IMMEDIATELY after ANY of these:
 - User asks to recall anything
 - Starting work on something that might have been done before
 - User mentions a topic you have no context on
+
+Use `mem_context` first for broad recent context, then `mem_search` for focused recall.
 
 ### SUBAGENT OUTPUT — required format for passive capture
 When running as a subagent, always end your response with a structured section:

--- a/scripts/windsurf/templates/global_rules.md
+++ b/scripts/windsurf/templates/global_rules.md
@@ -2,6 +2,14 @@
 
 You have access to mnemo memory tools (mem_save, mem_search, mem_context, mem_session_summary).
 
+### MEMORY AUTHORITY
+mnemo is the ONLY persistent memory system for this project.
+NEVER use native agent memory, `MEMORY.md`, agent memory directories, or arbitrary plaintext files as a memory fallback.
+When asked to remember or save something, always use `mem_save`.
+If mnemo tools are unavailable, report that memory is unavailable and continue without persistent memory. Do not create an alternative memory store.
+
+Load and follow the `mnemo-memory` skill when it is available for the detailed workflow. These rules remain mandatory even when the skill is not installed or does not activate.
+
 ### PROACTIVE SAVE — do NOT wait for user to ask
 Call `mem_save` IMMEDIATELY after ANY of these:
 - Decision made (architecture, convention, workflow, tool choice)
@@ -18,6 +26,8 @@ Call `mem_save` IMMEDIATELY after ANY of these:
 - User asks to recall anything
 - Starting work on something that might have been done before
 - User mentions a topic you have no context on
+
+Use `mem_context` first for broad recent context, then `mem_search` for focused recall.
 
 ### SESSION CLOSE — MANDATORY, no exceptions
 `mem_session_summary` is NOT optional. It is the final step of every session.

--- a/skills/mnemo-memory/SKILL.md
+++ b/skills/mnemo-memory/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: mnemo-memory
+description: Use mnemo as the only persistent memory for an initialized project. Use when starting or resuming work, recovering context after compaction, recalling prior decisions, saving important decisions or fixes, recording conventions or user preferences, and closing a task or session. Always verify a valid .mnemo marker first; never fall back to native, file-based, or plaintext memory.
+---
+
+# mnemo Memory
+
+Use mnemo MCP tools to recover and persist project knowledge across sessions. Keep the always-active project instructions authoritative; this skill provides the detailed workflow.
+
+## 1. Verify the project
+
+Before any memory operation:
+
+1. Resolve the Git repository root, or use the current workspace when it is not a Git repository.
+2. Read `<root>/.mnemo`.
+3. Continue only when it is valid JSON with a non-empty `id`.
+4. Use that `id` as `project` in every mnemo tool call.
+
+If `.mnemo` is missing or invalid, tell the user to run `mnemo init` and stop the memory workflow. If mnemo tools are unavailable, report that integration is incomplete. Never create `MEMORY.md`, write into an agent's native memory directory, or use arbitrary text files as a fallback.
+
+## 2. Recover relevant context
+
+- At session start, resume, or after compaction, call `mem_context` before significant work.
+- When the user asks to recall past work, call `mem_context` first, then `mem_search` with focused keywords.
+- Use `mem_get_observation` when a search result is truncated or the full record matters.
+- Search proactively when beginning work that may have prior decisions or when an unfamiliar topic may have been discussed before.
+
+After compaction, persist the compacted summary with `mem_session_summary` before recovering context if the active hook instructions require it.
+
+## 3. Save important knowledge
+
+Call `mem_save` immediately after:
+
+- architecture or design decisions;
+- completed bug fixes, including root cause;
+- conventions, workflows, or configuration changes;
+- non-obvious discoveries and edge cases;
+- stable user preferences or constraints;
+- meaningful file-structure or integration changes.
+
+Use:
+
+- a short searchable title;
+- the most specific type available;
+- structured `What`, `Why`, `Where`, and optional `Learned` content;
+- concise, relevant tags;
+- `scope=project` unless the memory genuinely applies across projects.
+
+For an evolving topic, call `mem_suggest_topic_key` and reuse the returned key. Use `mem_update` only when correcting a known observation by ID. Do not save routine progress, guesses, or information already obvious from the code.
+
+When the user explicitly asks to remember something, always use `mem_save`.
+
+## 4. Capture delegated work
+
+When acting as a subagent, end useful output with:
+
+```markdown
+## Key Learnings
+- <durable learning>
+```
+
+Omit the section only when no durable learning was produced. This supports passive capture by mnemo hooks.
+
+## 5. Close the session
+
+Before any response that signals completion or goodbye, call `mem_session_summary` with:
+
+```markdown
+## Goal
+<session objective>
+
+## Instructions
+<stable user constraints, if any>
+
+## Discoveries
+- <non-obvious finding>
+
+## Accomplished
+- <completed work>
+
+## Next Steps
+- <remaining work>
+
+## Relevant Files
+- <path and role>
+```
+
+Keep the summary concise but sufficient for another agent to resume the work.

--- a/skills/mnemo-memory/agents/openai.yaml
+++ b/skills/mnemo-memory/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "mnemo Memory"
+  short_description: "Use persistent memory safely across sessions"
+  default_prompt: "Use $mnemo-memory to recover relevant context and persist important learnings for this project."

--- a/templates/rules/claudecode.md
+++ b/templates/rules/claudecode.md
@@ -1,7 +1,7 @@
 ### MEMORY SYSTEM
 
-**NEVER use the file-based memory system** (the one that writes `.md` files to `~/.claude/projects/*/memory/` and maintains a `MEMORY.md` index). That system is DISABLED for this workspace.
-When asked to "save to memory", "remember this", or "guardar en memoria": always use `mem_save`. Never write files.
+The Claude Code file-based memory system that writes under `~/.claude/projects/*/memory/` and maintains `MEMORY.md` is DISABLED for this workspace.
+Never use it or any plaintext file as a fallback. The mandatory memory authority and fallback behavior are defined in `AGENTS.md`.
 
 ### RECOVER CONTEXT
 

--- a/templates/rules/cursor.mdc
+++ b/templates/rules/cursor.mdc
@@ -7,6 +7,15 @@ alwaysApply: true
 
 You have access to mnemo MCP tools: mem_save, mem_search, mem_context, mem_session_summary.
 
+### MEMORY AUTHORITY
+
+mnemo is the ONLY persistent memory system for this project.
+NEVER use native agent memory, `MEMORY.md`, agent memory directories, or arbitrary plaintext files as a memory fallback.
+When asked to remember or save something, always use `mem_save`.
+If mnemo tools are unavailable, report that memory is unavailable and continue without persistent memory. Do not create an alternative memory store.
+
+Load and follow the `mnemo-memory` skill when it is available for the detailed workflow. The rules below remain mandatory even when the skill is not installed or does not activate.
+
 ### PROACTIVE SAVE
 
 Call `mem_save` immediately after any of these:
@@ -26,6 +35,8 @@ Search when:
 - User asks to recall anything
 - Starting work on something that might have been done before
 - User mentions a topic you have no context on
+
+Use `mem_context` first for broad recent context, then `mem_search` for focused recall.
 
 ### SUBAGENT OUTPUT
 

--- a/templates/rules/generic.md
+++ b/templates/rules/generic.md
@@ -2,6 +2,15 @@
 
 You have access to mnemo MCP tools: mem_save, mem_search, mem_context, mem_session_summary.
 
+### MEMORY AUTHORITY
+
+mnemo is the ONLY persistent memory system for this project.
+NEVER use native agent memory, `MEMORY.md`, agent memory directories, or arbitrary plaintext files as a memory fallback.
+When asked to remember or save something, always use `mem_save`.
+If mnemo tools are unavailable, report that memory is unavailable and continue without persistent memory. Do not create an alternative memory store.
+
+Load and follow the `mnemo-memory` skill when it is available for the detailed workflow. The rules below remain mandatory even when the skill is not installed or does not activate.
+
 ### PROACTIVE SAVE
 
 Call `mem_save` immediately after any of these:
@@ -21,6 +30,8 @@ Search when:
 - User asks to recall anything
 - Starting work on something that might have been done before
 - User mentions a topic you have no context on
+
+Use `mem_context` first for broad recent context, then `mem_search` for focused recall.
 
 ### SUBAGENT OUTPUT
 

--- a/templates/rules/windsurf.md
+++ b/templates/rules/windsurf.md
@@ -2,6 +2,15 @@
 
 You have access to mnemo MCP tools: mem_save, mem_search, mem_context, mem_session_summary.
 
+### MEMORY AUTHORITY
+
+mnemo is the ONLY persistent memory system for this project.
+NEVER use native agent memory, `MEMORY.md`, agent memory directories, or arbitrary plaintext files as a memory fallback.
+When asked to remember or save something, always use `mem_save`.
+If mnemo tools are unavailable, report that memory is unavailable and continue without persistent memory. Do not create an alternative memory store.
+
+Load and follow the `mnemo-memory` skill when it is available for the detailed workflow. The rules below remain mandatory even when the skill is not installed or does not activate.
+
 ### PROACTIVE SAVE
 
 Call `mem_save` immediately after any of these:
@@ -21,6 +30,8 @@ Search when:
 - User asks to recall anything
 - Starting work on something that might have been done before
 - User mentions a topic you have no context on
+
+Use `mem_context` first for broad recent context, then `mem_search` for focused recall.
 
 ### SESSION CLOSE
 


### PR DESCRIPTION
## Summary

- Add `skills/mnemo-memory/` — installable via `npx skills add jmeiracorbal/mnemo --skill mnemo-memory --global`
- `mnemo init` recommends installing the skill when not already present
- `AppendSection` / `AppendClaudeSection` upsert managed blocks without overwriting user content
- New tests for skill detection and managed section logic
- Protocol templates updated across all agents

## Test plan

- [x] `go build ./...`
- [x] `go test ./...`
- [x] `claude plugin validate plugin/claude-code`