### PR TITLE
Add setup refresh command

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ mnemo install-instructions [--agent=AGENT]  Install global agent instructions
 mnemo doctor [--json] [--agent=AGENT] [--path=DIR]  Run read-only diagnostics
 mnemo setup status [--json] [--agent=AGENT] [--home=DIR]  Show global agent setup status
 mnemo setup print-config AGENT [--home=DIR] [--mnemo-bin=PATH]  Print manual setup config snippets
+mnemo setup refresh [--agent=AGENT] [--home=DIR] [--mnemo-bin=PATH]  Refresh installed global setup files
 mnemo save <title> <content>         Save a memory
 mnemo search <query>                 Search memories
 mnemo context [project]              Show context from previous sessions
@@ -343,6 +344,7 @@ mnemo doctor --agent=all --path=.
 mnemo doctor --json --agent=codex --path=.
 mnemo setup status --agent=all
 mnemo setup print-config codex
+mnemo setup refresh --agent=codex
 
 # Project activation
 cat .mnemo                          # must contain id + agents list

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,13 +7,11 @@ This document tracks planned capabilities that are not yet released. Released be
 Add explicit setup maintenance commands for global agent integrations:
 
 ```bash
-mnemo setup refresh --agent=all
 mnemo setup uninstall --agent=codex
 ```
 
 Goals:
 
-- refresh previously installed global files after upgrades;
 - uninstall mnemo from selected agents without removing the local database;
 
 ## Project management

--- a/assets.go
+++ b/assets.go
@@ -1,0 +1,9 @@
+package mnemo
+
+import "embed"
+
+// SetupAssets contains the files that `mnemo setup refresh` can reinstall
+// from the compiled binary.
+//
+//go:embed scripts/codex/hooks/* scripts/cursor/hooks/* scripts/opencode/plugins/* scripts/windsurf/hooks/*
+var SetupAssets embed.FS

--- a/cmd/mnemo/setup_refresh.go
+++ b/cmd/mnemo/setup_refresh.go
@@ -1,0 +1,229 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	mnemoassets "github.com/jmeiracorbal/mnemo"
+	"github.com/jmeiracorbal/mnemo/internal/agentinit"
+	"github.com/jmeiracorbal/mnemo/internal/jsonmerge"
+)
+
+type setupRefreshOptions struct {
+	Agent    string
+	Home     string
+	MnemoBin string
+}
+
+func runSetupRefresh() {
+	opts, err := parseSetupRefreshArgs(os.Args[3:], os.UserHomeDir, exec.LookPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mnemo setup refresh: %v\n", err)
+		os.Exit(1)
+	}
+	updated, err := refreshSetup(opts)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mnemo setup refresh: %v\n", err)
+		os.Exit(1)
+	}
+	for _, path := range updated {
+		fmt.Printf("mnemo setup refresh: updated %s\n", path)
+	}
+}
+
+func parseSetupRefreshArgs(args []string, userHomeDir func() (string, error), lookPath func(string) (string, error)) (setupRefreshOptions, error) {
+	opts := setupRefreshOptions{Agent: "all"}
+	for _, arg := range args {
+		switch {
+		case strings.HasPrefix(arg, "--agent="):
+			opts.Agent = strings.TrimSpace(arg[len("--agent="):])
+		case strings.HasPrefix(arg, "--home="):
+			opts.Home = arg[len("--home="):]
+		case strings.HasPrefix(arg, "--mnemo-bin="):
+			opts.MnemoBin = arg[len("--mnemo-bin="):]
+		default:
+			return opts, fmt.Errorf("unknown argument %q", arg)
+		}
+	}
+	if opts.Agent == "" {
+		opts.Agent = "all"
+	}
+	if opts.Home == "" {
+		home, err := userHomeDir()
+		if err != nil {
+			return opts, fmt.Errorf("home: %w", err)
+		}
+		opts.Home = home
+	}
+	if opts.MnemoBin == "" {
+		if path, err := lookPath("mnemo"); err == nil && strings.TrimSpace(path) != "" {
+			opts.MnemoBin = path
+		} else {
+			opts.MnemoBin = "mnemo"
+		}
+	}
+	return opts, nil
+}
+
+func refreshSetup(opts setupRefreshOptions) ([]string, error) {
+	agents, err := agentinit.ExpandAgents(opts.Agent)
+	if err != nil {
+		return nil, err
+	}
+	var updated []string
+	for _, agent := range agents {
+		agentUpdated, err := refreshAgentSetup(opts.Home, opts.MnemoBin, agent)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", agent, err)
+		}
+		updated = append(updated, agentUpdated...)
+	}
+	return updated, nil
+}
+
+func refreshAgentSetup(home, mnemoBin, agent string) ([]string, error) {
+	var updated []string
+
+	instructionsPath, err := agentinit.InstallGlobalInstructions(home, agent)
+	if err != nil {
+		return nil, err
+	}
+	updated = append(updated, instructionsPath)
+
+	snippets, err := setupConfigSnippetsForAgent(home, mnemoBin, agent)
+	if err != nil {
+		return nil, err
+	}
+	for _, snippet := range snippets {
+		if err := applySetupConfigSnippet(snippet); err != nil {
+			return nil, err
+		}
+		updated = append(updated, snippet.Path)
+	}
+
+	runtimeFiles, err := refreshAgentRuntimeFiles(home, agent)
+	if err != nil {
+		return nil, err
+	}
+	updated = append(updated, runtimeFiles...)
+	return updated, nil
+}
+
+func applySetupConfigSnippet(snippet setupConfigSnippet) error {
+	switch snippet.Format {
+	case "json":
+		var patch any
+		if err := json.Unmarshal([]byte(snippet.Content), &patch); err != nil {
+			return fmt.Errorf("parse generated JSON for %s: %w", snippet.Path, err)
+		}
+		if _, err := jsonmerge.MergeValue(snippet.Path, patch); err != nil {
+			return err
+		}
+	case "toml":
+		if err := upsertCodexMCPConfig(snippet.Path, snippet.Content); err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("unsupported config format %q for %s", snippet.Format, snippet.Path)
+	}
+	return nil
+}
+
+func upsertCodexMCPConfig(path, section string) error {
+	data, err := os.ReadFile(path)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("read %s: %w", path, err)
+	}
+	lines := strings.Split(string(data), "\n")
+	var out []string
+	skipping := false
+	replaced := false
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "[mcp_servers.mnemo]" {
+			out = append(out, strings.TrimRight(section, "\n"))
+			skipping = true
+			replaced = true
+			continue
+		}
+		if skipping && strings.HasPrefix(trimmed, "[") {
+			skipping = false
+		}
+		if !skipping {
+			out = append(out, line)
+		}
+	}
+	content := strings.TrimRight(strings.Join(out, "\n"), "\n")
+	if !replaced {
+		content = strings.TrimRight(string(data), "\n")
+		if content != "" {
+			content += "\n\n"
+		}
+		content += strings.TrimRight(section, "\n")
+	}
+	content += "\n"
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, []byte(content), 0644)
+}
+
+func refreshAgentRuntimeFiles(home, agent string) ([]string, error) {
+	switch agent {
+	case "claudecode":
+		// Claude Code hooks are managed by the Claude plugin installation.
+		return nil, nil
+	case "cursor":
+		return writeSetupAssets(home, []setupAssetTarget{
+			{Asset: "scripts/cursor/hooks/before-submit-prompt.sh", Path: filepath.Join(".cursor", "hooks", "before-submit-prompt.sh"), Mode: 0755},
+			{Asset: "scripts/cursor/hooks/stop.sh", Path: filepath.Join(".cursor", "hooks", "stop.sh"), Mode: 0755},
+		})
+	case "windsurf":
+		return writeSetupAssets(home, []setupAssetTarget{
+			{Asset: "scripts/windsurf/hooks/pre-user-prompt.sh", Path: filepath.Join(".codeium", "windsurf", "hooks", "pre-user-prompt.sh"), Mode: 0755},
+			{Asset: "scripts/windsurf/hooks/post-cascade-response.sh", Path: filepath.Join(".codeium", "windsurf", "hooks", "post-cascade-response.sh"), Mode: 0755},
+		})
+	case "codex":
+		return writeSetupAssets(home, []setupAssetTarget{
+			{Asset: "scripts/codex/hooks/session-start.sh", Path: filepath.Join(".codex", "hooks", "session-start.sh"), Mode: 0755},
+			{Asset: "scripts/codex/hooks/stop.sh", Path: filepath.Join(".codex", "hooks", "stop.sh"), Mode: 0755},
+			{Asset: "scripts/codex/hooks/mnemo-protocol.md", Path: filepath.Join(".codex", "hooks", "mnemo-protocol.md"), Mode: 0644},
+		})
+	case "opencode":
+		return writeSetupAssets(home, []setupAssetTarget{
+			{Asset: "scripts/opencode/plugins/mnemo.ts", Path: filepath.Join(".config", "opencode", "plugins", "mnemo.ts"), Mode: 0644},
+			{Asset: "scripts/opencode/plugins/mnemo-protocol.md", Path: filepath.Join(".config", "opencode", "plugins", "mnemo-protocol.md"), Mode: 0644},
+		})
+	default:
+		return nil, fmt.Errorf("unsupported agent %q for setup refresh", agent)
+	}
+}
+
+type setupAssetTarget struct {
+	Asset string
+	Path  string
+	Mode  os.FileMode
+}
+
+func writeSetupAssets(home string, targets []setupAssetTarget) ([]string, error) {
+	updated := make([]string, 0, len(targets))
+	for _, target := range targets {
+		data, err := mnemoassets.SetupAssets.ReadFile(target.Asset)
+		if err != nil {
+			return nil, fmt.Errorf("read embedded asset %s: %w", target.Asset, err)
+		}
+		path := filepath.Join(home, target.Path)
+		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+			return nil, err
+		}
+		if err := os.WriteFile(path, data, target.Mode); err != nil {
+			return nil, err
+		}
+		updated = append(updated, path)
+	}
+	return updated, nil
+}

--- a/cmd/mnemo/setup_refresh.go
+++ b/cmd/mnemo/setup_refresh.go
@@ -223,6 +223,9 @@ func writeSetupAssets(home string, targets []setupAssetTarget) ([]string, error)
 		if err := os.WriteFile(path, data, target.Mode); err != nil {
 			return nil, err
 		}
+		if err := os.Chmod(path, target.Mode); err != nil {
+			return nil, err
+		}
 		updated = append(updated, path)
 	}
 	return updated, nil

--- a/cmd/mnemo/setup_refresh_test.go
+++ b/cmd/mnemo/setup_refresh_test.go
@@ -66,6 +66,21 @@ func TestRefreshSetupPreservesExistingJSONConfig(t *testing.T) {
 	}
 }
 
+func TestRefreshSetupRestoresExistingScriptPermissions(t *testing.T) {
+	home := t.TempDir()
+	scriptPath := filepath.Join(home, ".codex", "hooks", "session-start.sh")
+	writeFile(t, scriptPath, "#!/bin/sh\n")
+	if err := os.Chmod(scriptPath, 0644); err != nil {
+		t.Fatalf("chmod fixture: %v", err)
+	}
+
+	if _, err := refreshSetup(setupRefreshOptions{Agent: "codex", Home: home, MnemoBin: "mnemo"}); err != nil {
+		t.Fatalf("refresh setup: %v", err)
+	}
+
+	assertExecutable(t, scriptPath)
+}
+
 func readTestFile(t *testing.T, path string) string {
 	t.Helper()
 	data, err := os.ReadFile(path)

--- a/cmd/mnemo/setup_refresh_test.go
+++ b/cmd/mnemo/setup_refresh_test.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParseSetupRefreshArgs(t *testing.T) {
+	opts, err := parseSetupRefreshArgs(
+		[]string{"--agent=codex", "--home=/home/test", "--mnemo-bin=/bin/mnemo"},
+		func() (string, error) {
+			t.Fatal("userHomeDir should not be called when --home is provided")
+			return "", nil
+		},
+		func(string) (string, error) {
+			t.Fatal("lookPath should not be called when --mnemo-bin is provided")
+			return "", nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("parse setup refresh args: %v", err)
+	}
+	if opts.Agent != "codex" || opts.Home != "/home/test" || opts.MnemoBin != "/bin/mnemo" {
+		t.Fatalf("unexpected options: %+v", opts)
+	}
+}
+
+func TestRefreshSetupWritesCodexFiles(t *testing.T) {
+	home := t.TempDir()
+	updated, err := refreshSetup(setupRefreshOptions{Agent: "codex", Home: home, MnemoBin: "/bin/mnemo"})
+	if err != nil {
+		t.Fatalf("refresh setup: %v", err)
+	}
+	if len(updated) != 6 {
+		t.Fatalf("updated paths = %d, want 6 (%v)", len(updated), updated)
+	}
+
+	config := readTestFile(t, filepath.Join(home, ".codex", "config.toml"))
+	if !strings.Contains(config, `[mcp_servers.mnemo]`) || !strings.Contains(config, `command = "/bin/mnemo"`) {
+		t.Fatalf("unexpected codex config:\n%s", config)
+	}
+	hooks := readTestFile(t, filepath.Join(home, ".codex", "hooks.json"))
+	if !strings.Contains(hooks, filepath.Join(home, ".codex", "hooks", "session-start.sh")) {
+		t.Fatalf("unexpected hooks config:\n%s", hooks)
+	}
+	assertExecutable(t, filepath.Join(home, ".codex", "hooks", "session-start.sh"))
+	assertExecutable(t, filepath.Join(home, ".codex", "hooks", "stop.sh"))
+	if got := readTestFile(t, filepath.Join(home, ".codex", "hooks", "mnemo-protocol.md")); !strings.Contains(got, "mnemo — Persistent Memory Protocol") {
+		t.Fatalf("unexpected protocol: %q", got)
+	}
+}
+
+func TestRefreshSetupPreservesExistingJSONConfig(t *testing.T) {
+	home := t.TempDir()
+	writeFile(t, filepath.Join(home, ".cursor", "mcp.json"), `{"mcpServers":{"other":{"command":"other"}}}`)
+
+	if _, err := refreshSetup(setupRefreshOptions{Agent: "cursor", Home: home, MnemoBin: "mnemo"}); err != nil {
+		t.Fatalf("refresh setup: %v", err)
+	}
+
+	content := readTestFile(t, filepath.Join(home, ".cursor", "mcp.json"))
+	if !strings.Contains(content, `"other"`) || !strings.Contains(content, `"mnemo"`) {
+		t.Fatalf("merged config did not preserve existing server:\n%s", content)
+	}
+}
+
+func readTestFile(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(data)
+}
+
+func assertExecutable(t *testing.T, path string) {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	if info.Mode()&0111 == 0 {
+		t.Fatalf("%s is not executable: %v", path, info.Mode())
+	}
+}

--- a/cmd/mnemo/setup_status.go
+++ b/cmd/mnemo/setup_status.go
@@ -42,6 +42,8 @@ func runSetup() {
 		runSetupStatus()
 	case "print-config":
 		runSetupPrintConfig()
+	case "refresh":
+		runSetupRefresh()
 	default:
 		printSetupUsage()
 		os.Exit(1)
@@ -51,6 +53,7 @@ func runSetup() {
 func printSetupUsage() {
 	fmt.Fprintln(os.Stderr, "usage: mnemo setup status [--json] [--agent=AGENT] [--home=DIR]")
 	fmt.Fprintln(os.Stderr, "       mnemo setup print-config AGENT [--home=DIR] [--mnemo-bin=PATH]")
+	fmt.Fprintln(os.Stderr, "       mnemo setup refresh [--agent=AGENT] [--home=DIR] [--mnemo-bin=PATH]")
 }
 
 func runSetupStatus() {

--- a/cmd/mnemo/templates/usage.txt
+++ b/cmd/mnemo/templates/usage.txt
@@ -14,6 +14,7 @@ Usage:
   mnemo doctor [--json] [--agent=AGENT] [--path=DIR]  Run read-only diagnostics
   mnemo setup status [--json] [--agent=AGENT] [--home=DIR]  Show global agent setup status
   mnemo setup print-config AGENT [--home=DIR] [--mnemo-bin=PATH]  Print manual setup config snippets
+  mnemo setup refresh [--agent=AGENT] [--home=DIR] [--mnemo-bin=PATH]  Refresh installed global setup files
   mnemo init [--agent=AGENT] [--path=DIR]  Activate mnemo in the current project (.mnemo)
   mnemo install-instructions [--agent=AGENT]  Install global agent instructions
   mnemo migrate [--path=DIR]              Migrate project from legacy key to UUID-based identity
@@ -46,6 +47,11 @@ Setup print-config options:
   AGENT                claudecode | cursor | windsurf | codex | opencode | all
   --home=DIR           Use DIR when rendering user-level config paths
   --mnemo-bin=PATH     Use PATH as the mnemo binary in snippets
+
+Setup refresh options:
+  --agent=AGENT        Refresh one agent or all agents (default: all)
+  --home=DIR           Override home directory for global agent files
+  --mnemo-bin=PATH     Use PATH as the mnemo binary in config files
 
 Tool profiles for mcp:
   --tools=agent    15 tools for AI agents (default when using plugin)

--- a/internal/jsonmerge/merge.go
+++ b/internal/jsonmerge/merge.go
@@ -21,6 +21,16 @@ import (
 //
 // Returns true if the file was changed, false if it was already up to date.
 func MergeFile(filePath string) (changed bool, err error) {
+	var patch any
+	if err := json.NewDecoder(os.Stdin).Decode(&patch); err != nil {
+		return false, fmt.Errorf("read patch from stdin: %w", err)
+	}
+	return MergeValue(filePath, patch)
+}
+
+// MergeValue reads filePath (or starts from {} if it does not exist),
+// deep-merges patch into it, and writes the result back atomically.
+func MergeValue(filePath string, patch any) (changed bool, err error) {
 	// If filePath is a symlink, resolve it so we write to the real file and
 	// do not replace the symlink with a regular file (e.g. dotfiles setups).
 	if fi, statErr := os.Lstat(filePath); statErr == nil && fi.Mode()&os.ModeSymlink != 0 {
@@ -43,12 +53,6 @@ func MergeFile(filePath string) (changed bool, err error) {
 		if err := json.Unmarshal(data, &target); err != nil {
 			return false, fmt.Errorf("parse %s: %w", filePath, err)
 		}
-	}
-
-	// Read patch from stdin.
-	var patch any
-	if err := json.NewDecoder(os.Stdin).Decode(&patch); err != nil {
-		return false, fmt.Errorf("read patch from stdin: %w", err)
 	}
 
 	merged := deepMerge(target, patch)


### PR DESCRIPTION
## Summary
- add `mnemo setup refresh`
- refresh agent instructions, config, and runtime files
- update docs and roadmap

## Tests
- go test ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `mnemo setup refresh` to reinstall and update global agent integrations.
  - Refresh supports selecting agents and customizing the home directory or executable path.
  - Updates agent instructions, configuration, hooks, and plugins while preserving existing configuration entries.
  - Reports updated files and signals failures through the command’s exit status.

- **Documentation**
  - Added setup refresh usage, options, and verification examples to the CLI documentation and roadmap.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->