### PR TITLE
fix: count project-scoped observations in codex stop hook

### DIFF
--- a/cmd/mnemo/main.go
+++ b/cmd/mnemo/main.go
@@ -302,6 +302,14 @@ func runSession(s *store.Store) {
 		}
 		fmt.Println(n)
 
+	case "project-obs-count":
+		n, err := s.ObsCountForSession(id)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "mnemo: project-obs-count failed: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Println(n)
+
 	default:
 		fmt.Fprintf(os.Stderr, "mnemo: unknown session subcommand %q\n", subcmd)
 		os.Exit(1)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -903,6 +903,22 @@ func (s *Store) ObsCount(sessionID string) (int, error) {
 	return count, err
 }
 
+// ObsCountForSession counts all non-deleted observations saved for the session's
+// project on or after the session started. This catches observations saved via MCP
+// tools with a different session_id than the system session_id.
+func (s *Store) ObsCountForSession(sessionID string) (int, error) {
+	var count int
+	err := s.db.QueryRow(`
+		SELECT COUNT(*) FROM observations o
+		JOIN sessions ss ON ss.id = ?
+		WHERE o.project = ss.project
+		  AND o.created_at >= ss.started_at
+		  AND o.deleted_at IS NULL`,
+		sessionID,
+	).Scan(&count)
+	return count, err
+}
+
 func (s *Store) RecentSessions(project string, limit int) ([]SessionSummary, error) {
 	if limit <= 0 {
 		limit = 5

--- a/scripts/codex/hooks/stop.sh
+++ b/scripts/codex/hooks/stop.sh
@@ -40,7 +40,7 @@ if [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ]; then
   fi
 fi
 
-OBS_COUNT=$(mnemo session obs-count "$SESSION_ID" 2>/dev/null)
+OBS_COUNT=$(mnemo session project-obs-count "$SESSION_ID" 2>/dev/null)
 mnemo session end "$SESSION_ID" >/dev/null 2>&1 || true
 
 if [ "${OBS_COUNT:-0}" = "0" ]; then


### PR DESCRIPTION
`obs-count` checked only by exact `session_id`. MCP saves use a custom session_id, so the count was always 0 and the stop hook warned incorrectly.

Added `ObsCountForSession` — counts observations for the session's project since `started_at`. Stop hook now uses `project-obs-count`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `mnemo session project-obs-count` subcommand to retrieve observation counts for a session.

* **Changes**
  * Updated session stop process to use the new observation counting method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->