### PR TITLE
Add setup status command

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ mnemo mcp [--tools=PROFILE]          Start MCP server (stdio)
 mnemo init [--agent=AGENT]           Activate mnemo in the current project (.mnemo)
 mnemo install-instructions [--agent=AGENT]  Install global agent instructions
 mnemo doctor [--json] [--agent=AGENT] [--path=DIR]  Run read-only diagnostics
-mnemo setup status [--json] [--agent=AGENT]  Show global agent setup status
+mnemo setup status [--json] [--agent=AGENT] [--home=DIR]  Show global agent setup status
 mnemo save <title> <content>         Save a memory
 mnemo search <query>                 Search memories
 mnemo context [project]              Show context from previous sessions

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ mnemo --version
 - **Portable Agent Skill:** teaches compatible agents the complete mnemo workflow without weakening the always-active safety rules
 - **Full CLI:** save, search, export, import, inspect, and diagnose memories from the terminal
 - **Read-only diagnostics:** `mnemo doctor` checks project activation, global agent setup, MCP config, hooks/plugins, and local store health
+- **Setup status:** `mnemo setup status` summarizes detected agent integrations and configured MCP/hooks/instructions without repairing anything
 - **Own storage:** isolated `~/.mnemo/memory.db`, created automatically on first run
 - **Claude Code + Cursor + Windsurf + Codex + OpenCode:** native integration for all five agents via their respective hook systems
 
@@ -262,6 +263,7 @@ mnemo mcp [--tools=PROFILE]          Start MCP server (stdio)
 mnemo init [--agent=AGENT]           Activate mnemo in the current project (.mnemo)
 mnemo install-instructions [--agent=AGENT]  Install global agent instructions
 mnemo doctor [--json] [--agent=AGENT] [--path=DIR]  Run read-only diagnostics
+mnemo setup status [--json] [--agent=AGENT]  Show global agent setup status
 mnemo save <title> <content>         Save a memory
 mnemo search <query>                 Search memories
 mnemo context [project]              Show context from previous sessions
@@ -333,11 +335,12 @@ ls -l ~/.claude/skills/mnemo-memory \
 
 Only symlinks for agent-specific consumers selected during `npx skills add` are expected to exist. Codex and Cursor use the canonical `.agents/skills` path directly.
 
-After running the installer, use `mnemo doctor` for a read-only health check. You can also inspect the files manually:
+After running the installer, use `mnemo doctor` for a read-only health check and `mnemo setup status` for a compact global setup table. `setup status` is read-only: `Detected` means the agent's user-level configuration directory exists, and the other columns report whether mnemo's MCP, hooks/plugin files, and global instructions are configured. You can also inspect the files manually:
 
 ```bash
 mnemo doctor --agent=all --path=.
 mnemo doctor --json --agent=codex --path=.
+mnemo setup status --agent=all
 
 # Project activation
 cat .mnemo                          # must contain id + agents list

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,22 +2,6 @@
 
 This document tracks planned capabilities that are not yet released. Released behavior belongs in release notes, not here.
 
-## Diagnostics
-
-### mnemo setup status
-
-Add a global setup status command that reports detected and configured agent integrations without performing repairs.
-
-Target output shape:
-
-```text
-Agent       Detected  MCP  Hooks  Instructions
-Claude      yes       yes  yes    yes
-Codex       yes       yes  yes    yes
-Cursor      yes       yes  yes    yes
-OpenCode    no        no   no     no
-```
-
 ## Setup lifecycle
 
 Add explicit setup maintenance commands for global agent integrations:

--- a/cmd/mnemo/doctor.go
+++ b/cmd/mnemo/doctor.go
@@ -14,6 +14,11 @@ import (
 	_ "modernc.org/sqlite"
 )
 
+var (
+	errClaudePluginRegistryNotFound = errors.New("claude code plugin registry not found")
+	errClaudeMnemoPluginNotFound    = errors.New("claude code mnemo plugin not found")
+)
+
 type doctorOptions struct {
 	JSON    bool
 	Agent   string
@@ -293,7 +298,11 @@ func checkAgentRuntimeFiles(home, agent string) doctorCheck {
 	case "claudecode":
 		installPath, err := claudeMnemoPluginInstallPath(home)
 		if err != nil {
-			return agentWarning(agent, "runtime_files."+agent, err.Error(), filepath.Join(home, ".claude", "plugins", "installed_plugins.json"))
+			path := filepath.Join(home, ".claude", "plugins", "installed_plugins.json")
+			if errors.Is(err, errClaudePluginRegistryNotFound) || errors.Is(err, errClaudeMnemoPluginNotFound) {
+				return agentWarning(agent, "runtime_files."+agent, err.Error(), path)
+			}
+			return agentError(agent, "runtime_files."+agent, err.Error(), path)
 		}
 		paths := []string{
 			filepath.Join(installPath, ".claude-plugin", "plugin.json"),
@@ -344,22 +353,37 @@ func claudeMnemoPluginInstallPath(home string) (string, error) {
 	path := filepath.Join(home, ".claude", "plugins", "installed_plugins.json")
 	data, err := os.ReadFile(path)
 	if errors.Is(err, os.ErrNotExist) {
-		return "", fmt.Errorf("Claude Code plugin registry not found")
+		return "", errClaudePluginRegistryNotFound
 	}
 	if err != nil {
 		return "", fmt.Errorf("read Claude Code plugin registry: %w", err)
 	}
 	var registry struct {
-		Plugins map[string][]struct {
-			InstallPath string `json:"installPath"`
-		} `json:"plugins"`
+		Plugins map[string]json.RawMessage `json:"plugins"`
 	}
 	if err := json.Unmarshal(data, &registry); err != nil {
 		return "", fmt.Errorf("parse Claude Code plugin registry: %w", err)
 	}
-	entries := registry.Plugins["mnemo@mnemo"]
+	raw, ok := registry.Plugins["mnemo@mnemo"]
+	if !ok {
+		return "", errClaudeMnemoPluginNotFound
+	}
+	var entries []struct {
+		InstallPath string `json:"installPath"`
+	}
+	if err := json.Unmarshal(raw, &entries); err != nil {
+		var entry struct {
+			InstallPath string `json:"installPath"`
+		}
+		if err := json.Unmarshal(raw, &entry); err != nil {
+			return "", fmt.Errorf("parse Claude Code mnemo plugin entry: %w", err)
+		}
+		entries = []struct {
+			InstallPath string `json:"installPath"`
+		}{entry}
+	}
 	if len(entries) == 0 || strings.TrimSpace(entries[0].InstallPath) == "" {
-		return "", fmt.Errorf("Claude Code mnemo plugin not found")
+		return "", errClaudeMnemoPluginNotFound
 	}
 	return entries[0].InstallPath, nil
 }

--- a/cmd/mnemo/doctor.go
+++ b/cmd/mnemo/doctor.go
@@ -290,6 +290,23 @@ func checkMCPConfig(home, agent string) doctorCheck {
 
 func checkAgentRuntimeFiles(home, agent string) doctorCheck {
 	switch agent {
+	case "claudecode":
+		installPath, err := claudeMnemoPluginInstallPath(home)
+		if err != nil {
+			return agentWarning(agent, "runtime_files."+agent, err.Error(), filepath.Join(home, ".claude", "plugins", "installed_plugins.json"))
+		}
+		paths := []string{
+			filepath.Join(installPath, ".claude-plugin", "plugin.json"),
+			filepath.Join(installPath, "hooks", "hooks.json"),
+			filepath.Join(installPath, "scripts", "session-start.sh"),
+			filepath.Join(installPath, "scripts", "session-stop.sh"),
+			filepath.Join(installPath, "scripts", "subagent-stop.sh"),
+			filepath.Join(installPath, "scripts", "post-compact.sh"),
+			filepath.Join(installPath, "scripts", "post-compact-resume.sh"),
+			filepath.Join(installPath, "scripts", "post-file-edit.sh"),
+			filepath.Join(installPath, "scripts", "post-bash-git.sh"),
+		}
+		return checkFiles(agent, "runtime_files."+agent, "Claude Code plugin hooks installed", paths, true)
 	case "cursor":
 		paths := []string{
 			filepath.Join(home, ".cursor", "hooks.json"),
@@ -321,6 +338,30 @@ func checkAgentRuntimeFiles(home, agent string) doctorCheck {
 	default:
 		return doctorCheck{}
 	}
+}
+
+func claudeMnemoPluginInstallPath(home string) (string, error) {
+	path := filepath.Join(home, ".claude", "plugins", "installed_plugins.json")
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return "", fmt.Errorf("Claude Code plugin registry not found")
+	}
+	if err != nil {
+		return "", fmt.Errorf("read Claude Code plugin registry: %w", err)
+	}
+	var registry struct {
+		Plugins map[string][]struct {
+			InstallPath string `json:"installPath"`
+		} `json:"plugins"`
+	}
+	if err := json.Unmarshal(data, &registry); err != nil {
+		return "", fmt.Errorf("parse Claude Code plugin registry: %w", err)
+	}
+	entries := registry.Plugins["mnemo@mnemo"]
+	if len(entries) == 0 || strings.TrimSpace(entries[0].InstallPath) == "" {
+		return "", fmt.Errorf("Claude Code mnemo plugin not found")
+	}
+	return entries[0].InstallPath, nil
 }
 
 func checkFiles(agent, id, okMessage string, paths []string, executableScripts bool) doctorCheck {

--- a/cmd/mnemo/main.go
+++ b/cmd/mnemo/main.go
@@ -53,6 +53,9 @@ func main() {
 	case "doctor":
 		runDoctor()
 		return
+	case "setup":
+		runSetup()
+		return
 	case "--version", "version":
 		fmt.Printf("mnemo %s\n", version)
 		return

--- a/cmd/mnemo/setup_status.go
+++ b/cmd/mnemo/setup_status.go
@@ -1,0 +1,204 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/jmeiracorbal/mnemo/internal/agentinit"
+)
+
+type setupStatusOptions struct {
+	JSON  bool
+	Agent string
+	Home  string
+}
+
+type setupStatusReport struct {
+	Status  string           `json:"status"`
+	Agent   string           `json:"agent"`
+	Summary doctorSummary    `json:"summary"`
+	Rows    []setupStatusRow `json:"agents"`
+}
+
+type setupStatusRow struct {
+	Agent        string `json:"agent"`
+	Detected     string `json:"detected"`
+	MCP          string `json:"mcp"`
+	Hooks        string `json:"hooks"`
+	Instructions string `json:"instructions"`
+}
+
+func runSetup() {
+	if len(os.Args) < 3 || os.Args[2] != "status" {
+		fmt.Fprintln(os.Stderr, "usage: mnemo setup status [--json] [--agent=AGENT] [--home=DIR]")
+		os.Exit(1)
+	}
+
+	opts, err := parseSetupStatusArgs(os.Args[3:], os.UserHomeDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mnemo setup status: home: %v\n", err)
+		os.Exit(1)
+	}
+	report := buildSetupStatusReport(opts)
+
+	if opts.JSON {
+		out, err := json.MarshalIndent(report, "", "  ")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "mnemo setup status: json: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Println(string(out))
+	} else {
+		printSetupStatusReport(report)
+	}
+
+	if report.Status == "error" {
+		os.Exit(1)
+	}
+}
+
+func parseSetupStatusArgs(args []string, userHomeDir func() (string, error)) (setupStatusOptions, error) {
+	opts := setupStatusOptions{Agent: "all"}
+	for _, arg := range args {
+		switch {
+		case arg == "--json":
+			opts.JSON = true
+		case strings.HasPrefix(arg, "--agent="):
+			opts.Agent = strings.TrimSpace(arg[len("--agent="):])
+		case strings.HasPrefix(arg, "--home="):
+			opts.Home = arg[len("--home="):]
+		}
+	}
+	if opts.Agent == "" {
+		opts.Agent = "all"
+	}
+	if opts.Home != "" {
+		return opts, nil
+	}
+	home, err := userHomeDir()
+	if err != nil {
+		return opts, err
+	}
+	opts.Home = home
+	return opts, nil
+}
+
+func buildSetupStatusReport(opts setupStatusOptions) setupStatusReport {
+	report := setupStatusReport{Status: "ok", Agent: opts.Agent}
+	agents, err := agentinit.ExpandAgents(opts.Agent)
+	if err != nil {
+		report.Status = "error"
+		report.Summary.Total = 1
+		report.Summary.Errors = 1
+		report.Rows = append(report.Rows, setupStatusRow{
+			Agent:        opts.Agent,
+			Detected:     "error",
+			MCP:          "error",
+			Hooks:        "error",
+			Instructions: err.Error(),
+		})
+		return report
+	}
+
+	for _, agent := range agents {
+		report.Rows = append(report.Rows, buildSetupStatusRow(opts.Home, agent))
+	}
+	report.Summary.Total = len(report.Rows)
+	for _, row := range report.Rows {
+		if row.Detected == "yes" && row.MCP == "yes" && (row.Hooks == "yes" || row.Hooks == "n/a") && row.Instructions == "yes" {
+			report.Summary.OK++
+			continue
+		}
+		report.Summary.Warnings++
+	}
+	if report.Summary.Warnings > 0 {
+		report.Status = "warning"
+	}
+	return report
+}
+
+func buildSetupStatusRow(home, agent string) setupStatusRow {
+	hooks := statusFromCheck(checkAgentRuntimeFiles(home, agent))
+	if hooks == "" {
+		hooks = "n/a"
+	}
+	return setupStatusRow{
+		Agent:        agentLabel(agent),
+		Detected:     yesNo(agentDetected(home, agent)),
+		MCP:          statusFromCheck(checkMCPConfig(home, agent)),
+		Hooks:        hooks,
+		Instructions: statusFromCheck(checkGlobalInstructions(home, agent)),
+	}
+}
+
+func printSetupStatusReport(report setupStatusReport) {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	_, _ = fmt.Fprintln(w, "Agent\tDetected\tMCP\tHooks\tInstructions")
+	for _, row := range report.Rows {
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", row.Agent, row.Detected, row.MCP, row.Hooks, row.Instructions)
+	}
+	_ = w.Flush()
+}
+
+func statusFromCheck(check doctorCheck) string {
+	if check.ID == "" {
+		return ""
+	}
+	if check.Status == "ok" {
+		return "yes"
+	}
+	return "no"
+}
+
+func yesNo(v bool) string {
+	if v {
+		return "yes"
+	}
+	return "no"
+}
+
+func agentDetected(home, agent string) bool {
+	for _, path := range agentDetectionPaths(home, agent) {
+		if pathExists(path) {
+			return true
+		}
+	}
+	return false
+}
+
+func agentDetectionPaths(home, agent string) []string {
+	switch agent {
+	case "claudecode":
+		return []string{filepath.Join(home, ".claude")}
+	case "cursor":
+		return []string{filepath.Join(home, ".cursor")}
+	case "windsurf":
+		return []string{filepath.Join(home, ".codeium", "windsurf")}
+	case "codex":
+		return []string{filepath.Join(home, ".codex")}
+	case "opencode":
+		return []string{filepath.Join(home, ".config", "opencode")}
+	default:
+		return nil
+	}
+}
+
+func pathExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+func agentLabel(agent string) string {
+	switch agent {
+	case "claudecode":
+		return "Claude"
+	case "opencode":
+		return "OpenCode"
+	default:
+		return strings.ToUpper(agent[:1]) + agent[1:]
+	}
+}

--- a/cmd/mnemo/setup_status.go
+++ b/cmd/mnemo/setup_status.go
@@ -109,13 +109,19 @@ func buildSetupStatusReport(opts setupStatusOptions) setupStatusReport {
 	}
 	report.Summary.Total = len(report.Rows)
 	for _, row := range report.Rows {
+		if setupStatusRowHasError(row) {
+			report.Summary.Errors++
+			continue
+		}
 		if row.Detected == "yes" && row.MCP == "yes" && (row.Hooks == "yes" || row.Hooks == "n/a") && row.Instructions == "yes" {
 			report.Summary.OK++
 			continue
 		}
 		report.Summary.Warnings++
 	}
-	if report.Summary.Warnings > 0 {
+	if report.Summary.Errors > 0 {
+		report.Status = "error"
+	} else if report.Summary.Warnings > 0 {
 		report.Status = "warning"
 	}
 	return report
@@ -148,10 +154,18 @@ func statusFromCheck(check doctorCheck) string {
 	if check.ID == "" {
 		return ""
 	}
-	if check.Status == "ok" {
+	switch check.Status {
+	case "ok":
 		return "yes"
+	case "error":
+		return "error"
+	default:
+		return "no"
 	}
-	return "no"
+}
+
+func setupStatusRowHasError(row setupStatusRow) bool {
+	return row.Detected == "error" || row.MCP == "error" || row.Hooks == "error" || row.Instructions == "error"
 }
 
 func yesNo(v bool) string {

--- a/cmd/mnemo/setup_status_test.go
+++ b/cmd/mnemo/setup_status_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"path/filepath"
 	"testing"
 
@@ -60,34 +61,59 @@ func TestBuildSetupStatusReportReportsMissingAgent(t *testing.T) {
 }
 
 func TestBuildSetupStatusReportChecksClaudeCodePluginHooks(t *testing.T) {
+	for name, registry := range map[string]string{
+		"array":  `{"plugins":{"mnemo@mnemo":[{"installPath":"%s"}]}}`,
+		"object": `{"plugins":{"mnemo@mnemo":{"installPath":"%s"}}}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			home := t.TempDir()
+			installPath := filepath.Join(home, "plugin-cache", "mnemo")
+
+			if _, err := agentinit.InstallGlobalInstructions(home, "claudecode"); err != nil {
+				t.Fatalf("install instructions: %v", err)
+			}
+			writeFile(t, filepath.Join(home, ".claude", ".mcp.json"), `{"mcpServers":{"mnemo":{"command":"mnemo"}}}`)
+			writeFile(t, filepath.Join(home, ".claude", "plugins", "installed_plugins.json"), fmt.Sprintf(registry, installPath))
+			writeFile(t, filepath.Join(installPath, ".claude-plugin", "plugin.json"), `{"name":"mnemo"}`)
+			writeFile(t, filepath.Join(installPath, "hooks", "hooks.json"), `{"hooks":{}}`)
+			for _, script := range []string{
+				"session-start.sh",
+				"session-stop.sh",
+				"subagent-stop.sh",
+				"post-compact.sh",
+				"post-compact-resume.sh",
+				"post-file-edit.sh",
+				"post-bash-git.sh",
+			} {
+				writeExecutable(t, filepath.Join(installPath, "scripts", script))
+			}
+
+			report := buildSetupStatusReport(setupStatusOptions{Agent: "claudecode", Home: home})
+			if report.Status != "ok" {
+				t.Fatalf("status = %q, want ok", report.Status)
+			}
+			row := report.Rows[0]
+			if row.Agent != "Claude" || row.Detected != "yes" || row.MCP != "yes" || row.Hooks != "yes" || row.Instructions != "yes" {
+				t.Fatalf("unexpected row: %+v", row)
+			}
+		})
+	}
+}
+
+func TestBuildSetupStatusReportCountsRuntimeErrors(t *testing.T) {
 	home := t.TempDir()
-	installPath := filepath.Join(home, "plugin-cache", "mnemo")
 
 	if _, err := agentinit.InstallGlobalInstructions(home, "claudecode"); err != nil {
 		t.Fatalf("install instructions: %v", err)
 	}
 	writeFile(t, filepath.Join(home, ".claude", ".mcp.json"), `{"mcpServers":{"mnemo":{"command":"mnemo"}}}`)
-	writeFile(t, filepath.Join(home, ".claude", "plugins", "installed_plugins.json"), `{"plugins":{"mnemo@mnemo":[{"installPath":"`+installPath+`"}]}}`)
-	writeFile(t, filepath.Join(installPath, ".claude-plugin", "plugin.json"), `{"name":"mnemo"}`)
-	writeFile(t, filepath.Join(installPath, "hooks", "hooks.json"), `{"hooks":{}}`)
-	for _, script := range []string{
-		"session-start.sh",
-		"session-stop.sh",
-		"subagent-stop.sh",
-		"post-compact.sh",
-		"post-compact-resume.sh",
-		"post-file-edit.sh",
-		"post-bash-git.sh",
-	} {
-		writeExecutable(t, filepath.Join(installPath, "scripts", script))
-	}
+	writeFile(t, filepath.Join(home, ".claude", "plugins", "installed_plugins.json"), `{`)
 
 	report := buildSetupStatusReport(setupStatusOptions{Agent: "claudecode", Home: home})
-	if report.Status != "ok" {
-		t.Fatalf("status = %q, want ok", report.Status)
+	if report.Status != "error" || report.Summary.Errors != 1 {
+		t.Fatalf("status = %q errors = %d, want error/1", report.Status, report.Summary.Errors)
 	}
-	row := report.Rows[0]
-	if row.Agent != "Claude" || row.Detected != "yes" || row.MCP != "yes" || row.Hooks != "yes" || row.Instructions != "yes" {
-		t.Fatalf("unexpected row: %+v", row)
+	if got := report.Rows[0].Hooks; got != "error" {
+		t.Fatalf("hooks = %q, want error", got)
 	}
 }

--- a/cmd/mnemo/setup_status_test.go
+++ b/cmd/mnemo/setup_status_test.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/jmeiracorbal/mnemo/internal/agentinit"
+)
+
+func TestParseSetupStatusArgs(t *testing.T) {
+	opts, err := parseSetupStatusArgs([]string{"--json", "--agent=codex", "--home=/home/test"}, func() (string, error) {
+		t.Fatal("userHomeDir should not be called when --home is provided")
+		return "", nil
+	})
+	if err != nil {
+		t.Fatalf("parse setup status args: %v", err)
+	}
+	if !opts.JSON || opts.Agent != "codex" || opts.Home != "/home/test" {
+		t.Fatalf("unexpected options: %+v", opts)
+	}
+}
+
+func TestBuildSetupStatusReportReportsConfiguredCodex(t *testing.T) {
+	home := t.TempDir()
+
+	if _, err := agentinit.InstallGlobalInstructions(home, "codex"); err != nil {
+		t.Fatalf("install instructions: %v", err)
+	}
+	writeFile(t, filepath.Join(home, ".codex", "config.toml"), "[mcp_servers.mnemo]\ncommand = \"mnemo\"\nargs = [\"mcp\", \"--tools=agent\"]\n")
+	writeFile(t, filepath.Join(home, ".codex", "hooks.json"), `{"hooks":{"SessionStart":[],"Stop":[]}}`)
+	writeExecutable(t, filepath.Join(home, ".codex", "hooks", "session-start.sh"))
+	writeExecutable(t, filepath.Join(home, ".codex", "hooks", "stop.sh"))
+	writeFile(t, filepath.Join(home, ".codex", "hooks", "mnemo-protocol.md"), "protocol")
+
+	report := buildSetupStatusReport(setupStatusOptions{Agent: "codex", Home: home})
+	if report.Status != "ok" {
+		t.Fatalf("status = %q, want ok", report.Status)
+	}
+	if len(report.Rows) != 1 {
+		t.Fatalf("rows = %d, want 1", len(report.Rows))
+	}
+	row := report.Rows[0]
+	if row.Agent != "Codex" || row.Detected != "yes" || row.MCP != "yes" || row.Hooks != "yes" || row.Instructions != "yes" {
+		t.Fatalf("unexpected row: %+v", row)
+	}
+}
+
+func TestBuildSetupStatusReportReportsMissingAgent(t *testing.T) {
+	report := buildSetupStatusReport(setupStatusOptions{Agent: "cursor", Home: t.TempDir()})
+	if report.Status != "warning" {
+		t.Fatalf("status = %q, want warning", report.Status)
+	}
+	if len(report.Rows) != 1 {
+		t.Fatalf("rows = %d, want 1", len(report.Rows))
+	}
+	row := report.Rows[0]
+	if row.Agent != "Cursor" || row.Detected != "no" || row.MCP != "no" || row.Hooks != "no" || row.Instructions != "no" {
+		t.Fatalf("unexpected row: %+v", row)
+	}
+}
+
+func TestBuildSetupStatusReportChecksClaudeCodePluginHooks(t *testing.T) {
+	home := t.TempDir()
+	installPath := filepath.Join(home, "plugin-cache", "mnemo")
+
+	if _, err := agentinit.InstallGlobalInstructions(home, "claudecode"); err != nil {
+		t.Fatalf("install instructions: %v", err)
+	}
+	writeFile(t, filepath.Join(home, ".claude", ".mcp.json"), `{"mcpServers":{"mnemo":{"command":"mnemo"}}}`)
+	writeFile(t, filepath.Join(home, ".claude", "plugins", "installed_plugins.json"), `{"plugins":{"mnemo@mnemo":[{"installPath":"`+installPath+`"}]}}`)
+	writeFile(t, filepath.Join(installPath, ".claude-plugin", "plugin.json"), `{"name":"mnemo"}`)
+	writeFile(t, filepath.Join(installPath, "hooks", "hooks.json"), `{"hooks":{}}`)
+	for _, script := range []string{
+		"session-start.sh",
+		"session-stop.sh",
+		"subagent-stop.sh",
+		"post-compact.sh",
+		"post-compact-resume.sh",
+		"post-file-edit.sh",
+		"post-bash-git.sh",
+	} {
+		writeExecutable(t, filepath.Join(installPath, "scripts", script))
+	}
+
+	report := buildSetupStatusReport(setupStatusOptions{Agent: "claudecode", Home: home})
+	if report.Status != "ok" {
+		t.Fatalf("status = %q, want ok", report.Status)
+	}
+	row := report.Rows[0]
+	if row.Agent != "Claude" || row.Detected != "yes" || row.MCP != "yes" || row.Hooks != "yes" || row.Instructions != "yes" {
+		t.Fatalf("unexpected row: %+v", row)
+	}
+}

--- a/cmd/mnemo/templates/usage.txt
+++ b/cmd/mnemo/templates/usage.txt
@@ -12,7 +12,7 @@ Usage:
   mnemo import <file.json>             Import memories from JSON
   mnemo capture <content>|-            Extract learnings from text (passive capture; "-" reads stdin)
   mnemo doctor [--json] [--agent=AGENT] [--path=DIR]  Run read-only diagnostics
-  mnemo setup status [--json] [--agent=AGENT]  Show global agent setup status
+  mnemo setup status [--json] [--agent=AGENT] [--home=DIR]  Show global agent setup status
   mnemo init [--agent=AGENT] [--path=DIR]  Activate mnemo in the current project (.mnemo)
   mnemo install-instructions [--agent=AGENT]  Install global agent instructions
   mnemo migrate [--path=DIR]              Migrate project from legacy key to UUID-based identity

--- a/cmd/mnemo/templates/usage.txt
+++ b/cmd/mnemo/templates/usage.txt
@@ -12,6 +12,7 @@ Usage:
   mnemo import <file.json>             Import memories from JSON
   mnemo capture <content>|-            Extract learnings from text (passive capture; "-" reads stdin)
   mnemo doctor [--json] [--agent=AGENT] [--path=DIR]  Run read-only diagnostics
+  mnemo setup status [--json] [--agent=AGENT]  Show global agent setup status
   mnemo init [--agent=AGENT] [--path=DIR]  Activate mnemo in the current project (.mnemo)
   mnemo install-instructions [--agent=AGENT]  Install global agent instructions
   mnemo migrate [--path=DIR]              Migrate project from legacy key to UUID-based identity
@@ -34,6 +35,11 @@ Doctor options:
   --agent=AGENT        Check one agent or all agents (default: all)
   --home=DIR           Override home directory for global agent checks
   --data-dir=DIR       Override mnemo data directory for store checks
+
+Setup status options:
+  --json               Emit a stable JSON status envelope
+  --agent=AGENT        Check one agent or all agents (default: all)
+  --home=DIR           Override home directory for global agent checks
 
 Tool profiles for mcp:
   --tools=agent    15 tools for AI agents (default when using plugin)


### PR DESCRIPTION
## Summary
- add read-only `mnemo setup status` table and JSON output
- reuse diagnostics checks for MCP, hooks, and instructions
- update docs and roadmap

## Tests
- go test ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `mnemo setup status` to summarize agent detection and MCP, hooks, and instructions configuration.
  * Supports table output, JSON output, selecting specific agents, and custom home directories.
  * Added setup-status details to the CLI help and usage documentation.
* **Bug Fixes**
  * Fixed the top-level CLI so the `mnemo setup` command is recognized and runs correctly.
  * Improved health checks for Claude Code plugin runtime files and hooks.
* **Documentation**
  * Updated verification guidance to include both `mnemo doctor` and `mnemo setup status`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->