### PR TITLE
fix: silence stdout in codex stop hook

### DIFF
--- a/scripts/codex/hooks/stop.sh
+++ b/scripts/codex/hooks/stop.sh
@@ -36,12 +36,12 @@ if [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ]; then
   fi
 
   if [ -n "$CONTENT" ]; then
-    printf '%s' "$CONTENT" | mnemo capture - --session "$SESSION_ID" --project "$PROJECT" 2>/dev/null || true
+    printf '%s' "$CONTENT" | mnemo capture - --session "$SESSION_ID" --project "$PROJECT" >/dev/null 2>&1 || true
   fi
 fi
 
 OBS_COUNT=$(mnemo session obs-count "$SESSION_ID" 2>/dev/null)
-mnemo session end "$SESSION_ID" 2>/dev/null || true
+mnemo session end "$SESSION_ID" >/dev/null 2>&1 || true
 
 if [ "${OBS_COUNT:-0}" = "0" ]; then
   printf '{"continue":true,"systemMessage":"[mnemo] warning: session ended with 0 memories saved."}\n'


### PR DESCRIPTION
`mnemo capture` and `mnemo session end` print success messages to stdout. The hook only redirected stderr (`2>/dev/null`), so those strings appeared before the JSON output and Codex rejected it with `hook returned invalid stop hook JSON output`.

Changed `2>/dev/null` to `>/dev/null 2>&1` on both lines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved output handling in internal scripts to better suppress diagnostic information during shutdown operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->