### PR TITLE
Install agent instructions globally

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,13 +61,16 @@ mnemo --version
 claude plugin marketplace add jmeiracorbal/mnemo
 claude plugin install mnemo@mnemo
 
-# or via install.sh for any agent:
-curl -sSf https://raw.githubusercontent.com/jmeiracorbal/mnemo/main/install.sh | bash -s -- --agent=claudecode
-curl -sSf https://raw.githubusercontent.com/jmeiracorbal/mnemo/main/install.sh | bash -s -- --agent=cursor
-curl -sSf https://raw.githubusercontent.com/jmeiracorbal/mnemo/main/install.sh | bash -s -- --agent=windsurf
+# or via install.sh; default is --agent=auto, CodeGraph-style detection
+curl -sSf https://raw.githubusercontent.com/jmeiracorbal/mnemo/main/install.sh | bash
+
+# explicit targets are still supported
 curl -sSf https://raw.githubusercontent.com/jmeiracorbal/mnemo/main/install.sh | bash -s -- --agent=codex
 curl -sSf https://raw.githubusercontent.com/jmeiracorbal/mnemo/main/install.sh | bash -s -- --agent=opencode
+curl -sSf https://raw.githubusercontent.com/jmeiracorbal/mnemo/main/install.sh | bash -s -- --agent=all
 ```
+
+**Note:** The plugin integrations depend on the `mnemo` binary. Ensure that the installed binary is available in your system's `PATH`.
 
 This installs hook scripts to the agent's global directory and registers the MCP server. Hooks are wired up once here, but they will do nothing in projects without a `.mnemo` marker.
 
@@ -90,83 +93,33 @@ The skill is recommended rather than required. Hooks, MCP, and the always-active
 Run from the project root:
 
 ```bash
-mnemo init --agent=claudecode   # or cursor, windsurf, codex, all
+mnemo init --agent=claudecode   # or cursor, windsurf, codex, opencode, all
 ```
 
-This creates a `.mnemo` marker, writes the agent protocol file, and configures per-project hook settings where the agent supports it. From this point on, hooks will fire when working in this project.
+This creates a `.mnemo` marker and records the selected agent in it. Agent hooks, MCP configuration, and the short conditional protocol live globally after installation; they activate only when a project has a valid `.mnemo` file.
 
 ## Agent capabilities
 
-Not all agents support per-project hook configuration. The table below shows what each phase can configure per agent.
+mnemo follows a CodeGraph-style split: installation configures agents globally, while `mnemo init` only activates an individual project through `.mnemo`. The table below shows the global surfaces used by each agent.
 
 | | Claude Code | Cursor | Windsurf | Codex | OpenCode |
 |---|---|---|---|---|---|
 | **Hook scripts (global)** | via plugin | `~/.cursor/hooks/` | `~/.codeium/windsurf/hooks/` | `~/.codex/hooks/` | `~/.config/opencode/plugins/` |
 | **MCP (always global)** | `~/.claude/.mcp.json` | `~/.cursor/mcp.json` | `~/.codeium/windsurf/mcp_config.json` | `~/.codex/config.toml` | `~/.config/opencode/opencode.json` |
-| **Per-project hook config** | plugin hooks check `.mnemo` | `.cursor/hooks.json` | `.windsurf/hooks.json` | global hooks check `.mnemo` | global plugin checks `.mnemo` |
-| **Per-project protocol** | `AGENTS.md` + `CLAUDE.md` | `.cursor/rules/mnemo.mdc` | `.windsurf/rules/mnemo.md` | `AGENTS.md` | `AGENTS.md` |
+| **Hook config** | plugin hooks check `.mnemo` | `~/.cursor/hooks.json` | `~/.codeium/windsurf/hooks.json` | `~/.codex/hooks.json` checks `.mnemo` | global plugin checks `.mnemo` |
+| **Global protocol** | `~/.claude/CLAUDE.md` | `~/.cursor/rules/mnemo.mdc` | `~/.codeium/windsurf/memories/global_rules.md` | `~/.codex/AGENTS.md` | `~/.config/opencode/AGENTS.md` |
 | **Global skill access** | symlink at `~/.claude/skills/mnemo-memory` | canonical `~/.agents/skills/mnemo-memory` | symlink at `~/.codeium/windsurf/skills/mnemo-memory` | canonical `~/.agents/skills/mnemo-memory` | canonical `~/.agents/skills/mnemo-memory` |
 
-Codex and OpenCode do not support per-project hook configuration. Their hooks are registered globally and check for `.mnemo` at runtime before acting.
+All supported agents now use global hook/configuration surfaces where available. Their global instructions are intentionally conditional: if `.mnemo` is missing or invalid, agents skip mnemo entirely and do not create fallback memory files.
 
-## What `mnemo init` creates per agent
-
-### Claude Code
+## What `mnemo init` creates
 
 ```
 project/
-├── .mnemo                   ← project ID + configured agents
-├── AGENTS.md                ← mnemo protocol section appended here
-└── CLAUDE.md                ← @AGENTS.md include + Claude-specific additions
+└── .mnemo                        ← project ID + configured agents
 ```
 
-`CLAUDE.md` is a regular file. Existing user content is preserved, and mnemo manages only its marked section. Session hooks come from the globally installed Claude Code plugin and activate only when `.mnemo` exists.
-
-### Cursor
-
-```
-project/
-├── .mnemo                        ← marker (agents includes "cursor")
-└── .cursor/
-    ├── hooks.json                ← beforeSubmitPrompt + stop hooks
-    └── rules/
-        └── mnemo.mdc             ← protocol as a Cursor rule (alwaysApply: true)
-```
-
-`hooks.json` references the global scripts installed to `~/.cursor/hooks/` with their absolute paths.
-
-### Windsurf
-
-```
-project/
-├── .mnemo                        ← marker (agents includes "windsurf")
-└── .windsurf/
-    ├── hooks.json                ← pre_user_prompt + post_cascade_response_with_transcript hooks
-    └── rules/
-        └── mnemo.md              ← protocol as a Windsurf workspace rule
-```
-
-`hooks.json` references the global scripts installed to `~/.codeium/windsurf/hooks/`.
-
-### Codex
-
-```
-project/
-├── .mnemo                        ← marker (agents includes "codex")
-└── AGENTS.md                     ← mnemo protocol section appended here
-```
-
-Hooks remain in `~/.codex/hooks.json`. The session-start and stop scripts check for `.mnemo` at runtime and skip if the marker is absent.
-
-### OpenCode
-
-```
-project/
-├── .mnemo                        ← marker (agents includes "opencode")
-└── AGENTS.md                     ← mnemo protocol section appended here
-```
-
-The plugin (`mnemo.ts`) is a TypeScript module that runs under Bun and is installed globally at `~/.config/opencode/plugins/`. It checks for `.mnemo` at runtime and does nothing if the marker is absent. MCP is registered in `~/.config/opencode/opencode.json`.
+`mnemo init` no longer appends mnemo protocol sections to project `AGENTS.md`, `CLAUDE.md`, Cursor rules, or Windsurf rules. Those instructions are installed globally by `install.sh` / `mnemo install-instructions` and are activated by the `.mnemo` marker.
 
 ## The `.mnemo` marker
 
@@ -180,7 +133,7 @@ The `.mnemo` file at the project root is what activates mnemo for a project. It 
 }
 ```
 
-`id` is the deterministic project identifier used by every integration. `agents` lists which agents have been configured via `mnemo init`. All hooks, including the global-only Codex hooks, read this file before acting. If the file is absent or has no ID, the hook exits silently.
+`id` is the deterministic project identifier used by every integration. `agents` lists which agents have been activated via `mnemo init`. All global hooks and plugins read this file before acting. If the file is absent or has no ID, the integration exits silently.
 
 `mnemo init` creates and updates this file automatically and adds it to `.gitignore`. Do not commit it: each clone derives its own identifier from its local path.
 
@@ -305,7 +258,8 @@ claude mcp add -s user mnemo-admin -- ~/.local/bin/mnemo mcp --tools=admin
 
 ```
 mnemo mcp [--tools=PROFILE]          Start MCP server (stdio)
-mnemo init [--agent=AGENT]           Configure mnemo in the current project
+mnemo init [--agent=AGENT]           Activate mnemo in the current project (.mnemo)
+mnemo install-instructions [--agent=AGENT]  Install global agent instructions
 mnemo save <title> <content>         Save a memory
 mnemo search <query>                 Search memories
 mnemo context [project]              Show context from previous sessions
@@ -322,14 +276,14 @@ mnemo extract-transcript <file>      Extract assistant text blocks from a JSONL 
 mnemo version                        Show version
 ```
 
-Agents for `mnemo init`:
+Agents for `mnemo init` / `mnemo install-instructions`:
 
 ```
---agent=claudecode   AGENTS.md + CLAUDE.md managed sections (default)
---agent=cursor       .cursor/hooks.json + .cursor/rules/mnemo.mdc
---agent=windsurf     .windsurf/hooks.json + .windsurf/rules/mnemo.md
---agent=codex        AGENTS.md append only (hooks stay global)
---agent=opencode     AGENTS.md append only (plugin stays global)
+--agent=claudecode   Claude Code global CLAUDE.md instructions / .mnemo activation (default for init)
+--agent=cursor       Cursor global rule / .mnemo activation
+--agent=windsurf     Windsurf global rule / .mnemo activation
+--agent=codex        Codex global AGENTS.md instructions / .mnemo activation
+--agent=opencode     OpenCode global AGENTS.md instructions / .mnemo activation
 --agent=all          All agents
 ```
 
@@ -377,30 +331,21 @@ ls -l ~/.claude/skills/mnemo-memory \
 
 Only symlinks for agent-specific consumers selected during `npx skills add` are expected to exist. Codex and Cursor use the canonical `.agents/skills` path directly.
 
-After running `mnemo init`, check the project files exist:
+After running the installer, check global agent files exist; after `mnemo init`, check only the project marker:
 
 ```bash
-# Claude Code
-cat .mnemo                          # must contain agents list
-grep "@AGENTS.md" CLAUDE.md         # must include shared project instructions
-grep "mnemo:claude-start" CLAUDE.md # must contain the managed Claude section
+# Project activation
+cat .mnemo                          # must contain id + agents list
 
-# Cursor
-cat .cursor/hooks.json              # must have beforeSubmitPrompt + stop
-head -3 .cursor/rules/mnemo.mdc    # must have: alwaysApply: true
+# Global instructions
+grep "mnemo:start" ~/.codex/AGENTS.md ~/.claude/CLAUDE.md 2>/dev/null
+head -3 ~/.cursor/rules/mnemo.mdc   # should have: alwaysApply: true
+grep "mnemo:start" ~/.codeium/windsurf/memories/global_rules.md 2>/dev/null
+grep "mnemo:start" ~/.config/opencode/AGENTS.md 2>/dev/null
 
-# Windsurf
-cat .windsurf/hooks.json            # must have pre_user_prompt + post_cascade_response_with_transcript
-ls .windsurf/rules/mnemo.md
-
-# Codex
-grep "mnemo" AGENTS.md             # must have the protocol section
-
-# OpenCode
-ls ~/.config/opencode/plugins/mnemo.ts        # plugin must exist
-ls ~/.config/opencode/plugins/mnemo-protocol.md
-grep "mnemo" ~/.config/opencode/opencode.json  # MCP must be registered
-grep "mnemo" AGENTS.md                         # must have the protocol section
+# Global hooks/config
+grep "mnemo" ~/.cursor/hooks.json ~/.codeium/windsurf/hooks.json ~/.codex/hooks.json 2>/dev/null
+ls ~/.config/opencode/plugins/mnemo.ts ~/.config/opencode/plugins/mnemo-protocol.md
 ```
 
 Validate the Claude Code plugin:
@@ -409,11 +354,13 @@ Validate the Claude Code plugin:
 claude plugin validate plugin/claude-code
 ```
 
-Check idempotency. Running `mnemo init` again must refresh the managed sections without duplicating them or changing surrounding user content:
+Check idempotency. Running `mnemo install-instructions` or `mnemo init` again must not duplicate managed sections or marker entries:
 
 ```bash
+mnemo install-instructions --agent=codex
+mnemo install-instructions --agent=codex  # second run: no duplicate block
 mnemo init --agent=claudecode
-mnemo init --agent=claudecode  # second run: no changes
+mnemo init --agent=claudecode             # second run: no duplicate agent entry
 ```
 
 ## Storage

--- a/cmd/mnemo/install_instructions_test.go
+++ b/cmd/mnemo/install_instructions_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestParseInstallInstructionsArgsHomeOverrideDoesNotRequireUserHome(t *testing.T) {
+	agent, home, err := parseInstallInstructionsArgs(
+		[]string{"--agent=codex", "--home=/tmp/mnemo-home"},
+		func() (string, error) { return "", errors.New("HOME not set") },
+	)
+	if err != nil {
+		t.Fatalf("expected --home to avoid user home lookup error, got %v", err)
+	}
+	if agent != "codex" {
+		t.Fatalf("agent = %q, want codex", agent)
+	}
+	if home != "/tmp/mnemo-home" {
+		t.Fatalf("home = %q, want /tmp/mnemo-home", home)
+	}
+}
+
+func TestParseInstallInstructionsArgsFallsBackToUserHome(t *testing.T) {
+	agent, home, err := parseInstallInstructionsArgs(
+		[]string{"--agent=opencode"},
+		func() (string, error) { return "/home/tester", nil },
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if agent != "opencode" {
+		t.Fatalf("agent = %q, want opencode", agent)
+	}
+	if home != "/home/tester" {
+		t.Fatalf("home = %q, want /home/tester", home)
+	}
+}

--- a/cmd/mnemo/main.go
+++ b/cmd/mnemo/main.go
@@ -47,6 +47,9 @@ func main() {
 	case "extract-transcript":
 		runExtractTranscript()
 		return
+	case "install-instructions":
+		runInstallInstructions()
+		return
 	case "--version", "version":
 		fmt.Printf("mnemo %s\n", version)
 		return
@@ -578,9 +581,50 @@ func runExtractTranscript() {
 	fmt.Println(strings.Join(lines, "\n"))
 }
 
+// ─── install instructions ───────────────────────────────────────────────────
+
+func runInstallInstructions() {
+	agent, home, err := parseInstallInstructionsArgs(os.Args[2:], os.UserHomeDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mnemo install-instructions: home: %v\n", err)
+		os.Exit(1)
+	}
+
+	agents, err := agentinit.ExpandAgents(agent)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mnemo install-instructions: %v\n", err)
+		os.Exit(1)
+	}
+	for _, a := range agents {
+		path, err := agentinit.InstallGlobalInstructions(home, a)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "mnemo install-instructions: %s: %v\n", a, err)
+			os.Exit(1)
+		}
+		fmt.Printf("mnemo install-instructions: %s updated %s\n", a, path)
+	}
+}
+
+func parseInstallInstructionsArgs(args []string, userHomeDir func() (string, error)) (agent, home string, err error) {
+	agent = "all"
+	for _, arg := range args {
+		switch {
+		case strings.HasPrefix(arg, "--agent="):
+			agent = arg[len("--agent="):]
+		case strings.HasPrefix(arg, "--home="):
+			home = arg[len("--home="):]
+		}
+	}
+	if home != "" {
+		return agent, home, nil
+	}
+	home, err = userHomeDir()
+	return agent, home, err
+}
+
 // ─── init ────────────────────────────────────────────────────────────────────
 
-// runInit configures mnemo for one or more agents in the current project.
+// runInit activates mnemo for one or more agents in the current project.
 func runInit(s *store.Store) {
 	agent := "claudecode"
 	dir := "."
@@ -612,9 +656,10 @@ func runInit(s *store.Store) {
 		os.Exit(1)
 	}
 
-	agents := []string{agent}
-	if agent == "all" {
-		agents = []string{"claudecode", "cursor", "windsurf", "codex", "opencode"}
+	agents, err := agentinit.ExpandAgents(agent)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mnemo init: %v\n", err)
+		os.Exit(1)
 	}
 
 	for _, a := range agents {
@@ -622,7 +667,7 @@ func runInit(s *store.Store) {
 			fmt.Fprintf(os.Stderr, "mnemo init: %s: %v\n", a, err)
 			os.Exit(1)
 		}
-		fmt.Printf("mnemo init: %s configured in %s\n", a, root)
+		fmt.Printf("mnemo init: %s activated in %s\n", a, root)
 	}
 	if err := agentinit.EnsureGitignore(root); err != nil {
 		fmt.Fprintf(os.Stderr, "mnemo init: gitignore: %v\n", err)

--- a/cmd/mnemo/plugin_integrity_test.go
+++ b/cmd/mnemo/plugin_integrity_test.go
@@ -72,7 +72,9 @@ func TestShippedHooksReferenceRealScripts(t *testing.T) {
 func TestShippedProtocolsForbidFallbackMemory(t *testing.T) {
 	files := []string{
 		filepath.Join("..", "..", "templates", "rules", "generic.md"),
+		filepath.Join("..", "..", "templates", "rules", "global.md"),
 		filepath.Join("..", "..", "templates", "rules", "cursor.mdc"),
+		filepath.Join("..", "..", "templates", "rules", "cursor-global.mdc"),
 		filepath.Join("..", "..", "templates", "rules", "windsurf.md"),
 		filepath.Join("..", "..", "plugin", "claude-code", "scripts", "mnemo.md"),
 		filepath.Join("..", "..", "plugin", "claude-code", "scripts", "session-start-protocol.md"),

--- a/cmd/mnemo/templates/usage.txt
+++ b/cmd/mnemo/templates/usage.txt
@@ -11,21 +11,22 @@ Usage:
   mnemo export [file]                  Export all memories to JSON
   mnemo import <file.json>             Import memories from JSON
   mnemo capture <content>|-            Extract learnings from text (passive capture; "-" reads stdin)
-  mnemo init [--agent=AGENT] [--path=DIR]  Configure mnemo in the current project
+  mnemo init [--agent=AGENT] [--path=DIR]  Activate mnemo in the current project (.mnemo)
+  mnemo install-instructions [--agent=AGENT]  Install global agent instructions
   mnemo migrate [--path=DIR]              Migrate project from legacy key to UUID-based identity
   mnemo json KEY [KEY ...]             Extract field from JSON on stdin (used by hooks)
   mnemo json-merge <file>              Deep-merge JSON from stdin into file
   mnemo extract-transcript <file>      Extract assistant text from JSONL transcript
   mnemo version                        Show version
 
-Agents for init:
-  --agent=claudecode   AGENTS.md (generic) + CLAUDE.md with Claude-specific additions (default)
-  --agent=cursor       .cursor/hooks.json + .cursor/rules/mnemo.mdc
-  --agent=windsurf     .windsurf/hooks.json + .windsurf/rules/mnemo.md
-  --agent=codex        AGENTS.md append
-  --agent=opencode     AGENTS.md append only (plugin stays global)
+Agents for init / install-instructions:
+  --agent=claudecode   Claude Code global CLAUDE.md instructions / .mnemo activation (default for init)
+  --agent=cursor       Cursor global rule / .mnemo activation
+  --agent=windsurf     Windsurf global rule / .mnemo activation
+  --agent=codex        Codex global AGENTS.md instructions / .mnemo activation
+  --agent=opencode     OpenCode global AGENTS.md instructions / .mnemo activation
   --agent=all          All agents
-  --path=DIR           Target project directory (default: current directory)
+  --path=DIR           Target project directory for init (default: current directory)
 
 Tool profiles for mcp:
   --tools=agent    15 tools for AI agents (default when using plugin)

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,8 @@
 # mnemo installer
 # Usage: curl -sSf https://raw.githubusercontent.com/jmeiracorbal/mnemo/main/install.sh | bash
 #
-# Agent selection (default: claudecode):
+# Agent selection (default: auto-detect installed compatible agents):
+#   bash -s -- --agent=auto
 #   bash -s -- --agent=cursor
 #   bash -s -- --agent=windsurf
 #   bash -s -- --agent=codex
@@ -20,7 +21,7 @@ REPO="jmeiracorbal/mnemo"
 INSTALL_DIR="${MNEMO_INSTALL_DIR:-$HOME/.local/bin}"
 DRY_RUN="${MNEMO_DRY_RUN:-false}"
 MNEMO_VERSION="${MNEMO_VERSION:-}"
-AGENT="${MNEMO_AGENT:-claudecode}"
+AGENT="${MNEMO_AGENT:-auto}"
 TMP_SCRIPTS=""
 
 # ── helpers ────────────────────────────────────────────────────────────────────
@@ -223,7 +224,8 @@ setup_claudecode() {
     "$mnemo_bin" | "$mnemo_bin" json-merge "$mcp_json")
   ok "~/.claude/.mcp.json: ${result}"
 
-  ok "Run 'mnemo init --agent=claudecode' from each project to enable mnemo there."
+  "$mnemo_bin" install-instructions --agent=claudecode
+  ok "Global Claude Code instructions installed. Run 'mnemo init --agent=claudecode' in projects that should use mnemo."
 }
 
 # ── setup: Cursor ──────────────────────────────────────────────────────────────
@@ -233,7 +235,6 @@ setup_cursor() {
   local hooks_dir="$HOME/.cursor/hooks"
   local mcp_json="$HOME/.cursor/mcp.json"
   local hooks_json="$HOME/.cursor/hooks.json"
-  local rules_dir="$HOME/.cursor/rules"
 
   info "Configuring Cursor..."
 
@@ -248,7 +249,12 @@ setup_cursor() {
     "$mnemo_bin" | "$mnemo_bin" json-merge "$mcp_json")
   ok "~/.cursor/mcp.json: ${result}"
 
-  ok "Run 'mnemo init --agent=cursor' from each project to enable hooks and rules there."
+  result=$(printf '{"version":1,"hooks":{"beforeSubmitPrompt":[{"command":"%s/before-submit-prompt.sh"}],"stop":[{"command":"%s/stop.sh"}]}}' \
+    "$hooks_dir" "$hooks_dir" | "$mnemo_bin" json-merge "$hooks_json")
+  ok "~/.cursor/hooks.json: ${result}"
+
+  "$mnemo_bin" install-instructions --agent=cursor
+  ok "Global Cursor hooks and instructions installed. Run 'mnemo init --agent=cursor' in projects that should use mnemo."
 }
 
 # ── setup: Codex ──────────────────────────────────────────────────────────────
@@ -259,9 +265,6 @@ setup_codex() {
   local hooks_dir="$codex_dir/hooks"
   local hooks_json="$codex_dir/hooks.json"
   local codex_config="$codex_dir/config.toml"
-  local agents_md="$codex_dir/AGENTS.md"
-  local marker="## mnemo — Persistent Memory Protocol"
-
   info "Configuring Codex..."
 
   mkdir -p "$hooks_dir"
@@ -303,7 +306,8 @@ setup_codex() {
     "$hooks_dir" "$hooks_dir" | "$mnemo_bin" json-merge "$hooks_json")
   ok "~/.codex/hooks.json: ${result}"
 
-  ok "Run 'mnemo init --agent=codex' from each project to enable mnemo there."
+  "$mnemo_bin" install-instructions --agent=codex
+  ok "Global Codex hooks and instructions installed. Run 'mnemo init --agent=codex' in projects that should use mnemo."
 }
 
 # ── setup: Windsurf ────────────────────────────────────────────────────────────
@@ -313,10 +317,6 @@ setup_windsurf() {
   local hooks_dir="$HOME/.codeium/windsurf/hooks"
   local mcp_json="$HOME/.codeium/windsurf/mcp_config.json"
   local hooks_json="$HOME/.codeium/windsurf/hooks.json"
-  local memories_dir="$HOME/.codeium/windsurf/memories"
-  local global_rules="$memories_dir/global_rules.md"
-  local marker="## mnemo — Persistent Memory Protocol"
-
   info "Configuring Windsurf..."
 
   mkdir -p "$hooks_dir"
@@ -330,7 +330,12 @@ setup_windsurf() {
     "$mnemo_bin" | "$mnemo_bin" json-merge "$mcp_json")
   ok "~/.codeium/windsurf/mcp_config.json: ${result}"
 
-  ok "Run 'mnemo init --agent=windsurf' from each project to enable hooks and rules there."
+  result=$(printf '{"hooks":{"pre_user_prompt":[{"command":"%s/pre-user-prompt.sh"}],"post_cascade_response_with_transcript":[{"command":"%s/post-cascade-response.sh"}]}}' \
+    "$hooks_dir" "$hooks_dir" | "$mnemo_bin" json-merge "$hooks_json")
+  ok "~/.codeium/windsurf/hooks.json: ${result}"
+
+  "$mnemo_bin" install-instructions --agent=windsurf
+  ok "Global Windsurf hooks and instructions installed. Run 'mnemo init --agent=windsurf' in projects that should use mnemo."
 }
 
 # ── setup: OpenCode ────────────────────────────────────────────────────────────
@@ -352,7 +357,59 @@ setup_opencode() {
     "$mnemo_bin" | "$mnemo_bin" json-merge "$opencode_json")
   ok "~/.config/opencode/opencode.json: ${result}"
 
-  ok "Run 'mnemo init --agent=opencode' from each project to enable mnemo there."
+  "$mnemo_bin" install-instructions --agent=opencode
+  ok "Global OpenCode plugin and instructions installed. Run 'mnemo init --agent=opencode' in projects that should use mnemo."
+}
+
+
+# ── agent detection ───────────────────────────────────────────────────────────
+
+agent_detected() {
+  case "$1" in
+    claudecode)
+      command -v claude >/dev/null 2>&1 || [ -d "$HOME/.claude" ] || [ -f "$HOME/.claude.json" ]
+      ;;
+    cursor)
+      command -v cursor >/dev/null 2>&1 || [ -d "$HOME/.cursor" ]
+      ;;
+    windsurf)
+      command -v windsurf >/dev/null 2>&1 || [ -d "$HOME/.codeium/windsurf" ]
+      ;;
+    codex)
+      command -v codex >/dev/null 2>&1 || [ -d "$HOME/.codex" ]
+      ;;
+    opencode)
+      command -v opencode >/dev/null 2>&1 || [ -d "$HOME/.config/opencode" ]
+      ;;
+    *) return 1 ;;
+  esac
+}
+
+detect_agents() {
+  local found=""
+  local agent
+  for agent in claudecode cursor windsurf codex opencode; do
+    if agent_detected "$agent"; then
+      found="$found $agent"
+    fi
+  done
+  # CodeGraph falls back to Claude when auto-detection finds nothing.
+  if [ -z "$found" ]; then
+    found=" claudecode"
+  fi
+  echo "$found"
+}
+
+setup_agent() {
+  local agent="$1" mnemo_bin="$2"
+  case "$agent" in
+    claudecode) setup_claudecode "$mnemo_bin" ;;
+    cursor) setup_cursor "$mnemo_bin" ;;
+    windsurf) setup_windsurf "$mnemo_bin" ;;
+    codex) setup_codex "$mnemo_bin" ;;
+    opencode) setup_opencode "$mnemo_bin" ;;
+    *) err "Unknown agent: ${agent}. Valid options: auto | claudecode | cursor | windsurf | codex | opencode | all" ;;
+  esac
 }
 
 # ── main ───────────────────────────────────────────────────────────────────────
@@ -399,36 +456,27 @@ main() {
   download_scripts "$version"
 
   case "$AGENT" in
-    claudecode)
-      setup_claudecode "$mnemo_bin"
-      ok "Done. Run 'mnemo init --agent=claudecode' from each project to activate mnemo there."
-      ;;
-    cursor)
-      setup_cursor "$mnemo_bin"
-      ok "Done. Run 'mnemo init --agent=cursor' from each project to activate mnemo there."
-      ;;
-    windsurf)
-      setup_windsurf "$mnemo_bin"
-      ok "Done. Run 'mnemo init --agent=windsurf' from each project to activate mnemo there."
-      ;;
-    codex)
-      setup_codex "$mnemo_bin"
-      ok "Done. Run 'mnemo init --agent=codex' from each project to activate mnemo there."
-      ;;
-    opencode)
-      setup_opencode "$mnemo_bin"
-      ok "Done. Run 'mnemo init --agent=opencode' from each project to activate mnemo there."
+    auto)
+      local detected
+      detected=$(detect_agents)
+      info "Auto-detected agents:${detected}"
+      for selected in $detected; do
+        setup_agent "$selected" "$mnemo_bin"
+      done
+      ok "Done. Run 'mnemo init --agent=all' in projects that should use mnemo."
       ;;
     all)
-      setup_claudecode "$mnemo_bin"
-      setup_cursor "$mnemo_bin"
-      setup_windsurf "$mnemo_bin"
-      setup_codex "$mnemo_bin"
-      setup_opencode "$mnemo_bin"
-      ok "Done. Run 'mnemo init --agent=all' from each project to activate mnemo there."
+      for selected in claudecode cursor windsurf codex opencode; do
+        setup_agent "$selected" "$mnemo_bin"
+      done
+      ok "Done. Run 'mnemo init --agent=all' in projects that should use mnemo."
+      ;;
+    claudecode|cursor|windsurf|codex|opencode)
+      setup_agent "$AGENT" "$mnemo_bin"
+      ok "Done. Run 'mnemo init --agent=${AGENT}' in projects that should use mnemo."
       ;;
     *)
-      err "Unknown agent: ${AGENT}. Valid options: claudecode | cursor | windsurf | codex | opencode | all"
+      err "Unknown agent: ${AGENT}. Valid options: auto | claudecode | cursor | windsurf | codex | opencode | all"
       ;;
   esac
 }

--- a/internal/agentinit/claudecode.go
+++ b/internal/agentinit/claudecode.go
@@ -1,48 +1,8 @@
 package agentinit
 
-import (
-	"fmt"
-	"os"
-	"path/filepath"
-
-	"github.com/jmeiracorbal/mnemo/templates"
-)
-
-// InitClaudeCode configures mnemo for Claude Code in the given project root.
-//
-// Appends the generic mnemo protocol to AGENTS.md (shared with other agents) and
-// creates CLAUDE.md as a real file containing an @AGENTS.md include plus the
-// Claude Code-specific protocol additions. If CLAUDE.md already exists as a
-// regular file, the Claude section is appended to it. If it was previously a
-// symlink (old architecture), the symlink is removed first.
+// InitClaudeCode activates mnemo for Claude Code in the given project root.
+// Agent instructions are installed globally by install.sh / install-instructions;
+// project init only records activation in .mnemo.
 func InitClaudeCode(root string) error {
-	agentsPath := filepath.Join(root, "AGENTS.md")
-	claudePath := filepath.Join(root, "CLAUDE.md")
-
-	if err := AppendSection(agentsPath, templates.Generic); err != nil {
-		return fmt.Errorf("AGENTS.md: %w", err)
-	}
-
-	info, err := os.Lstat(claudePath)
-	if err == nil {
-		mode := info.Mode()
-		if mode.IsDir() {
-			return fmt.Errorf("CLAUDE.md: is a directory")
-		}
-		if mode&os.ModeSymlink != 0 {
-			if err := os.Remove(claudePath); err != nil {
-				return fmt.Errorf("CLAUDE.md: remove symlink: %w", err)
-			}
-		} else if !mode.IsRegular() {
-			return fmt.Errorf("CLAUDE.md: unexpected file type %v", mode.Type())
-		}
-	} else if !os.IsNotExist(err) {
-		return fmt.Errorf("CLAUDE.md: stat: %w", err)
-	}
-
-	if err := AppendClaudeSection(claudePath, templates.ClaudeCode); err != nil {
-		return fmt.Errorf("CLAUDE.md: %w", err)
-	}
-
 	return AddAgent(root, "claudecode")
 }

--- a/internal/agentinit/codex.go
+++ b/internal/agentinit/codex.go
@@ -1,20 +1,7 @@
 package agentinit
 
-import (
-	"fmt"
-	"path/filepath"
-
-	"github.com/jmeiracorbal/mnemo/templates"
-)
-
-// InitCodex configures mnemo for Codex in the given project root.
-//
-// Appends the mnemo protocol section to AGENTS.md. Hooks for Codex are global
-// (registered by install.sh); they check for the .mnemo marker at runtime.
+// InitCodex activates mnemo for Codex in the given project root.
+// Global hooks and instructions check for .mnemo at runtime.
 func InitCodex(root string) error {
-	agentsPath := filepath.Join(root, "AGENTS.md")
-	if err := AppendSection(agentsPath, templates.Generic); err != nil {
-		return fmt.Errorf("codex init: AGENTS.md: %w", err)
-	}
 	return AddAgent(root, "codex")
 }

--- a/internal/agentinit/cursor.go
+++ b/internal/agentinit/cursor.go
@@ -1,62 +1,7 @@
 package agentinit
 
-import (
-	"encoding/json"
-	"fmt"
-	"os"
-	"path/filepath"
-
-	"github.com/jmeiracorbal/mnemo/templates"
-)
-
-// InitCursor configures mnemo for Cursor in the given project root.
-//
-// Writes .cursor/hooks.json referencing the global hook scripts and
-// .cursor/rules/mnemo.mdc with the mnemo protocol.
+// InitCursor activates mnemo for Cursor in the given project root.
+// Global hooks and instructions check for .mnemo at runtime.
 func InitCursor(root string) error {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return fmt.Errorf("cursor init: could not determine HOME: %w", err)
-	}
-
-	hooksDir := filepath.Join(home, ".cursor", "hooks")
-	beforeSubmit := filepath.Join(hooksDir, "before-submit-prompt.sh")
-	stop := filepath.Join(hooksDir, "stop.sh")
-
-	if _, err := os.Stat(beforeSubmit); err != nil {
-		if os.IsNotExist(err) {
-			return fmt.Errorf("cursor init: hook script not found: %s\nRun install.sh --agent=cursor first", beforeSubmit)
-		}
-		return fmt.Errorf("cursor init: stat %s: %w", beforeSubmit, err)
-	}
-	if _, err := os.Stat(stop); err != nil {
-		if os.IsNotExist(err) {
-			return fmt.Errorf("cursor init: hook script not found: %s\nRun install.sh --agent=cursor first", stop)
-		}
-		return fmt.Errorf("cursor init: stat %s: %w", stop, err)
-	}
-
-	hooksData := map[string]any{
-		"version": 1,
-		"hooks": map[string]any{
-			"beforeSubmitPrompt": []map[string]string{{"command": beforeSubmit}},
-			"stop":               []map[string]string{{"command": stop}},
-		},
-	}
-	hooksJSON, err := json.MarshalIndent(hooksData, "", "  ")
-	if err != nil {
-		return fmt.Errorf("cursor init: marshal hooks.json: %w", err)
-	}
-
-	hooksPath := filepath.Join(root, ".cursor", "hooks.json")
-	if err := WriteFile(hooksPath, append(hooksJSON, '\n')); err != nil {
-		return fmt.Errorf("cursor init: .cursor/hooks.json: %w", err)
-	}
-
-	rulesPath := filepath.Join(root, ".cursor", "rules", "mnemo.mdc")
-	if err := WriteFile(rulesPath, []byte(templates.Cursor)); err != nil {
-		return fmt.Errorf("cursor init: .cursor/rules/mnemo.mdc: %w", err)
-	}
-
 	return AddAgent(root, "cursor")
 }

--- a/internal/agentinit/global.go
+++ b/internal/agentinit/global.go
@@ -1,0 +1,65 @@
+package agentinit
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/jmeiracorbal/mnemo/templates"
+)
+
+// SupportedAgents is the canonical set of agent IDs accepted by mnemo init and
+// the installer helpers. Keep this list stable for scripts and docs.
+var SupportedAgents = []string{"claudecode", "cursor", "windsurf", "codex", "opencode"}
+
+// ExpandAgents resolves a single agent flag value to one or more concrete agent
+// IDs. It accepts the special value "all".
+func ExpandAgents(agent string) ([]string, error) {
+	if agent == "all" {
+		return append([]string(nil), SupportedAgents...), nil
+	}
+	for _, a := range SupportedAgents {
+		if agent == a {
+			return []string{agent}, nil
+		}
+	}
+	return nil, fmt.Errorf("unknown agent %q — valid: claudecode | cursor | windsurf | codex | opencode | all", agent)
+}
+
+// GlobalInstructionPath returns the user-scope instruction path used by an
+// agent, mirroring CodeGraph's global install model.
+func GlobalInstructionPath(home, agent string) (string, error) {
+	switch agent {
+	case "claudecode":
+		return filepath.Join(home, ".claude", "CLAUDE.md"), nil
+	case "cursor":
+		return filepath.Join(home, ".cursor", "rules", "mnemo.mdc"), nil
+	case "windsurf":
+		return filepath.Join(home, ".codeium", "windsurf", "memories", "global_rules.md"), nil
+	case "codex":
+		return filepath.Join(home, ".codex", "AGENTS.md"), nil
+	case "opencode":
+		return filepath.Join(home, ".config", "opencode", "AGENTS.md"), nil
+	default:
+		return "", fmt.Errorf("unknown agent %q", agent)
+	}
+}
+
+// InstallGlobalInstructions writes the short, conditional mnemo instructions to
+// an agent's global instruction surface. The block is conditional on a valid
+// project .mnemo marker so a global install does not activate mnemo everywhere.
+func InstallGlobalInstructions(home, agent string) (string, error) {
+	path, err := GlobalInstructionPath(home, agent)
+	if err != nil {
+		return "", err
+	}
+	if agent == "cursor" {
+		if err := WriteFile(path, []byte(templates.CursorGlobal)); err != nil {
+			return "", err
+		}
+		return path, nil
+	}
+	if err := AppendSection(path, templates.Global); err != nil {
+		return "", err
+	}
+	return path, nil
+}

--- a/internal/agentinit/global_test.go
+++ b/internal/agentinit/global_test.go
@@ -1,0 +1,77 @@
+package agentinit
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestInstallGlobalInstructionsWritesConditionalAgentFiles(t *testing.T) {
+	home := t.TempDir()
+
+	cases := map[string]string{
+		"claudecode": filepath.Join(home, ".claude", "CLAUDE.md"),
+		"cursor":     filepath.Join(home, ".cursor", "rules", "mnemo.mdc"),
+		"windsurf":   filepath.Join(home, ".codeium", "windsurf", "memories", "global_rules.md"),
+		"codex":      filepath.Join(home, ".codex", "AGENTS.md"),
+		"opencode":   filepath.Join(home, ".config", "opencode", "AGENTS.md"),
+	}
+
+	for agent, wantPath := range cases {
+		t.Run(agent, func(t *testing.T) {
+			gotPath, err := InstallGlobalInstructions(home, agent)
+			if err != nil {
+				t.Fatalf("install global instructions: %v", err)
+			}
+			if gotPath != wantPath {
+				t.Fatalf("path = %q, want %q", gotPath, wantPath)
+			}
+
+			data, err := os.ReadFile(wantPath)
+			if err != nil {
+				t.Fatalf("read global instructions: %v", err)
+			}
+			content := string(data)
+			if !strings.Contains(content, ".mnemo") {
+				t.Fatalf("global instructions are not conditional on .mnemo:\n%s", content)
+			}
+			if !strings.Contains(content, "ONLY persistent memory system") {
+				t.Fatalf("global instructions do not declare memory authority:\n%s", content)
+			}
+			if !strings.Contains(content, "skip mnemo entirely") {
+				t.Fatalf("global instructions do not tell agents to skip uninitialized projects:\n%s", content)
+			}
+		})
+	}
+}
+
+func TestInstallGlobalInstructionsPreservesExistingMarkedFile(t *testing.T) {
+	home := t.TempDir()
+	path := filepath.Join(home, ".codex", "AGENTS.md")
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("# Existing\n\nUser content.\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := InstallGlobalInstructions(home, "codex"); err != nil {
+		t.Fatalf("first install: %v", err)
+	}
+	if _, err := InstallGlobalInstructions(home, "codex"); err != nil {
+		t.Fatalf("second install: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(data)
+	if !strings.Contains(content, "# Existing\n\nUser content.\n") {
+		t.Fatalf("existing content was not preserved:\n%s", content)
+	}
+	if strings.Count(content, sectionStart) != 1 || strings.Count(content, sectionEnd) != 1 {
+		t.Fatalf("managed section not idempotent:\n%s", content)
+	}
+}

--- a/internal/agentinit/init_test.go
+++ b/internal/agentinit/init_test.go
@@ -1,0 +1,32 @@
+package agentinit
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestProjectInitDoesNotWriteProjectInstructionFiles(t *testing.T) {
+	root := t.TempDir()
+	for _, initFn := range []func(string) error{InitClaudeCode, InitCursor, InitWindsurf, InitCodex, InitOpenCode} {
+		if err := initFn(root); err != nil {
+			t.Fatalf("init agent: %v", err)
+		}
+	}
+
+	for _, rel := range []string{
+		"AGENTS.md",
+		"CLAUDE.md",
+		filepath.Join(".cursor", "hooks.json"),
+		filepath.Join(".cursor", "rules", "mnemo.mdc"),
+		filepath.Join(".windsurf", "hooks.json"),
+		filepath.Join(".windsurf", "rules", "mnemo.md"),
+	} {
+		path := filepath.Join(root, rel)
+		if _, err := os.Stat(path); err == nil {
+			t.Fatalf("project init unexpectedly wrote %s", rel)
+		} else if !os.IsNotExist(err) {
+			t.Fatalf("stat %s: %v", rel, err)
+		}
+	}
+}

--- a/internal/agentinit/opencode.go
+++ b/internal/agentinit/opencode.go
@@ -1,41 +1,7 @@
 package agentinit
 
-import (
-	"fmt"
-	"os"
-	"path/filepath"
-
-	"github.com/jmeiracorbal/mnemo/templates"
-)
-
-// InitOpenCode configures mnemo for OpenCode in the given project root.
-//
-// Appends the mnemo protocol section to AGENTS.md. Hooks for OpenCode are
-// registered globally by install.sh as a TypeScript plugin; they check for
-// the .mnemo marker at runtime.
+// InitOpenCode activates mnemo for OpenCode in the given project root.
+// The OpenCode plugin is installed globally and checks for .mnemo at runtime.
 func InitOpenCode(root string) error {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return fmt.Errorf("opencode init: could not determine HOME: %w", err)
-	}
-
-	pluginsDir := filepath.Join(home, ".config", "opencode", "plugins")
-	required := []string{
-		filepath.Join(pluginsDir, "mnemo.ts"),
-		filepath.Join(pluginsDir, "mnemo-protocol.md"),
-	}
-	for _, path := range required {
-		if _, err := os.Stat(path); err != nil {
-			if os.IsNotExist(err) {
-				return fmt.Errorf("opencode init: required file not found: %s\nRun install.sh --agent=opencode first", path)
-			}
-			return fmt.Errorf("opencode init: stat %s: %w", path, err)
-		}
-	}
-
-	agentsPath := filepath.Join(root, "AGENTS.md")
-	if err := AppendSection(agentsPath, templates.Generic); err != nil {
-		return fmt.Errorf("opencode init: AGENTS.md: %w", err)
-	}
 	return AddAgent(root, "opencode")
 }

--- a/internal/agentinit/windsurf.go
+++ b/internal/agentinit/windsurf.go
@@ -1,61 +1,7 @@
 package agentinit
 
-import (
-	"encoding/json"
-	"fmt"
-	"os"
-	"path/filepath"
-
-	"github.com/jmeiracorbal/mnemo/templates"
-)
-
-// InitWindsurf configures mnemo for Windsurf in the given project root.
-//
-// Writes .windsurf/hooks.json referencing the global hook scripts and
-// .windsurf/rules/mnemo.md with the mnemo protocol.
+// InitWindsurf activates mnemo for Windsurf in the given project root.
+// Global hooks and instructions check for .mnemo at runtime.
 func InitWindsurf(root string) error {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return fmt.Errorf("windsurf init: could not determine HOME: %w", err)
-	}
-
-	hooksDir := filepath.Join(home, ".codeium", "windsurf", "hooks")
-	prePrompt := filepath.Join(hooksDir, "pre-user-prompt.sh")
-	postCascade := filepath.Join(hooksDir, "post-cascade-response.sh")
-
-	if _, err := os.Stat(prePrompt); err != nil {
-		if os.IsNotExist(err) {
-			return fmt.Errorf("windsurf init: hook script not found: %s\nRun install.sh --agent=windsurf first", prePrompt)
-		}
-		return fmt.Errorf("windsurf init: stat %s: %w", prePrompt, err)
-	}
-	if _, err := os.Stat(postCascade); err != nil {
-		if os.IsNotExist(err) {
-			return fmt.Errorf("windsurf init: hook script not found: %s\nRun install.sh --agent=windsurf first", postCascade)
-		}
-		return fmt.Errorf("windsurf init: stat %s: %w", postCascade, err)
-	}
-
-	hooksData := map[string]any{
-		"hooks": map[string]any{
-			"pre_user_prompt":                       []map[string]string{{"command": prePrompt}},
-			"post_cascade_response_with_transcript": []map[string]string{{"command": postCascade}},
-		},
-	}
-	hooksJSON, err := json.MarshalIndent(hooksData, "", "  ")
-	if err != nil {
-		return fmt.Errorf("windsurf init: marshal hooks.json: %w", err)
-	}
-
-	hooksPath := filepath.Join(root, ".windsurf", "hooks.json")
-	if err := WriteFile(hooksPath, append(hooksJSON, '\n')); err != nil {
-		return fmt.Errorf("windsurf init: .windsurf/hooks.json: %w", err)
-	}
-
-	rulesPath := filepath.Join(root, ".windsurf", "rules", "mnemo.md")
-	if err := WriteFile(rulesPath, []byte(templates.Windsurf)); err != nil {
-		return fmt.Errorf("windsurf init: .windsurf/rules/mnemo.md: %w", err)
-	}
-
 	return AddAgent(root, "windsurf")
 }

--- a/templates/rules/cursor-global.mdc
+++ b/templates/rules/cursor-global.mdc
@@ -1,0 +1,18 @@
+---
+description: mnemo persistent memory protocol
+alwaysApply: true
+---
+
+## mnemo
+
+In repositories initialized with mnemo (a valid `.mnemo` file exists at the project root), mnemo is the ONLY persistent memory system for that project.
+
+When `.mnemo` exists and contains a non-empty `id`:
+- Use mnemo MCP tools: `mem_save`, `mem_search`, `mem_context`, `mem_session_summary`, and related mnemo tools.
+- Load and follow the `mnemo-memory` skill when it is available.
+- Never use native agent memory, `MEMORY.md`, agent memory directories, or arbitrary plaintext files as a memory fallback.
+- Call `mem_context` when starting work or recovering context.
+- Call `mem_save` immediately after decisions, bug fixes, conventions, discoveries, patterns, preferences, or non-obvious implementation details.
+- Call `mem_session_summary` before any response that ends or completes the session.
+
+If `.mnemo` is missing, malformed, or has no `id`, skip mnemo entirely for that project and do not create fallback memory files.

--- a/templates/rules/global.md
+++ b/templates/rules/global.md
@@ -1,0 +1,13 @@
+## mnemo
+
+In repositories initialized with mnemo (a valid `.mnemo` file exists at the project root), mnemo is the ONLY persistent memory system for that project.
+
+When `.mnemo` exists and contains a non-empty `id`:
+- Use mnemo MCP tools: `mem_save`, `mem_search`, `mem_context`, `mem_session_summary`, and related mnemo tools.
+- Load and follow the `mnemo-memory` skill when it is available.
+- Never use native agent memory, `MEMORY.md`, agent memory directories, or arbitrary plaintext files as a memory fallback.
+- Call `mem_context` when starting work or recovering context.
+- Call `mem_save` immediately after decisions, bug fixes, conventions, discoveries, patterns, preferences, or non-obvious implementation details.
+- Call `mem_session_summary` before any response that ends or completes the session.
+
+If `.mnemo` is missing, malformed, or has no `id`, skip mnemo entirely for that project and do not create fallback memory files.

--- a/templates/templates.go
+++ b/templates/templates.go
@@ -13,3 +13,9 @@ var Cursor string
 
 //go:embed rules/windsurf.md
 var Windsurf string
+
+//go:embed rules/global.md
+var Global string
+
+//go:embed rules/cursor-global.mdc
+var CursorGlobal string


### PR DESCRIPTION
## Summary
- install mnemo agent instructions in global agent surfaces
- make project init marker-only via .mnemo
- add tests for global instructions and clean project init

## Verification
- bash -n install.sh
- go test ./...
- go build ./...
- govulncheck -scan module

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `mnemo install-instructions` to install global agent instructions.
  * Installers now automatically detect supported agents by default.
  * Project activation now uses a `.mnemo` marker and conditional global integrations.
  * Added persistent memory guidance that skips mnemo when the marker is missing or invalid.

* **Documentation**
  * Updated CLI help, setup, verification, and idempotency instructions for the new workflow.

* **Tests**
  * Added coverage for global instruction installation, marker behavior, and preservation of existing content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->