### PR TITLE
Add setup print-config command

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ mnemo init [--agent=AGENT]           Activate mnemo in the current project (.mne
 mnemo install-instructions [--agent=AGENT]  Install global agent instructions
 mnemo doctor [--json] [--agent=AGENT] [--path=DIR]  Run read-only diagnostics
 mnemo setup status [--json] [--agent=AGENT] [--home=DIR]  Show global agent setup status
+mnemo setup print-config AGENT [--home=DIR] [--mnemo-bin=PATH]  Print manual setup config snippets
 mnemo save <title> <content>         Save a memory
 mnemo search <query>                 Search memories
 mnemo context [project]              Show context from previous sessions
@@ -341,6 +342,7 @@ After running the installer, use `mnemo doctor` for a read-only health check and
 mnemo doctor --agent=all --path=.
 mnemo doctor --json --agent=codex --path=.
 mnemo setup status --agent=all
+mnemo setup print-config codex
 
 # Project activation
 cat .mnemo                          # must contain id + agents list

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,14 +9,12 @@ Add explicit setup maintenance commands for global agent integrations:
 ```bash
 mnemo setup refresh --agent=all
 mnemo setup uninstall --agent=codex
-mnemo setup print-config codex
 ```
 
 Goals:
 
 - refresh previously installed global files after upgrades;
 - uninstall mnemo from selected agents without removing the local database;
-- print target-specific MCP/config snippets for manual setup and debugging.
 
 ## Project management
 

--- a/cmd/mnemo/setup_print_config.go
+++ b/cmd/mnemo/setup_print_config.go
@@ -81,12 +81,16 @@ func buildSetupConfigSnippets(opts setupPrintConfigOptions) ([]setupConfigSnippe
 	}
 	var snippets []setupConfigSnippet
 	for _, agent := range agents {
-		snippets = append(snippets, setupConfigSnippetsForAgent(opts.Home, opts.MnemoBin, agent)...)
+		agentSnippets, err := setupConfigSnippetsForAgent(opts.Home, opts.MnemoBin, agent)
+		if err != nil {
+			return nil, err
+		}
+		snippets = append(snippets, agentSnippets...)
 	}
 	return snippets, nil
 }
 
-func setupConfigSnippetsForAgent(home, mnemoBin, agent string) []setupConfigSnippet {
+func setupConfigSnippetsForAgent(home, mnemoBin, agent string) ([]setupConfigSnippet, error) {
 	switch agent {
 	case "claudecode":
 		return []setupConfigSnippet{{
@@ -94,7 +98,7 @@ func setupConfigSnippetsForAgent(home, mnemoBin, agent string) []setupConfigSnip
 			Path:    filepath.Join(home, ".claude", ".mcp.json"),
 			Format:  "json",
 			Content: mcpServersJSON(mnemoBin),
-		}}
+		}}, nil
 	case "cursor":
 		hooksDir := filepath.Join(home, ".cursor", "hooks")
 		return []setupConfigSnippet{
@@ -116,7 +120,7 @@ func setupConfigSnippetsForAgent(home, mnemoBin, agent string) []setupConfigSnip
 					},
 				}),
 			},
-		}
+		}, nil
 	case "windsurf":
 		hooksDir := filepath.Join(home, ".codeium", "windsurf", "hooks")
 		return []setupConfigSnippet{
@@ -137,7 +141,7 @@ func setupConfigSnippetsForAgent(home, mnemoBin, agent string) []setupConfigSnip
 					},
 				}),
 			},
-		}
+		}, nil
 	case "codex":
 		hooksDir := filepath.Join(home, ".codex", "hooks")
 		return []setupConfigSnippet{
@@ -173,7 +177,7 @@ func setupConfigSnippetsForAgent(home, mnemoBin, agent string) []setupConfigSnip
 					},
 				}),
 			},
-		}
+		}, nil
 	case "opencode":
 		return []setupConfigSnippet{{
 			Agent:  agentLabel(agent),
@@ -187,9 +191,9 @@ func setupConfigSnippetsForAgent(home, mnemoBin, agent string) []setupConfigSnip
 					},
 				},
 			}),
-		}}
+		}}, nil
 	default:
-		return nil
+		return nil, fmt.Errorf("unsupported agent %q for setup print-config", agent)
 	}
 }
 

--- a/cmd/mnemo/setup_print_config.go
+++ b/cmd/mnemo/setup_print_config.go
@@ -1,0 +1,223 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/jmeiracorbal/mnemo/internal/agentinit"
+)
+
+type setupPrintConfigOptions struct {
+	Agent    string
+	Home     string
+	MnemoBin string
+}
+
+type setupConfigSnippet struct {
+	Agent   string
+	Path    string
+	Format  string
+	Content string
+}
+
+func runSetupPrintConfig() {
+	opts, err := parseSetupPrintConfigArgs(os.Args[3:], os.UserHomeDir, exec.LookPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mnemo setup print-config: %v\n", err)
+		os.Exit(1)
+	}
+	snippets, err := buildSetupConfigSnippets(opts)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mnemo setup print-config: %v\n", err)
+		os.Exit(1)
+	}
+	printSetupConfigSnippets(snippets)
+}
+
+func parseSetupPrintConfigArgs(args []string, userHomeDir func() (string, error), lookPath func(string) (string, error)) (setupPrintConfigOptions, error) {
+	opts := setupPrintConfigOptions{}
+	for _, arg := range args {
+		switch {
+		case strings.HasPrefix(arg, "--home="):
+			opts.Home = arg[len("--home="):]
+		case strings.HasPrefix(arg, "--mnemo-bin="):
+			opts.MnemoBin = arg[len("--mnemo-bin="):]
+		case strings.HasPrefix(arg, "--"):
+			return opts, fmt.Errorf("unknown option %q", arg)
+		case opts.Agent == "":
+			opts.Agent = strings.TrimSpace(arg)
+		default:
+			return opts, fmt.Errorf("unexpected argument %q", arg)
+		}
+	}
+	if opts.Agent == "" {
+		return opts, fmt.Errorf("missing agent — usage: mnemo setup print-config AGENT")
+	}
+	if opts.Home == "" {
+		home, err := userHomeDir()
+		if err != nil {
+			return opts, fmt.Errorf("home: %w", err)
+		}
+		opts.Home = home
+	}
+	if opts.MnemoBin == "" {
+		if path, err := lookPath("mnemo"); err == nil && strings.TrimSpace(path) != "" {
+			opts.MnemoBin = path
+		} else {
+			opts.MnemoBin = "mnemo"
+		}
+	}
+	return opts, nil
+}
+
+func buildSetupConfigSnippets(opts setupPrintConfigOptions) ([]setupConfigSnippet, error) {
+	agents, err := agentinit.ExpandAgents(opts.Agent)
+	if err != nil {
+		return nil, err
+	}
+	var snippets []setupConfigSnippet
+	for _, agent := range agents {
+		snippets = append(snippets, setupConfigSnippetsForAgent(opts.Home, opts.MnemoBin, agent)...)
+	}
+	return snippets, nil
+}
+
+func setupConfigSnippetsForAgent(home, mnemoBin, agent string) []setupConfigSnippet {
+	switch agent {
+	case "claudecode":
+		return []setupConfigSnippet{{
+			Agent:   agentLabel(agent),
+			Path:    filepath.Join(home, ".claude", ".mcp.json"),
+			Format:  "json",
+			Content: mcpServersJSON(mnemoBin),
+		}}
+	case "cursor":
+		hooksDir := filepath.Join(home, ".cursor", "hooks")
+		return []setupConfigSnippet{
+			{
+				Agent:   agentLabel(agent),
+				Path:    filepath.Join(home, ".cursor", "mcp.json"),
+				Format:  "json",
+				Content: mcpServersJSON(mnemoBin),
+			},
+			{
+				Agent:  agentLabel(agent),
+				Path:   filepath.Join(home, ".cursor", "hooks.json"),
+				Format: "json",
+				Content: prettyJSON(map[string]any{
+					"version": 1,
+					"hooks": map[string]any{
+						"beforeSubmitPrompt": []any{map[string]any{"command": filepath.Join(hooksDir, "before-submit-prompt.sh")}},
+						"stop":               []any{map[string]any{"command": filepath.Join(hooksDir, "stop.sh")}},
+					},
+				}),
+			},
+		}
+	case "windsurf":
+		hooksDir := filepath.Join(home, ".codeium", "windsurf", "hooks")
+		return []setupConfigSnippet{
+			{
+				Agent:   agentLabel(agent),
+				Path:    filepath.Join(home, ".codeium", "windsurf", "mcp_config.json"),
+				Format:  "json",
+				Content: mcpServersJSON(mnemoBin),
+			},
+			{
+				Agent:  agentLabel(agent),
+				Path:   filepath.Join(home, ".codeium", "windsurf", "hooks.json"),
+				Format: "json",
+				Content: prettyJSON(map[string]any{
+					"hooks": map[string]any{
+						"pre_user_prompt":                       []any{map[string]any{"command": filepath.Join(hooksDir, "pre-user-prompt.sh")}},
+						"post_cascade_response_with_transcript": []any{map[string]any{"command": filepath.Join(hooksDir, "post-cascade-response.sh")}},
+					},
+				}),
+			},
+		}
+	case "codex":
+		hooksDir := filepath.Join(home, ".codex", "hooks")
+		return []setupConfigSnippet{
+			{
+				Agent:   agentLabel(agent),
+				Path:    filepath.Join(home, ".codex", "config.toml"),
+				Format:  "toml",
+				Content: fmt.Sprintf("[mcp_servers.mnemo]\ncommand = %q\nargs = [\"mcp\", \"--tools=agent\"]\n", mnemoBin),
+			},
+			{
+				Agent:  agentLabel(agent),
+				Path:   filepath.Join(home, ".codex", "hooks.json"),
+				Format: "json",
+				Content: prettyJSON(map[string]any{
+					"hooks": map[string]any{
+						"SessionStart": []any{map[string]any{
+							"matcher": "startup|resume",
+							"hooks": []any{map[string]any{
+								"type":          "command",
+								"command":       filepath.Join(hooksDir, "session-start.sh"),
+								"statusMessage": "Loading mnemo memory...",
+								"timeout":       10,
+							}},
+						}},
+						"Stop": []any{map[string]any{
+							"matcher": "",
+							"hooks": []any{map[string]any{
+								"type":    "command",
+								"command": filepath.Join(hooksDir, "stop.sh"),
+								"timeout": 10,
+							}},
+						}},
+					},
+				}),
+			},
+		}
+	case "opencode":
+		return []setupConfigSnippet{{
+			Agent:  agentLabel(agent),
+			Path:   filepath.Join(home, ".config", "opencode", "opencode.json"),
+			Format: "json",
+			Content: prettyJSON(map[string]any{
+				"mcp": map[string]any{
+					"mnemo": map[string]any{
+						"type":    "local",
+						"command": []string{mnemoBin, "mcp", "--tools=agent"},
+					},
+				},
+			}),
+		}}
+	default:
+		return nil
+	}
+}
+
+func mcpServersJSON(mnemoBin string) string {
+	return prettyJSON(map[string]any{
+		"mcpServers": map[string]any{
+			"mnemo": map[string]any{
+				"command": mnemoBin,
+				"args":    []string{"mcp", "--tools=agent"},
+			},
+		},
+	})
+}
+
+func prettyJSON(v any) string {
+	out, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		panic(err)
+	}
+	return string(out) + "\n"
+}
+
+func printSetupConfigSnippets(snippets []setupConfigSnippet) {
+	for i, snippet := range snippets {
+		if i > 0 {
+			fmt.Println()
+		}
+		fmt.Printf("# %s: %s (%s)\n", snippet.Agent, snippet.Path, snippet.Format)
+		fmt.Print(snippet.Content)
+	}
+}

--- a/cmd/mnemo/setup_print_config_test.go
+++ b/cmd/mnemo/setup_print_config_test.go
@@ -92,3 +92,10 @@ func TestBuildSetupConfigSnippetsForAll(t *testing.T) {
 		t.Fatalf("snippets = %d, want 8", len(snippets))
 	}
 }
+
+func TestSetupConfigSnippetsForAgentRejectsUnsupportedAgent(t *testing.T) {
+	_, err := setupConfigSnippetsForAgent("/home/test", "mnemo", "future-agent")
+	if err == nil || !strings.Contains(err.Error(), `unsupported agent "future-agent"`) {
+		t.Fatalf("error = %v, want unsupported agent", err)
+	}
+}

--- a/cmd/mnemo/setup_print_config_test.go
+++ b/cmd/mnemo/setup_print_config_test.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestParseSetupPrintConfigArgs(t *testing.T) {
+	opts, err := parseSetupPrintConfigArgs(
+		[]string{"codex", "--home=/home/test", "--mnemo-bin=/bin/mnemo"},
+		func() (string, error) {
+			t.Fatal("userHomeDir should not be called when --home is provided")
+			return "", nil
+		},
+		func(string) (string, error) {
+			t.Fatal("lookPath should not be called when --mnemo-bin is provided")
+			return "", nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("parse setup print-config args: %v", err)
+	}
+	if opts.Agent != "codex" || opts.Home != "/home/test" || opts.MnemoBin != "/bin/mnemo" {
+		t.Fatalf("unexpected options: %+v", opts)
+	}
+}
+
+func TestParseSetupPrintConfigArgsDefaultsBinaryToPath(t *testing.T) {
+	opts, err := parseSetupPrintConfigArgs(
+		[]string{"cursor"},
+		func() (string, error) { return "/home/test", nil },
+		func(name string) (string, error) {
+			if name != "mnemo" {
+				t.Fatalf("lookPath called with %q", name)
+			}
+			return "/usr/local/bin/mnemo", nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("parse setup print-config args: %v", err)
+	}
+	if opts.Agent != "cursor" || opts.Home != "/home/test" || opts.MnemoBin != "/usr/local/bin/mnemo" {
+		t.Fatalf("unexpected options: %+v", opts)
+	}
+}
+
+func TestParseSetupPrintConfigArgsDefaultsBinaryToMnemo(t *testing.T) {
+	opts, err := parseSetupPrintConfigArgs(
+		[]string{"cursor"},
+		func() (string, error) { return "/home/test", nil },
+		func(string) (string, error) { return "", errors.New("not found") },
+	)
+	if err != nil {
+		t.Fatalf("parse setup print-config args: %v", err)
+	}
+	if opts.MnemoBin != "mnemo" {
+		t.Fatalf("mnemo bin = %q, want mnemo", opts.MnemoBin)
+	}
+}
+
+func TestBuildSetupConfigSnippetsForCodex(t *testing.T) {
+	snippets, err := buildSetupConfigSnippets(setupPrintConfigOptions{
+		Agent:    "codex",
+		Home:     "/home/test",
+		MnemoBin: "/bin/mnemo",
+	})
+	if err != nil {
+		t.Fatalf("build snippets: %v", err)
+	}
+	if len(snippets) != 2 {
+		t.Fatalf("snippets = %d, want 2", len(snippets))
+	}
+	if snippets[0].Path != "/home/test/.codex/config.toml" || !strings.Contains(snippets[0].Content, "[mcp_servers.mnemo]") || !strings.Contains(snippets[0].Content, `command = "/bin/mnemo"`) {
+		t.Fatalf("unexpected mcp snippet: %+v", snippets[0])
+	}
+	if snippets[1].Path != "/home/test/.codex/hooks.json" || !strings.Contains(snippets[1].Content, "/home/test/.codex/hooks/session-start.sh") {
+		t.Fatalf("unexpected hooks snippet: %+v", snippets[1])
+	}
+}
+
+func TestBuildSetupConfigSnippetsForAll(t *testing.T) {
+	snippets, err := buildSetupConfigSnippets(setupPrintConfigOptions{
+		Agent:    "all",
+		Home:     "/home/test",
+		MnemoBin: "mnemo",
+	})
+	if err != nil {
+		t.Fatalf("build snippets: %v", err)
+	}
+	if len(snippets) != 8 {
+		t.Fatalf("snippets = %d, want 8", len(snippets))
+	}
+}

--- a/cmd/mnemo/setup_status.go
+++ b/cmd/mnemo/setup_status.go
@@ -33,11 +33,27 @@ type setupStatusRow struct {
 }
 
 func runSetup() {
-	if len(os.Args) < 3 || os.Args[2] != "status" {
-		fmt.Fprintln(os.Stderr, "usage: mnemo setup status [--json] [--agent=AGENT] [--home=DIR]")
+	if len(os.Args) < 3 {
+		printSetupUsage()
 		os.Exit(1)
 	}
+	switch os.Args[2] {
+	case "status":
+		runSetupStatus()
+	case "print-config":
+		runSetupPrintConfig()
+	default:
+		printSetupUsage()
+		os.Exit(1)
+	}
+}
 
+func printSetupUsage() {
+	fmt.Fprintln(os.Stderr, "usage: mnemo setup status [--json] [--agent=AGENT] [--home=DIR]")
+	fmt.Fprintln(os.Stderr, "       mnemo setup print-config AGENT [--home=DIR] [--mnemo-bin=PATH]")
+}
+
+func runSetupStatus() {
 	opts, err := parseSetupStatusArgs(os.Args[3:], os.UserHomeDir)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "mnemo setup status: home: %v\n", err)

--- a/cmd/mnemo/templates/usage.txt
+++ b/cmd/mnemo/templates/usage.txt
@@ -13,6 +13,7 @@ Usage:
   mnemo capture <content>|-            Extract learnings from text (passive capture; "-" reads stdin)
   mnemo doctor [--json] [--agent=AGENT] [--path=DIR]  Run read-only diagnostics
   mnemo setup status [--json] [--agent=AGENT] [--home=DIR]  Show global agent setup status
+  mnemo setup print-config AGENT [--home=DIR] [--mnemo-bin=PATH]  Print manual setup config snippets
   mnemo init [--agent=AGENT] [--path=DIR]  Activate mnemo in the current project (.mnemo)
   mnemo install-instructions [--agent=AGENT]  Install global agent instructions
   mnemo migrate [--path=DIR]              Migrate project from legacy key to UUID-based identity
@@ -40,6 +41,11 @@ Setup status options:
   --json               Emit a stable JSON status envelope
   --agent=AGENT        Check one agent or all agents (default: all)
   --home=DIR           Override home directory for global agent checks
+
+Setup print-config options:
+  AGENT                claudecode | cursor | windsurf | codex | opencode | all
+  --home=DIR           Use DIR when rendering user-level config paths
+  --mnemo-bin=PATH     Use PATH as the mnemo binary in snippets
 
 Tool profiles for mcp:
   --tools=agent    15 tools for AI agents (default when using plugin)


### PR DESCRIPTION
## Summary
- add read-only `mnemo setup print-config`
- print MCP and hook config snippets for supported agents
- update docs and roadmap

## Tests
- go test ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `mnemo setup print-config` to generate setup configuration snippets for supported agents.
  * Supports individual agents or all agents, with optional home-directory and binary-path settings.
  * Displays generated file paths and configuration content directly in the terminal.

* **Documentation**
  * Updated CLI help, README guidance, and setup verification examples for the new command.
  * Refined the setup lifecycle roadmap to include agent maintenance commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->