### PR TITLE
Add mnemo doctor diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ claude mcp add -s user mnemo-admin -- ~/.local/bin/mnemo mcp --tools=admin
 mnemo mcp [--tools=PROFILE]          Start MCP server (stdio)
 mnemo init [--agent=AGENT]           Activate mnemo in the current project (.mnemo)
 mnemo install-instructions [--agent=AGENT]  Install global agent instructions
+mnemo doctor [--json] [--agent=AGENT] [--path=DIR]  Run read-only diagnostics
 mnemo save <title> <content>         Save a memory
 mnemo search <query>                 Search memories
 mnemo context [project]              Show context from previous sessions
@@ -331,9 +332,12 @@ ls -l ~/.claude/skills/mnemo-memory \
 
 Only symlinks for agent-specific consumers selected during `npx skills add` are expected to exist. Codex and Cursor use the canonical `.agents/skills` path directly.
 
-After running the installer, check global agent files exist; after `mnemo init`, check only the project marker:
+After running the installer, use `mnemo doctor` for a read-only health check. You can also inspect the files manually:
 
 ```bash
+mnemo doctor --agent=all --path=.
+mnemo doctor --json --agent=codex --path=.
+
 # Project activation
 cat .mnemo                          # must contain id + agents list
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,29 +4,6 @@ This document tracks planned capabilities that are not yet released. Released be
 
 ## Diagnostics
 
-### mnemo doctor
-
-Add read-only operational diagnostics for mnemo installations.
-
-Planned checks:
-
-- project `.mnemo` marker exists, parses, and contains a non-empty `id`;
-- `mnemo` binary is available on `PATH` for agent/plugin integrations;
-- global agent instructions are installed for selected agents;
-- MCP configuration exists and points to `mnemo mcp --tools=agent`;
-- global hook/plugin files exist and are executable where relevant;
-- SQLite store opens successfully and exposes basic stats;
-- output supports both human-readable text and a stable JSON envelope.
-
-Target CLI shape:
-
-```bash
-mnemo doctor
-mnemo doctor --json
-mnemo doctor --agent=codex
-mnemo doctor --path=.
-```
-
 ### mnemo setup status
 
 Add a global setup status command that reports detected and configured agent integrations without performing repairs.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,10 +1,98 @@
 # Roadmap
 
-This file tracks planned capabilities that are not yet released. Released behavior belongs in release notes, not here.
+This document tracks planned capabilities that are not yet released. Released behavior belongs in release notes, not here.
 
-## mnemo-curate
+## Diagnostics
 
-Add a separate, explicitly invoked Agent Skill for memory maintenance. It should use the admin and tag-management tools without expanding the normal `mnemo-memory` workflow.
+### mnemo doctor
+
+Add read-only operational diagnostics for mnemo installations.
+
+Planned checks:
+
+- project `.mnemo` marker exists, parses, and contains a non-empty `id`;
+- `mnemo` binary is available on `PATH` for agent/plugin integrations;
+- global agent instructions are installed for selected agents;
+- MCP configuration exists and points to `mnemo mcp --tools=agent`;
+- global hook/plugin files exist and are executable where relevant;
+- SQLite store opens successfully and exposes basic stats;
+- output supports both human-readable text and a stable JSON envelope.
+
+Target CLI shape:
+
+```bash
+mnemo doctor
+mnemo doctor --json
+mnemo doctor --agent=codex
+mnemo doctor --path=.
+```
+
+### mnemo setup status
+
+Add a global setup status command that reports detected and configured agent integrations without performing repairs.
+
+Target output shape:
+
+```text
+Agent       Detected  MCP  Hooks  Instructions
+Claude      yes       yes  yes    yes
+Codex       yes       yes  yes    yes
+Cursor      yes       yes  yes    yes
+OpenCode    no        no   no     no
+```
+
+## Setup lifecycle
+
+Add explicit setup maintenance commands for global agent integrations:
+
+```bash
+mnemo setup refresh --agent=all
+mnemo setup uninstall --agent=codex
+mnemo setup print-config codex
+```
+
+Goals:
+
+- refresh previously installed global files after upgrades;
+- uninstall mnemo from selected agents without removing the local database;
+- print target-specific MCP/config snippets for manual setup and debugging.
+
+## Project management
+
+Add project management commands for UUID-based projects:
+
+```bash
+mnemo projects list
+mnemo projects prune
+mnemo projects merge <from> <to>
+mnemo projects rename <id> <name>
+```
+
+Goals:
+
+- make old or unused project records visible;
+- provide safe cleanup for stale projects;
+- support explicit consolidation when project identity changes.
+
+## Local sync
+
+Expose local/Git-friendly sync flows before introducing any cloud replication:
+
+```bash
+mnemo sync export
+mnemo sync import
+mnemo sync status
+```
+
+Goals:
+
+- share project-scoped memory across machines through version-controlled chunks;
+- keep local SQLite as the source of truth;
+- avoid merge conflicts and large generated files.
+
+## Memory curation
+
+Add a separate, explicitly invoked Agent Skill for memory maintenance. It should use admin and tag-management tools without expanding the normal `mnemo-memory` workflow.
 
 Planned responsibilities:
 
@@ -17,9 +105,27 @@ Planned responsibilities:
 
 The skill must require a valid `.mnemo` marker, default to read-only analysis, and request explicit confirmation before deletion or broad mutation.
 
-## mnemo-trace
+## Memory conflicts and review
 
-Add project trace related with the agent session before action will be excecuted to inspect that commands will be related with a agent's actions.
+Add higher-level review tools for memory quality:
 
-- relate commands and actions with a project.
-- commands executed for every project.
+- compare possibly related memories;
+- surface contradictory decisions or stale patterns;
+- mark observations as reviewed;
+- identify topic keys that should be consolidated.
+
+## Agent trace
+
+Add optional project trace metadata related to agent sessions and command execution.
+
+Goals:
+
+- relate commands and actions to a project and session;
+- record commands executed for each project;
+- use trace data to improve passive capture and debugging.
+
+## Later-stage ideas
+
+- terminal UI for memory browsing and curation;
+- optional cloud replication after local sync is mature;
+- Obsidian/Markdown export for human review.

--- a/cmd/mnemo/doctor.go
+++ b/cmd/mnemo/doctor.go
@@ -1,0 +1,433 @@
+package main
+
+import (
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/jmeiracorbal/mnemo/internal/agentinit"
+	_ "modernc.org/sqlite"
+)
+
+type doctorOptions struct {
+	JSON    bool
+	Agent   string
+	Path    string
+	Home    string
+	DataDir string
+}
+
+type doctorReport struct {
+	Status      string        `json:"status"`
+	ProjectRoot string        `json:"project_root"`
+	Agent       string        `json:"agent"`
+	Summary     doctorSummary `json:"summary"`
+	Checks      []doctorCheck `json:"checks"`
+}
+
+type doctorSummary struct {
+	Total    int `json:"total"`
+	OK       int `json:"ok"`
+	Warnings int `json:"warnings"`
+	Errors   int `json:"errors"`
+}
+
+type doctorCheck struct {
+	ID       string            `json:"id"`
+	Status   string            `json:"status"`
+	Severity string            `json:"severity"`
+	Message  string            `json:"message"`
+	Agent    string            `json:"agent,omitempty"`
+	Path     string            `json:"path,omitempty"`
+	Details  map[string]string `json:"details,omitempty"`
+}
+
+func runDoctor() {
+	opts := parseDoctorArgs(os.Args[2:])
+	report := buildDoctorReport(opts)
+
+	if opts.JSON {
+		out, err := json.MarshalIndent(report, "", "  ")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "mnemo doctor: json: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Println(string(out))
+	} else {
+		printDoctorReport(report)
+	}
+
+	if report.Status == "error" {
+		os.Exit(1)
+	}
+}
+
+func parseDoctorArgs(args []string) doctorOptions {
+	opts := doctorOptions{Agent: "all", Path: "."}
+	for _, arg := range args {
+		switch {
+		case arg == "--json":
+			opts.JSON = true
+		case strings.HasPrefix(arg, "--agent="):
+			opts.Agent = strings.TrimSpace(arg[len("--agent="):])
+		case strings.HasPrefix(arg, "--path="):
+			opts.Path = arg[len("--path="):]
+		case strings.HasPrefix(arg, "--home="):
+			opts.Home = arg[len("--home="):]
+		case strings.HasPrefix(arg, "--data-dir="):
+			opts.DataDir = arg[len("--data-dir="):]
+		}
+	}
+	if opts.Agent == "" {
+		opts.Agent = "all"
+	}
+	if opts.Path == "" {
+		opts.Path = "."
+	}
+	return opts
+}
+
+func buildDoctorReport(opts doctorOptions) doctorReport {
+	report := doctorReport{Status: "ok", Agent: opts.Agent}
+	absPath, err := filepath.Abs(opts.Path)
+	if err != nil {
+		report.addCheck(errorCheck("project_path", "resolve project path: "+err.Error(), opts.Path))
+	} else {
+		report.ProjectRoot = agentinit.ProjectRoot(absPath)
+		report.addCheck(okCheck("project_path", "project path resolved", report.ProjectRoot))
+		report.addCheck(checkProjectMarker(report.ProjectRoot))
+	}
+
+	home := opts.Home
+	if home == "" {
+		resolved, err := os.UserHomeDir()
+		if err != nil {
+			report.addCheck(errorCheck("home", "resolve home directory: "+err.Error(), ""))
+		} else {
+			home = resolved
+			report.addCheck(okCheck("home", "home directory resolved", home))
+		}
+	} else {
+		report.addCheck(okCheck("home", "home directory override provided", home))
+	}
+
+	report.addCheck(checkBinaryOnPath())
+
+	if home != "" {
+		agents, err := agentinit.ExpandAgents(opts.Agent)
+		if err != nil {
+			report.addCheck(errorCheck("agent", err.Error(), opts.Agent))
+		} else {
+			for _, agent := range agents {
+				report.addCheck(checkGlobalInstructions(home, agent))
+				report.addCheck(checkMCPConfig(home, agent))
+				if check := checkAgentRuntimeFiles(home, agent); check.ID != "" {
+					report.addCheck(check)
+				}
+			}
+		}
+	}
+
+	if opts.DataDir == "" && home != "" {
+		opts.DataDir = filepath.Join(home, ".mnemo")
+	}
+	if opts.DataDir != "" {
+		report.addCheck(checkStoreReadOnly(opts.DataDir))
+	}
+
+	report.finalize()
+	return report
+}
+
+func (r *doctorReport) addCheck(check doctorCheck) {
+	r.Checks = append(r.Checks, check)
+}
+
+func (r *doctorReport) finalize() {
+	for _, check := range r.Checks {
+		r.Summary.Total++
+		switch check.Status {
+		case "ok":
+			r.Summary.OK++
+		case "warning":
+			r.Summary.Warnings++
+		case "error":
+			r.Summary.Errors++
+		}
+	}
+	if r.Summary.Errors > 0 {
+		r.Status = "error"
+	} else if r.Summary.Warnings > 0 {
+		r.Status = "warning"
+	} else {
+		r.Status = "ok"
+	}
+}
+
+func printDoctorReport(report doctorReport) {
+	fmt.Printf("mnemo doctor: %s (%d ok, %d warnings, %d errors)\n", report.Status, report.Summary.OK, report.Summary.Warnings, report.Summary.Errors)
+	if report.ProjectRoot != "" {
+		fmt.Printf("project: %s\n", report.ProjectRoot)
+	}
+	fmt.Println()
+	for _, check := range report.Checks {
+		marker := "✓"
+		if check.Status == "warning" {
+			marker = "!"
+		} else if check.Status == "error" {
+			marker = "✗"
+		}
+		suffix := ""
+		if check.Agent != "" {
+			suffix += " [" + check.Agent + "]"
+		}
+		if check.Path != "" {
+			suffix += " " + check.Path
+		}
+		fmt.Printf("%s %-8s %s%s\n", marker, check.Status, check.Message, suffix)
+	}
+}
+
+func okCheck(id, message, path string) doctorCheck {
+	return doctorCheck{ID: id, Status: "ok", Severity: "info", Message: message, Path: path}
+}
+
+func warningCheck(id, message, path string) doctorCheck {
+	return doctorCheck{ID: id, Status: "warning", Severity: "warning", Message: message, Path: path}
+}
+
+func errorCheck(id, message, path string) doctorCheck {
+	return doctorCheck{ID: id, Status: "error", Severity: "error", Message: message, Path: path}
+}
+
+func checkProjectMarker(root string) doctorCheck {
+	path := filepath.Join(root, ".mnemo")
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return warningCheck("project_marker", ".mnemo not found; run mnemo init to activate this project", path)
+	}
+	if err != nil {
+		return errorCheck("project_marker", "read .mnemo: "+err.Error(), path)
+	}
+	var marker agentinit.Marker
+	if err := json.Unmarshal(data, &marker); err != nil {
+		return errorCheck("project_marker", "malformed .mnemo: "+err.Error(), path)
+	}
+	if strings.TrimSpace(marker.ID) == "" {
+		return errorCheck("project_marker", ".mnemo has no project id", path)
+	}
+	return doctorCheck{ID: "project_marker", Status: "ok", Severity: "info", Message: ".mnemo marker is valid", Path: path, Details: map[string]string{"id": marker.ID, "agents": strings.Join(marker.Agents, ",")}}
+}
+
+func checkBinaryOnPath() doctorCheck {
+	path, err := exec.LookPath("mnemo")
+	if err != nil {
+		return warningCheck("binary_path", "mnemo binary is not available on PATH; plugin integrations may fail", "")
+	}
+	return okCheck("binary_path", "mnemo binary found on PATH", path)
+}
+
+func checkGlobalInstructions(home, agent string) doctorCheck {
+	path, err := agentinit.GlobalInstructionPath(home, agent)
+	if err != nil {
+		return errorCheck("global_instructions."+agent, err.Error(), "")
+	}
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return agentWarning(agent, "global_instructions."+agent, "global instructions not found", path)
+	}
+	if err != nil {
+		return agentError(agent, "global_instructions."+agent, "read global instructions: "+err.Error(), path)
+	}
+	content := string(data)
+	if !strings.Contains(content, ".mnemo") || !strings.Contains(content, "ONLY persistent memory system") {
+		return agentWarning(agent, "global_instructions."+agent, "global instructions do not look like mnemo instructions", path)
+	}
+	if agent != "cursor" && (!strings.Contains(content, "<!-- mnemo:start -->") || !strings.Contains(content, "<!-- mnemo:end -->")) {
+		return agentWarning(agent, "global_instructions."+agent, "global instructions are missing mnemo managed markers", path)
+	}
+	return agentOK(agent, "global_instructions."+agent, "global instructions installed", path)
+}
+
+func checkMCPConfig(home, agent string) doctorCheck {
+	switch agent {
+	case "claudecode":
+		path := filepath.Join(home, ".claude", ".mcp.json")
+		return checkJSONHas(path, "mcp_config."+agent, agent, "mcpServers", "mnemo")
+	case "cursor":
+		path := filepath.Join(home, ".cursor", "mcp.json")
+		return checkJSONHas(path, "mcp_config."+agent, agent, "mcpServers", "mnemo")
+	case "windsurf":
+		path := filepath.Join(home, ".codeium", "windsurf", "mcp_config.json")
+		return checkJSONHas(path, "mcp_config."+agent, agent, "mcpServers", "mnemo")
+	case "codex":
+		path := filepath.Join(home, ".codex", "config.toml")
+		data, err := os.ReadFile(path)
+		if errors.Is(err, os.ErrNotExist) {
+			return agentWarning(agent, "mcp_config."+agent, "MCP config not found", path)
+		}
+		if err != nil {
+			return agentError(agent, "mcp_config."+agent, "read MCP config: "+err.Error(), path)
+		}
+		content := string(data)
+		if !strings.Contains(content, "[mcp_servers.mnemo]") || !strings.Contains(content, "mcp") {
+			return agentWarning(agent, "mcp_config."+agent, "MCP config does not contain mnemo server", path)
+		}
+		return agentOK(agent, "mcp_config."+agent, "MCP config contains mnemo server", path)
+	case "opencode":
+		path := filepath.Join(home, ".config", "opencode", "opencode.json")
+		return checkJSONHas(path, "mcp_config."+agent, agent, "mcp", "mnemo")
+	default:
+		return agentError(agent, "mcp_config."+agent, "unknown agent", "")
+	}
+}
+
+func checkAgentRuntimeFiles(home, agent string) doctorCheck {
+	switch agent {
+	case "cursor":
+		paths := []string{
+			filepath.Join(home, ".cursor", "hooks.json"),
+			filepath.Join(home, ".cursor", "hooks", "before-submit-prompt.sh"),
+			filepath.Join(home, ".cursor", "hooks", "stop.sh"),
+		}
+		return checkFiles(agent, "runtime_files."+agent, "Cursor global hooks installed", paths, true)
+	case "windsurf":
+		paths := []string{
+			filepath.Join(home, ".codeium", "windsurf", "hooks.json"),
+			filepath.Join(home, ".codeium", "windsurf", "hooks", "pre-user-prompt.sh"),
+			filepath.Join(home, ".codeium", "windsurf", "hooks", "post-cascade-response.sh"),
+		}
+		return checkFiles(agent, "runtime_files."+agent, "Windsurf global hooks installed", paths, true)
+	case "codex":
+		paths := []string{
+			filepath.Join(home, ".codex", "hooks.json"),
+			filepath.Join(home, ".codex", "hooks", "session-start.sh"),
+			filepath.Join(home, ".codex", "hooks", "stop.sh"),
+			filepath.Join(home, ".codex", "hooks", "mnemo-protocol.md"),
+		}
+		return checkFiles(agent, "runtime_files."+agent, "Codex global hooks installed", paths, true)
+	case "opencode":
+		paths := []string{
+			filepath.Join(home, ".config", "opencode", "plugins", "mnemo.ts"),
+			filepath.Join(home, ".config", "opencode", "plugins", "mnemo-protocol.md"),
+		}
+		return checkFiles(agent, "runtime_files."+agent, "OpenCode plugin files installed", paths, false)
+	default:
+		return doctorCheck{}
+	}
+}
+
+func checkFiles(agent, id, okMessage string, paths []string, executableScripts bool) doctorCheck {
+	missing := []string{}
+	notExecutable := []string{}
+	for _, path := range paths {
+		info, err := os.Stat(path)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				missing = append(missing, path)
+				continue
+			}
+			return agentError(agent, id, "stat runtime file: "+err.Error(), path)
+		}
+		if info.IsDir() {
+			missing = append(missing, path)
+			continue
+		}
+		if executableScripts && strings.HasSuffix(path, ".sh") && info.Mode()&0111 == 0 {
+			notExecutable = append(notExecutable, path)
+		}
+	}
+	if len(missing) > 0 || len(notExecutable) > 0 {
+		details := map[string]string{}
+		if len(missing) > 0 {
+			details["missing"] = strings.Join(missing, ",")
+		}
+		if len(notExecutable) > 0 {
+			details["not_executable"] = strings.Join(notExecutable, ",")
+		}
+		return doctorCheck{ID: id, Status: "warning", Severity: "warning", Agent: agent, Message: "runtime files are incomplete", Details: details}
+	}
+	return agentOK(agent, id, okMessage, strings.Join(paths, ","))
+}
+
+func checkJSONHas(path, id, agent string, keys ...string) doctorCheck {
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return agentWarning(agent, id, "MCP config not found", path)
+	}
+	if err != nil {
+		return agentError(agent, id, "read MCP config: "+err.Error(), path)
+	}
+	var raw any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return agentError(agent, id, "parse MCP config JSON: "+err.Error(), path)
+	}
+	if !jsonPathExists(raw, keys...) {
+		return agentWarning(agent, id, "MCP config does not contain mnemo server", path)
+	}
+	return agentOK(agent, id, "MCP config contains mnemo server", path)
+}
+
+func jsonPathExists(v any, keys ...string) bool {
+	current := v
+	for _, key := range keys {
+		m, ok := current.(map[string]any)
+		if !ok {
+			return false
+		}
+		current, ok = m[key]
+		if !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func checkStoreReadOnly(dataDir string) doctorCheck {
+	dbPath := filepath.Join(dataDir, "memory.db")
+	if _, err := os.Stat(dbPath); errors.Is(err, os.ErrNotExist) {
+		return warningCheck("store", "memory database not found yet", dbPath)
+	} else if err != nil {
+		return errorCheck("store", "stat memory database: "+err.Error(), dbPath)
+	}
+	db, err := sql.Open("sqlite", "file:"+filepath.ToSlash(dbPath)+"?mode=ro")
+	if err != nil {
+		return errorCheck("store", "open memory database read-only: "+err.Error(), dbPath)
+	}
+	defer db.Close()
+	if err := db.Ping(); err != nil {
+		return errorCheck("store", "ping memory database read-only: "+err.Error(), dbPath)
+	}
+	counts := map[string]string{}
+	for _, table := range []string{"sessions", "observations", "user_prompts"} {
+		var count int
+		if err := db.QueryRow("SELECT COUNT(*) FROM " + table).Scan(&count); err != nil {
+			return errorCheck("store", "query "+table+": "+err.Error(), dbPath)
+		}
+		counts[table] = fmt.Sprintf("%d", count)
+	}
+	return doctorCheck{ID: "store", Status: "ok", Severity: "info", Message: "memory database opens read-only", Path: dbPath, Details: counts}
+}
+
+func agentOK(agent, id, message, path string) doctorCheck {
+	check := okCheck(id, message, path)
+	check.Agent = agent
+	return check
+}
+
+func agentWarning(agent, id, message, path string) doctorCheck {
+	check := warningCheck(id, message, path)
+	check.Agent = agent
+	return check
+}
+
+func agentError(agent, id, message, path string) doctorCheck {
+	check := errorCheck(id, message, path)
+	check.Agent = agent
+	return check
+}

--- a/cmd/mnemo/doctor.go
+++ b/cmd/mnemo/doctor.go
@@ -177,9 +177,10 @@ func printDoctorReport(report doctorReport) {
 	fmt.Println()
 	for _, check := range report.Checks {
 		marker := "✓"
-		if check.Status == "warning" {
+		switch check.Status {
+		case "warning":
 			marker = "!"
-		} else if check.Status == "error" {
+		case "error":
 			marker = "✗"
 		}
 		suffix := ""
@@ -395,23 +396,34 @@ func checkStoreReadOnly(dataDir string) doctorCheck {
 	} else if err != nil {
 		return errorCheck("store", "stat memory database: "+err.Error(), dbPath)
 	}
-	db, err := sql.Open("sqlite", "file:"+filepath.ToSlash(dbPath)+"?mode=ro")
+	db, err := sql.Open("sqlite", sqliteReadOnlyDBURI(dbPath))
 	if err != nil {
 		return errorCheck("store", "open memory database read-only: "+err.Error(), dbPath)
 	}
-	defer db.Close()
+	defer func() {
+		_ = db.Close()
+	}()
 	if err := db.Ping(); err != nil {
 		return errorCheck("store", "ping memory database read-only: "+err.Error(), dbPath)
 	}
 	counts := map[string]string{}
-	for _, table := range []string{"sessions", "observations", "user_prompts"} {
+	queries := map[string]string{
+		"sessions":     "SELECT COUNT(*) FROM sessions",
+		"observations": "SELECT COUNT(*) FROM observations",
+		"user_prompts": "SELECT COUNT(*) FROM user_prompts",
+	}
+	for table, query := range queries {
 		var count int
-		if err := db.QueryRow("SELECT COUNT(*) FROM " + table).Scan(&count); err != nil {
+		if err := db.QueryRow(query).Scan(&count); err != nil {
 			return errorCheck("store", "query "+table+": "+err.Error(), dbPath)
 		}
 		counts[table] = fmt.Sprintf("%d", count)
 	}
 	return doctorCheck{ID: "store", Status: "ok", Severity: "info", Message: "memory database opens read-only", Path: dbPath, Details: counts}
+}
+
+func sqliteReadOnlyDBURI(dbPath string) string {
+	return "file:" + filepath.ToSlash(dbPath) + "?mode=ro&immutable=1"
 }
 
 func agentOK(agent, id, message, path string) doctorCheck {

--- a/cmd/mnemo/doctor_test.go
+++ b/cmd/mnemo/doctor_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jmeiracorbal/mnemo/internal/agentinit"
+)
+
+func TestParseDoctorArgs(t *testing.T) {
+	opts := parseDoctorArgs([]string{"--json", "--agent=codex", "--path=/repo", "--home=/home/test", "--data-dir=/data"})
+	if !opts.JSON || opts.Agent != "codex" || opts.Path != "/repo" || opts.Home != "/home/test" || opts.DataDir != "/data" {
+		t.Fatalf("unexpected options: %+v", opts)
+	}
+}
+
+func TestBuildDoctorReportChecksCodexGlobalInstall(t *testing.T) {
+	home := t.TempDir()
+	project := t.TempDir()
+	dataDir := t.TempDir()
+
+	if err := agentinit.EnsureMarkerWithID(project, "project-123"); err != nil {
+		t.Fatalf("marker: %v", err)
+	}
+	if _, err := agentinit.InstallGlobalInstructions(home, "codex"); err != nil {
+		t.Fatalf("install instructions: %v", err)
+	}
+	writeFile(t, filepath.Join(home, ".codex", "config.toml"), "[mcp_servers.mnemo]\ncommand = \"mnemo\"\nargs = [\"mcp\", \"--tools=agent\"]\n")
+	writeFile(t, filepath.Join(home, ".codex", "hooks.json"), `{"hooks":{"SessionStart":[],"Stop":[]}}`)
+	writeExecutable(t, filepath.Join(home, ".codex", "hooks", "session-start.sh"))
+	writeExecutable(t, filepath.Join(home, ".codex", "hooks", "stop.sh"))
+	writeFile(t, filepath.Join(home, ".codex", "hooks", "mnemo-protocol.md"), "protocol")
+
+	report := buildDoctorReport(doctorOptions{Agent: "codex", Path: project, Home: home, DataDir: dataDir})
+
+	assertCheckStatus(t, report, "project_marker", "ok")
+	assertCheckStatus(t, report, "global_instructions.codex", "ok")
+	assertCheckStatus(t, report, "mcp_config.codex", "ok")
+	assertCheckStatus(t, report, "runtime_files.codex", "ok")
+}
+
+func TestBuildDoctorReportWarnsWhenProjectMarkerMissing(t *testing.T) {
+	home := t.TempDir()
+	project := t.TempDir()
+	report := buildDoctorReport(doctorOptions{Agent: "codex", Path: project, Home: home, DataDir: t.TempDir()})
+	assertCheckStatus(t, report, "project_marker", "warning")
+}
+
+func assertCheckStatus(t *testing.T, report doctorReport, id, want string) {
+	t.Helper()
+	for _, check := range report.Checks {
+		if check.ID == id {
+			if check.Status != want {
+				t.Fatalf("check %s status = %q, want %q (message: %s)", id, check.Status, want, check.Message)
+			}
+			return
+		}
+	}
+	t.Fatalf("check %s not found in %+v", id, report.Checks)
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeExecutable(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/cmd/mnemo/doctor_test.go
+++ b/cmd/mnemo/doctor_test.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"database/sql"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/jmeiracorbal/mnemo/internal/agentinit"
@@ -47,6 +49,50 @@ func TestBuildDoctorReportWarnsWhenProjectMarkerMissing(t *testing.T) {
 	assertCheckStatus(t, report, "project_marker", "warning")
 }
 
+func TestCheckStoreReadOnlyUsesWALSafeImmutableURI(t *testing.T) {
+	dataDir := t.TempDir()
+	dbPath := filepath.Join(dataDir, "memory.db")
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if _, err := db.Exec("PRAGMA journal_mode = WAL"); err != nil {
+		closeTestDB(t, db)
+		t.Fatalf("enable WAL: %v", err)
+	}
+	for _, query := range []string{
+		"CREATE TABLE sessions (id TEXT)",
+		"CREATE TABLE observations (id TEXT)",
+		"CREATE TABLE user_prompts (id TEXT)",
+		"PRAGMA wal_checkpoint(FULL)",
+	} {
+		if _, err := db.Exec(query); err != nil {
+			closeTestDB(t, db)
+			t.Fatalf("exec %q: %v", query, err)
+		}
+	}
+	closeTestDB(t, db)
+
+	uri := sqliteReadOnlyDBURI(dbPath)
+	if !strings.Contains(uri, "mode=ro") || !strings.Contains(uri, "immutable=1") {
+		t.Fatalf("read-only URI is not WAL-safe: %s", uri)
+	}
+
+	if err := os.Chmod(dataDir, 0555); err != nil {
+		t.Fatalf("chmod read-only dir: %v", err)
+	}
+	defer func() {
+		if err := os.Chmod(dataDir, 0755); err != nil {
+			t.Fatalf("restore dir permissions: %v", err)
+		}
+	}()
+
+	check := checkStoreReadOnly(dataDir)
+	if check.Status != "ok" {
+		t.Fatalf("store check status = %q, want ok (message: %s)", check.Status, check.Message)
+	}
+}
+
 func assertCheckStatus(t *testing.T, report doctorReport, id, want string) {
 	t.Helper()
 	for _, check := range report.Checks {
@@ -77,5 +123,12 @@ func writeExecutable(t *testing.T, path string) {
 	}
 	if err := os.WriteFile(path, []byte("#!/bin/sh\n"), 0755); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func closeTestDB(t *testing.T, db *sql.DB) {
+	t.Helper()
+	if err := db.Close(); err != nil {
+		t.Fatalf("close sqlite: %v", err)
 	}
 }

--- a/cmd/mnemo/doctor_test.go
+++ b/cmd/mnemo/doctor_test.go
@@ -81,11 +81,11 @@ func TestCheckStoreReadOnlyUsesWALSafeImmutableURI(t *testing.T) {
 	if err := os.Chmod(dataDir, 0555); err != nil {
 		t.Fatalf("chmod read-only dir: %v", err)
 	}
-	defer func() {
+	t.Cleanup(func() {
 		if err := os.Chmod(dataDir, 0755); err != nil {
-			t.Fatalf("restore dir permissions: %v", err)
+			t.Errorf("restore dir permissions: %v", err)
 		}
-	}()
+	})
 
 	check := checkStoreReadOnly(dataDir)
 	if check.Status != "ok" {
@@ -129,6 +129,6 @@ func writeExecutable(t *testing.T, path string) {
 func closeTestDB(t *testing.T, db *sql.DB) {
 	t.Helper()
 	if err := db.Close(); err != nil {
-		t.Fatalf("close sqlite: %v", err)
+		t.Errorf("close sqlite: %v", err)
 	}
 }

--- a/cmd/mnemo/main.go
+++ b/cmd/mnemo/main.go
@@ -50,6 +50,9 @@ func main() {
 	case "install-instructions":
 		runInstallInstructions()
 		return
+	case "doctor":
+		runDoctor()
+		return
 	case "--version", "version":
 		fmt.Printf("mnemo %s\n", version)
 		return

--- a/cmd/mnemo/plugin_integrity_test.go
+++ b/cmd/mnemo/plugin_integrity_test.go
@@ -114,6 +114,7 @@ func TestShippedMnemoMemorySkill(t *testing.T) {
 		"non-empty `id`",
 		"Never create `MEMORY.md`",
 		"`mem_session_summary`",
+		"mnemo doctor",
 	}
 	for _, value := range required {
 		if !strings.Contains(content, value) {

--- a/cmd/mnemo/templates/usage.txt
+++ b/cmd/mnemo/templates/usage.txt
@@ -11,6 +11,7 @@ Usage:
   mnemo export [file]                  Export all memories to JSON
   mnemo import <file.json>             Import memories from JSON
   mnemo capture <content>|-            Extract learnings from text (passive capture; "-" reads stdin)
+  mnemo doctor [--json] [--agent=AGENT] [--path=DIR]  Run read-only diagnostics
   mnemo init [--agent=AGENT] [--path=DIR]  Activate mnemo in the current project (.mnemo)
   mnemo install-instructions [--agent=AGENT]  Install global agent instructions
   mnemo migrate [--path=DIR]              Migrate project from legacy key to UUID-based identity
@@ -26,7 +27,13 @@ Agents for init / install-instructions:
   --agent=codex        Codex global AGENTS.md instructions / .mnemo activation
   --agent=opencode     OpenCode global AGENTS.md instructions / .mnemo activation
   --agent=all          All agents
-  --path=DIR           Target project directory for init (default: current directory)
+  --path=DIR           Target project directory for init/doctor (default: current directory)
+
+Doctor options:
+  --json               Emit a stable JSON diagnostic envelope
+  --agent=AGENT        Check one agent or all agents (default: all)
+  --home=DIR           Override home directory for global agent checks
+  --data-dir=DIR       Override mnemo data directory for store checks
 
 Tool profiles for mcp:
   --tools=agent    15 tools for AI agents (default when using plugin)

--- a/skills/mnemo-memory/SKILL.md
+++ b/skills/mnemo-memory/SKILL.md
@@ -18,6 +18,17 @@ Before any memory operation:
 
 If `.mnemo` is missing or invalid, tell the user to run `mnemo init` and stop the memory workflow. If mnemo tools are unavailable, report that integration is incomplete. Never create `MEMORY.md`, write into an agent's native memory directory, or use arbitrary text files as a fallback.
 
+### Troubleshoot integration
+
+When mnemo appears misconfigured, unavailable, or inconsistent with the project marker, prefer the read-only diagnostic command before guessing:
+
+```bash
+mnemo doctor --path <root>
+mnemo doctor --json --path <root>
+```
+
+Use the output to explain missing `.mnemo`, PATH, global instruction, MCP, hook/plugin, or store issues. Do not repair configuration automatically unless the user explicitly asks for setup or install changes.
+
 ## 2. Recover relevant context
 
 - At session start, resume, or after compaction, call `mem_context` before significant work.


### PR DESCRIPTION
## Summary
- add read-only mnemo doctor diagnostics
- document doctor in README, usage, skill, and roadmap
- add doctor tests

## Verification
- go test ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `mnemo doctor` for read-only, project diagnostics (checks project marker, runtime/integration files, MCP configuration, and local memory store accessibility).
  - Supports `--json`, `--agent` selection, project `--path`, and `--home` / `--data-dir` overrides.
- **Documentation**
  - Updated README, CLI usage templates, and ROADMAP with the new diagnostics/setup lifecycle guidance.
  - Expanded mnemo-memory troubleshooting docs to instruct when and how to run `mnemo doctor`.
- **Tests**
  - Added unit tests for `doctor` argument parsing and health-check status cases, including WAL-safe read-only SQLite behavior.
  - Tightened a plugin documentation integrity check to require `mnemo doctor` guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->