### PR TITLE
ft: deterministic memory capture via PostToolUse hooks

### DIFF
--- a/plugin/claude-code/hooks/hooks.json
+++ b/plugin/claude-code/hooks/hooks.json
@@ -85,6 +85,30 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/post-file-edit.sh",
+            "timeout": 5,
+            "async": true
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/post-bash-git.sh",
+            "timeout": 5,
+            "async": true
+          }
+        ]
+      }
     ]
   }
 }

--- a/plugin/claude-code/scripts/post-bash-git.sh
+++ b/plugin/claude-code/scripts/post-bash-git.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# mnemo — PostToolUse hook for Bash tool calls
+# Captures git commit events as decision observations. No LLM involvement.
+
+INPUT=$(cat)
+CMD=$(echo "$INPUT" | mnemo json tool_input command 2>/dev/null)
+CWD=$(echo "$INPUT" | mnemo json cwd 2>/dev/null)
+
+[ -z "$CMD" ] && exit 0
+
+echo "$CMD" | grep -q "git commit" || exit 0
+
+[ -z "$CWD" ] && CWD="$(pwd)"
+
+PROJECT_ROOT=$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null || echo "$CWD")
+MNEMO_FILE="${PROJECT_ROOT}/.mnemo"
+[ -f "$MNEMO_FILE" ] && PROJECT=$(mnemo json id < "$MNEMO_FILE" 2>/dev/null)
+[ -z "$PROJECT" ] && exit 0
+
+MSG=$(git -C "$PROJECT_ROOT" log -1 --pretty=%B 2>/dev/null | head -5)
+[ -z "$MSG" ] && exit 0
+
+SUBJECT=$(echo "$MSG" | head -1)
+
+mnemo save \
+  "git commit: ${SUBJECT}" \
+  "**What**: Committed changes
+**Why**: ${MSG}
+**Where**: ${PROJECT_ROOT}" \
+  --type decision \
+  --project "$PROJECT" \
+  2>/dev/null || true
+
+exit 0

--- a/plugin/claude-code/scripts/post-file-edit.sh
+++ b/plugin/claude-code/scripts/post-file-edit.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# mnemo — PostToolUse hook for Edit/Write tool calls
+# Saves file-change observations deterministically. No LLM involvement.
+# Uses topic_key = file-change/<rel_path> so repeated edits upsert, not duplicate.
+
+INPUT=$(cat)
+TOOL_NAME=$(echo "$INPUT" | mnemo json tool_name 2>/dev/null)
+FILE_PATH=$(echo "$INPUT" | mnemo json tool_input file_path 2>/dev/null)
+CWD=$(echo "$INPUT" | mnemo json cwd 2>/dev/null)
+
+[ -z "$FILE_PATH" ] && exit 0
+[ -z "$CWD" ] && CWD="$(pwd)"
+
+PROJECT_ROOT=$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null || echo "$CWD")
+MNEMO_FILE="${PROJECT_ROOT}/.mnemo"
+[ -f "$MNEMO_FILE" ] && PROJECT=$(mnemo json id < "$MNEMO_FILE" 2>/dev/null)
+[ -z "$PROJECT" ] && exit 0
+
+BASENAME=$(basename "$FILE_PATH")
+REL_PATH="${FILE_PATH#${PROJECT_ROOT}/}"
+TOPIC="file-change/${REL_PATH}"
+
+mnemo save \
+  "file changed: ${BASENAME}" \
+  "**What**: ${TOOL_NAME} on ${REL_PATH}" \
+  --type file-change \
+  --project "$PROJECT" \
+  --topic "$TOPIC" \
+  2>/dev/null || true
+
+exit 0

--- a/plugin/claude-code/scripts/post-file-edit.sh
+++ b/plugin/claude-code/scripts/post-file-edit.sh
@@ -17,7 +17,7 @@ MNEMO_FILE="${PROJECT_ROOT}/.mnemo"
 [ -z "$PROJECT" ] && exit 0
 
 BASENAME=$(basename "$FILE_PATH")
-REL_PATH="${FILE_PATH#${PROJECT_ROOT}/}"
+REL_PATH="${FILE_PATH#"${PROJECT_ROOT}/"}"
 TOPIC="file-change/${REL_PATH}"
 
 mnemo save \


### PR DESCRIPTION
mem_save relies on the LLM deciding when to call it. That's not reliable — the agent can skip it, misinterpret the trigger, or simply miss events in a long context.

This adds two PostToolUse hooks that capture observations without LLM involvement:

- `post-file-edit.sh` — fires on every Edit/Write, records which files changed. Uses topic_key for upserts so repeated edits on the same file don't create duplicates.
- `post-bash-git.sh` — fires on Bash, filters for `git commit`, captures the commit message as a decision observation.

Both scripts exit 0 on all error paths and run async so they don't block tool execution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved change tracking by adding post-action hooks for edit/write and bash tool calls. After those actions, the system records lightweight observations tied to the affected file(s) or git commit details, including contextual commit message content when applicable. This enhances traceability and history for subsequent review, while keeping failures from the logging step from impacting the primary workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->