### PR TITLE
Add setup uninstall command

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ mnemo --version
 - **Portable Agent Skill:** teaches compatible agents the complete mnemo workflow without weakening the always-active safety rules
 - **Full CLI:** save, search, export, import, inspect, and diagnose memories from the terminal
 - **Read-only diagnostics:** `mnemo doctor` checks project activation, global agent setup, MCP config, hooks/plugins, and local store health
-- **Setup lifecycle:** `mnemo setup status`, `print-config`, and `refresh` inspect, print, and refresh global agent configuration
+- **Setup lifecycle:** `mnemo setup status`, `print-config`, `refresh`, and `uninstall` inspect and maintain global agent configuration
 - **Own storage:** isolated `~/.mnemo/memory.db`, created automatically on first run
 - **Claude Code + Cursor + Windsurf + Codex + OpenCode:** native integration for all five agents via their respective hook systems
 
@@ -266,6 +266,7 @@ mnemo doctor [--json] [--agent=AGENT] [--path=DIR]  Run read-only diagnostics
 mnemo setup status [--json] [--agent=AGENT] [--home=DIR]  Show global agent setup status
 mnemo setup print-config AGENT [--home=DIR] [--mnemo-bin=PATH]  Print manual setup config snippets
 mnemo setup refresh [--agent=AGENT] [--home=DIR] [--mnemo-bin=PATH]  Refresh installed global setup files
+mnemo setup uninstall --agent=AGENT [--home=DIR]  Remove global setup files for an agent
 mnemo save <title> <content>         Save a memory
 mnemo search <query>                 Search memories
 mnemo context [project]              Show context from previous sessions
@@ -345,6 +346,7 @@ mnemo doctor --json --agent=codex --path=.
 mnemo setup status --agent=all
 mnemo setup print-config codex
 mnemo setup refresh --agent=codex
+mnemo setup uninstall --agent=codex
 
 # Project activation
 cat .mnemo                          # must contain id + agents list

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,18 +2,6 @@
 
 This document tracks planned capabilities that are not yet released. Released behavior belongs in release notes, not here.
 
-## Setup lifecycle
-
-Add explicit setup maintenance commands for global agent integrations:
-
-```bash
-mnemo setup uninstall --agent=codex
-```
-
-Goals:
-
-- uninstall mnemo from selected agents without removing the local database;
-
 ## Project management
 
 Add project management commands for UUID-based projects:

--- a/cmd/mnemo/setup_refresh.go
+++ b/cmd/mnemo/setup_refresh.go
@@ -173,33 +173,41 @@ func upsertCodexMCPConfig(path, section string) error {
 }
 
 func refreshAgentRuntimeFiles(home, agent string) ([]string, error) {
+	targets, err := setupRuntimeAssetTargets(agent)
+	if err != nil {
+		return nil, err
+	}
+	return writeSetupAssets(home, targets)
+}
+
+func setupRuntimeAssetTargets(agent string) ([]setupAssetTarget, error) {
 	switch agent {
 	case "claudecode":
 		// Claude Code hooks are managed by the Claude plugin installation.
 		return nil, nil
 	case "cursor":
-		return writeSetupAssets(home, []setupAssetTarget{
+		return []setupAssetTarget{
 			{Asset: "scripts/cursor/hooks/before-submit-prompt.sh", Path: filepath.Join(".cursor", "hooks", "before-submit-prompt.sh"), Mode: 0755},
 			{Asset: "scripts/cursor/hooks/stop.sh", Path: filepath.Join(".cursor", "hooks", "stop.sh"), Mode: 0755},
-		})
+		}, nil
 	case "windsurf":
-		return writeSetupAssets(home, []setupAssetTarget{
+		return []setupAssetTarget{
 			{Asset: "scripts/windsurf/hooks/pre-user-prompt.sh", Path: filepath.Join(".codeium", "windsurf", "hooks", "pre-user-prompt.sh"), Mode: 0755},
 			{Asset: "scripts/windsurf/hooks/post-cascade-response.sh", Path: filepath.Join(".codeium", "windsurf", "hooks", "post-cascade-response.sh"), Mode: 0755},
-		})
+		}, nil
 	case "codex":
-		return writeSetupAssets(home, []setupAssetTarget{
+		return []setupAssetTarget{
 			{Asset: "scripts/codex/hooks/session-start.sh", Path: filepath.Join(".codex", "hooks", "session-start.sh"), Mode: 0755},
 			{Asset: "scripts/codex/hooks/stop.sh", Path: filepath.Join(".codex", "hooks", "stop.sh"), Mode: 0755},
 			{Asset: "scripts/codex/hooks/mnemo-protocol.md", Path: filepath.Join(".codex", "hooks", "mnemo-protocol.md"), Mode: 0644},
-		})
+		}, nil
 	case "opencode":
-		return writeSetupAssets(home, []setupAssetTarget{
+		return []setupAssetTarget{
 			{Asset: "scripts/opencode/plugins/mnemo.ts", Path: filepath.Join(".config", "opencode", "plugins", "mnemo.ts"), Mode: 0644},
 			{Asset: "scripts/opencode/plugins/mnemo-protocol.md", Path: filepath.Join(".config", "opencode", "plugins", "mnemo-protocol.md"), Mode: 0644},
-		})
+		}, nil
 	default:
-		return nil, fmt.Errorf("unsupported agent %q for setup refresh", agent)
+		return nil, fmt.Errorf("unsupported agent %q for setup runtime files", agent)
 	}
 }
 

--- a/cmd/mnemo/setup_refresh.go
+++ b/cmd/mnemo/setup_refresh.go
@@ -144,13 +144,15 @@ func upsertCodexMCPConfig(path, section string) error {
 	replaced := false
 	for _, line := range lines {
 		trimmed := strings.TrimSpace(line)
-		if trimmed == "[mcp_servers.mnemo]" {
-			out = append(out, strings.TrimRight(section, "\n"))
+		if isCodexMnemoTableHeader(trimmed) {
+			if !replaced {
+				out = append(out, strings.TrimRight(section, "\n"))
+			}
 			skipping = true
 			replaced = true
 			continue
 		}
-		if skipping && strings.HasPrefix(trimmed, "[") {
+		if skipping && isTOMLTableHeader(trimmed) {
 			skipping = false
 		}
 		if !skipping {

--- a/cmd/mnemo/setup_refresh_test.go
+++ b/cmd/mnemo/setup_refresh_test.go
@@ -66,6 +66,35 @@ func TestRefreshSetupPreservesExistingJSONConfig(t *testing.T) {
 	}
 }
 
+func TestRefreshSetupReplacesCodexMCPNestedTables(t *testing.T) {
+	home := t.TempDir()
+	configPath := filepath.Join(home, ".codex", "config.toml")
+	writeFile(t, configPath, `[mcp_servers.mnemo]
+command = "/old/mnemo"
+
+[mcp_servers.mnemo.env]
+STALE = "yes"
+
+[mcp_servers.other]
+command = "other"
+`)
+
+	if _, err := refreshSetup(setupRefreshOptions{Agent: "codex", Home: home, MnemoBin: "/bin/mnemo"}); err != nil {
+		t.Fatalf("refresh setup: %v", err)
+	}
+
+	content := readTestFile(t, configPath)
+	if !strings.Contains(content, `[mcp_servers.mnemo]`) || !strings.Contains(content, `command = "/bin/mnemo"`) {
+		t.Fatalf("mnemo MCP config was not refreshed:\n%s", content)
+	}
+	if strings.Contains(content, `[mcp_servers.mnemo.env]`) || strings.Contains(content, "STALE") {
+		t.Fatalf("stale mnemo nested table was not removed:\n%s", content)
+	}
+	if !strings.Contains(content, `[mcp_servers.other]`) {
+		t.Fatalf("unrelated MCP config was not preserved:\n%s", content)
+	}
+}
+
 func TestRefreshSetupRestoresExistingScriptPermissions(t *testing.T) {
 	home := t.TempDir()
 	scriptPath := filepath.Join(home, ".codex", "hooks", "session-start.sh")

--- a/cmd/mnemo/setup_status.go
+++ b/cmd/mnemo/setup_status.go
@@ -44,6 +44,8 @@ func runSetup() {
 		runSetupPrintConfig()
 	case "refresh":
 		runSetupRefresh()
+	case "uninstall":
+		runSetupUninstall()
 	default:
 		printSetupUsage()
 		os.Exit(1)
@@ -54,6 +56,7 @@ func printSetupUsage() {
 	fmt.Fprintln(os.Stderr, "usage: mnemo setup status [--json] [--agent=AGENT] [--home=DIR]")
 	fmt.Fprintln(os.Stderr, "       mnemo setup print-config AGENT [--home=DIR] [--mnemo-bin=PATH]")
 	fmt.Fprintln(os.Stderr, "       mnemo setup refresh [--agent=AGENT] [--home=DIR] [--mnemo-bin=PATH]")
+	fmt.Fprintln(os.Stderr, "       mnemo setup uninstall --agent=AGENT [--home=DIR]")
 }
 
 func runSetupStatus() {

--- a/cmd/mnemo/setup_uninstall.go
+++ b/cmd/mnemo/setup_uninstall.go
@@ -1,0 +1,339 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/jmeiracorbal/mnemo/internal/agentinit"
+)
+
+type setupUninstallOptions struct {
+	Agent string
+	Home  string
+}
+
+func runSetupUninstall() {
+	opts, err := parseSetupUninstallArgs(os.Args[3:], os.UserHomeDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mnemo setup uninstall: %v\n", err)
+		os.Exit(1)
+	}
+	removed, err := uninstallSetup(opts)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mnemo setup uninstall: %v\n", err)
+		os.Exit(1)
+	}
+	for _, path := range removed {
+		fmt.Printf("mnemo setup uninstall: updated %s\n", path)
+	}
+}
+
+func parseSetupUninstallArgs(args []string, userHomeDir func() (string, error)) (setupUninstallOptions, error) {
+	var opts setupUninstallOptions
+	for _, arg := range args {
+		switch {
+		case strings.HasPrefix(arg, "--agent="):
+			opts.Agent = strings.TrimSpace(arg[len("--agent="):])
+		case strings.HasPrefix(arg, "--home="):
+			opts.Home = arg[len("--home="):]
+		default:
+			return opts, fmt.Errorf("unknown argument %q", arg)
+		}
+	}
+	if opts.Agent == "" {
+		return opts, fmt.Errorf("missing --agent=AGENT")
+	}
+	if opts.Home == "" {
+		home, err := userHomeDir()
+		if err != nil {
+			return opts, fmt.Errorf("home: %w", err)
+		}
+		opts.Home = home
+	}
+	return opts, nil
+}
+
+func uninstallSetup(opts setupUninstallOptions) ([]string, error) {
+	agents, err := agentinit.ExpandAgents(opts.Agent)
+	if err != nil {
+		return nil, err
+	}
+	var removed []string
+	for _, agent := range agents {
+		agentRemoved, err := uninstallAgentSetup(opts.Home, agent)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", agent, err)
+		}
+		removed = append(removed, agentRemoved...)
+	}
+	return removed, nil
+}
+
+func uninstallAgentSetup(home, agent string) ([]string, error) {
+	var removed []string
+
+	instructionsPath, changed, err := agentinit.RemoveGlobalInstructions(home, agent)
+	if err != nil {
+		return nil, err
+	}
+	if changed {
+		removed = append(removed, instructionsPath)
+	}
+
+	configFiles, err := uninstallAgentConfig(home, agent)
+	if err != nil {
+		return nil, err
+	}
+	removed = append(removed, configFiles...)
+
+	runtimeFiles, err := uninstallAgentRuntimeFiles(home, agent)
+	if err != nil {
+		return nil, err
+	}
+	removed = append(removed, runtimeFiles...)
+	return removed, nil
+}
+
+func uninstallAgentConfig(home, agent string) ([]string, error) {
+	var removed []string
+	appendIfChanged := func(path string, changed bool, err error) error {
+		if err != nil {
+			return err
+		}
+		if changed {
+			removed = append(removed, path)
+		}
+		return nil
+	}
+
+	switch agent {
+	case "claudecode":
+		path := filepath.Join(home, ".claude", ".mcp.json")
+		changed, err := removeMCPServer(path, "mcpServers", "mnemo")
+		err = appendIfChanged(path, changed, err)
+		return removed, err
+	case "cursor":
+		mcpPath := filepath.Join(home, ".cursor", "mcp.json")
+		changed, err := removeMCPServer(mcpPath, "mcpServers", "mnemo")
+		if err := appendIfChanged(mcpPath, changed, err); err != nil {
+			return nil, err
+		}
+		hooksPath := filepath.Join(home, ".cursor", "hooks.json")
+		hooksDir := filepath.Join(home, ".cursor", "hooks")
+		changed, err = removeHookCommands(hooksPath, map[string]string{
+			"beforeSubmitPrompt": filepath.Join(hooksDir, "before-submit-prompt.sh"),
+			"stop":               filepath.Join(hooksDir, "stop.sh"),
+		})
+		err = appendIfChanged(hooksPath, changed, err)
+		return removed, err
+	case "windsurf":
+		mcpPath := filepath.Join(home, ".codeium", "windsurf", "mcp_config.json")
+		changed, err := removeMCPServer(mcpPath, "mcpServers", "mnemo")
+		if err := appendIfChanged(mcpPath, changed, err); err != nil {
+			return nil, err
+		}
+		hooksPath := filepath.Join(home, ".codeium", "windsurf", "hooks.json")
+		hooksDir := filepath.Join(home, ".codeium", "windsurf", "hooks")
+		changed, err = removeHookCommands(hooksPath, map[string]string{
+			"pre_user_prompt":                       filepath.Join(hooksDir, "pre-user-prompt.sh"),
+			"post_cascade_response_with_transcript": filepath.Join(hooksDir, "post-cascade-response.sh"),
+		})
+		err = appendIfChanged(hooksPath, changed, err)
+		return removed, err
+	case "codex":
+		configPath := filepath.Join(home, ".codex", "config.toml")
+		changed, err := removeCodexMCPConfig(configPath)
+		if err := appendIfChanged(configPath, changed, err); err != nil {
+			return nil, err
+		}
+		hooksPath := filepath.Join(home, ".codex", "hooks.json")
+		hooksDir := filepath.Join(home, ".codex", "hooks")
+		changed, err = removeHookCommands(hooksPath, map[string]string{
+			"SessionStart": filepath.Join(hooksDir, "session-start.sh"),
+			"Stop":         filepath.Join(hooksDir, "stop.sh"),
+		})
+		err = appendIfChanged(hooksPath, changed, err)
+		return removed, err
+	case "opencode":
+		path := filepath.Join(home, ".config", "opencode", "opencode.json")
+		changed, err := removeMCPServer(path, "mcp", "mnemo")
+		err = appendIfChanged(path, changed, err)
+		return removed, err
+	default:
+		return nil, fmt.Errorf("unsupported agent %q for setup uninstall", agent)
+	}
+}
+
+func uninstallAgentRuntimeFiles(home, agent string) ([]string, error) {
+	targets, err := setupRuntimeAssetTargets(agent)
+	if err != nil {
+		return nil, err
+	}
+	removed := make([]string, 0, len(targets))
+	for _, target := range targets {
+		path := filepath.Join(home, target.Path)
+		if err := os.Remove(path); err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, err
+		}
+		removed = append(removed, path)
+	}
+	return removed, nil
+}
+
+func removeMCPServer(path, rootKey, serverName string) (bool, error) {
+	return updateJSONFile(path, func(root map[string]any) bool {
+		servers, ok := root[rootKey].(map[string]any)
+		if !ok {
+			return false
+		}
+		if _, ok := servers[serverName]; !ok {
+			return false
+		}
+		delete(servers, serverName)
+		if len(servers) == 0 {
+			delete(root, rootKey)
+		}
+		return true
+	})
+}
+
+func removeHookCommands(path string, eventCommands map[string]string) (bool, error) {
+	return updateJSONFile(path, func(root map[string]any) bool {
+		hooks, ok := root["hooks"].(map[string]any)
+		if !ok {
+			return false
+		}
+		changed := false
+		for event, command := range eventCommands {
+			items, ok := hooks[event].([]any)
+			if !ok {
+				continue
+			}
+			kept := make([]any, 0, len(items))
+			for _, item := range items {
+				if containsCommand(item, command) {
+					changed = true
+					continue
+				}
+				kept = append(kept, item)
+			}
+			if len(kept) == 0 {
+				delete(hooks, event)
+			} else {
+				hooks[event] = kept
+			}
+		}
+		if len(hooks) == 0 {
+			delete(root, "hooks")
+		}
+		return changed
+	})
+}
+
+func updateJSONFile(path string, mutate func(map[string]any) bool) (bool, error) {
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	var root map[string]any
+	if len(data) > 0 {
+		if err := json.Unmarshal(data, &root); err != nil {
+			return false, fmt.Errorf("parse %s: %w", path, err)
+		}
+	}
+	if root == nil {
+		root = map[string]any{}
+	}
+	if !mutate(root) {
+		return false, nil
+	}
+	if len(root) == 0 {
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return false, err
+		}
+		return true, nil
+	}
+	out, err := json.MarshalIndent(root, "", "  ")
+	if err != nil {
+		return false, err
+	}
+	out = append(out, '\n')
+	if err := os.WriteFile(path, out, 0644); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func containsCommand(v any, command string) bool {
+	switch value := v.(type) {
+	case map[string]any:
+		for key, item := range value {
+			if key == "command" {
+				if got, ok := item.(string); ok && got == command {
+					return true
+				}
+			}
+			if containsCommand(item, command) {
+				return true
+			}
+		}
+	case []any:
+		for _, item := range value {
+			if containsCommand(item, command) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func removeCodexMCPConfig(path string) (bool, error) {
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+
+	lines := strings.Split(string(data), "\n")
+	removed := false
+	skipping := false
+	out := make([]string, 0, len(lines))
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "[mcp_servers.mnemo]" {
+			removed = true
+			skipping = true
+			continue
+		}
+		if skipping && strings.HasPrefix(trimmed, "[") {
+			skipping = false
+		}
+		if !skipping {
+			out = append(out, line)
+		}
+	}
+	if !removed {
+		return false, nil
+	}
+
+	content := strings.TrimRight(strings.Join(out, "\n"), "\n")
+	if strings.TrimSpace(content) == "" {
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return false, err
+		}
+		return true, nil
+	}
+	content += "\n"
+	return true, os.WriteFile(path, []byte(content), 0644)
+}

--- a/cmd/mnemo/setup_uninstall.go
+++ b/cmd/mnemo/setup_uninstall.go
@@ -23,9 +23,14 @@ func runSetupUninstall() {
 	}
 	removed, err := uninstallSetup(opts)
 	if err != nil {
+		printSetupUninstallRemoved(removed)
 		fmt.Fprintf(os.Stderr, "mnemo setup uninstall: %v\n", err)
 		os.Exit(1)
 	}
+	printSetupUninstallRemoved(removed)
+}
+
+func printSetupUninstallRemoved(removed []string) {
 	for _, path := range removed {
 		fmt.Printf("mnemo setup uninstall: updated %s\n", path)
 	}
@@ -64,10 +69,10 @@ func uninstallSetup(opts setupUninstallOptions) ([]string, error) {
 	var removed []string
 	for _, agent := range agents {
 		agentRemoved, err := uninstallAgentSetup(opts.Home, agent)
-		if err != nil {
-			return nil, fmt.Errorf("%s: %w", agent, err)
-		}
 		removed = append(removed, agentRemoved...)
+		if err != nil {
+			return removed, fmt.Errorf("%s: %w", agent, err)
+		}
 	}
 	return removed, nil
 }
@@ -77,23 +82,23 @@ func uninstallAgentSetup(home, agent string) ([]string, error) {
 
 	instructionsPath, changed, err := agentinit.RemoveGlobalInstructions(home, agent)
 	if err != nil {
-		return nil, err
+		return removed, err
 	}
 	if changed {
 		removed = append(removed, instructionsPath)
 	}
 
 	configFiles, err := uninstallAgentConfig(home, agent)
-	if err != nil {
-		return nil, err
-	}
 	removed = append(removed, configFiles...)
+	if err != nil {
+		return removed, err
+	}
 
 	runtimeFiles, err := uninstallAgentRuntimeFiles(home, agent)
-	if err != nil {
-		return nil, err
-	}
 	removed = append(removed, runtimeFiles...)
+	if err != nil {
+		return removed, err
+	}
 	return removed, nil
 }
 
@@ -119,7 +124,7 @@ func uninstallAgentConfig(home, agent string) ([]string, error) {
 		mcpPath := filepath.Join(home, ".cursor", "mcp.json")
 		changed, err := removeMCPServer(mcpPath, "mcpServers", "mnemo")
 		if err := appendIfChanged(mcpPath, changed, err); err != nil {
-			return nil, err
+			return removed, err
 		}
 		hooksPath := filepath.Join(home, ".cursor", "hooks.json")
 		hooksDir := filepath.Join(home, ".cursor", "hooks")
@@ -133,7 +138,7 @@ func uninstallAgentConfig(home, agent string) ([]string, error) {
 		mcpPath := filepath.Join(home, ".codeium", "windsurf", "mcp_config.json")
 		changed, err := removeMCPServer(mcpPath, "mcpServers", "mnemo")
 		if err := appendIfChanged(mcpPath, changed, err); err != nil {
-			return nil, err
+			return removed, err
 		}
 		hooksPath := filepath.Join(home, ".codeium", "windsurf", "hooks.json")
 		hooksDir := filepath.Join(home, ".codeium", "windsurf", "hooks")
@@ -147,7 +152,7 @@ func uninstallAgentConfig(home, agent string) ([]string, error) {
 		configPath := filepath.Join(home, ".codex", "config.toml")
 		changed, err := removeCodexMCPConfig(configPath)
 		if err := appendIfChanged(configPath, changed, err); err != nil {
-			return nil, err
+			return removed, err
 		}
 		hooksPath := filepath.Join(home, ".codex", "hooks.json")
 		hooksDir := filepath.Join(home, ".codex", "hooks")
@@ -179,7 +184,7 @@ func uninstallAgentRuntimeFiles(home, agent string) ([]string, error) {
 			if os.IsNotExist(err) {
 				continue
 			}
-			return nil, err
+			return removed, err
 		}
 		removed = append(removed, path)
 	}
@@ -311,12 +316,12 @@ func removeCodexMCPConfig(path string) (bool, error) {
 	out := make([]string, 0, len(lines))
 	for _, line := range lines {
 		trimmed := strings.TrimSpace(line)
-		if trimmed == "[mcp_servers.mnemo]" {
+		if isCodexMnemoTableHeader(trimmed) {
 			removed = true
 			skipping = true
 			continue
 		}
-		if skipping && strings.HasPrefix(trimmed, "[") {
+		if skipping && isTOMLTableHeader(trimmed) {
 			skipping = false
 		}
 		if !skipping {
@@ -336,4 +341,26 @@ func removeCodexMCPConfig(path string) (bool, error) {
 	}
 	content += "\n"
 	return true, os.WriteFile(path, []byte(content), 0644)
+}
+
+func isCodexMnemoTableHeader(line string) bool {
+	name, ok := tomlTableName(line)
+	return ok && (name == "mcp_servers.mnemo" || strings.HasPrefix(name, "mcp_servers.mnemo."))
+}
+
+func isTOMLTableHeader(line string) bool {
+	_, ok := tomlTableName(line)
+	return ok
+}
+
+func tomlTableName(line string) (string, bool) {
+	line = strings.TrimSpace(line)
+	switch {
+	case strings.HasPrefix(line, "[[") && strings.HasSuffix(line, "]]"):
+		return strings.TrimSpace(line[2 : len(line)-2]), true
+	case strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]"):
+		return strings.TrimSpace(line[1 : len(line)-1]), true
+	default:
+		return "", false
+	}
 }

--- a/cmd/mnemo/setup_uninstall_test.go
+++ b/cmd/mnemo/setup_uninstall_test.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParseSetupUninstallArgsRequiresAgent(t *testing.T) {
+	_, err := parseSetupUninstallArgs([]string{"--home=/home/test"}, func() (string, error) {
+		t.Fatal("userHomeDir should not be called when --home is provided")
+		return "", nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "missing --agent") {
+		t.Fatalf("error = %v, want missing --agent", err)
+	}
+}
+
+func TestParseSetupUninstallArgs(t *testing.T) {
+	opts, err := parseSetupUninstallArgs([]string{"--agent=codex", "--home=/home/test"}, func() (string, error) {
+		t.Fatal("userHomeDir should not be called when --home is provided")
+		return "", nil
+	})
+	if err != nil {
+		t.Fatalf("parse setup uninstall args: %v", err)
+	}
+	if opts.Agent != "codex" || opts.Home != "/home/test" {
+		t.Fatalf("unexpected options: %+v", opts)
+	}
+}
+
+func TestUninstallSetupRemovesCodexFilesAndPreservesUserConfig(t *testing.T) {
+	home := t.TempDir()
+	writeFile(t, filepath.Join(home, ".codex", "AGENTS.md"), "# Existing\n\nUser content.\n")
+	writeFile(t, filepath.Join(home, ".codex", "config.toml"), "[mcp_servers.other]\ncommand = \"other\"\n")
+	writeFile(t, filepath.Join(home, ".codex", "hooks.json"), `{"hooks":{"Stop":[{"matcher":"other","hooks":[{"type":"command","command":"/bin/other"}]}]}}`)
+
+	if _, err := refreshSetup(setupRefreshOptions{Agent: "codex", Home: home, MnemoBin: "/bin/mnemo"}); err != nil {
+		t.Fatalf("refresh setup: %v", err)
+	}
+	removed, err := uninstallSetup(setupUninstallOptions{Agent: "codex", Home: home})
+	if err != nil {
+		t.Fatalf("uninstall setup: %v", err)
+	}
+	if len(removed) == 0 {
+		t.Fatal("uninstall did not report removed paths")
+	}
+
+	agents := readTestFile(t, filepath.Join(home, ".codex", "AGENTS.md"))
+	if !strings.Contains(agents, "# Existing\n\nUser content.") {
+		t.Fatalf("user instructions were not preserved:\n%s", agents)
+	}
+	if strings.Contains(agents, "mnemo:start") {
+		t.Fatalf("mnemo instructions were not removed:\n%s", agents)
+	}
+
+	config := readTestFile(t, filepath.Join(home, ".codex", "config.toml"))
+	if !strings.Contains(config, "[mcp_servers.other]") {
+		t.Fatalf("user MCP config was not preserved:\n%s", config)
+	}
+	if strings.Contains(config, "[mcp_servers.mnemo]") {
+		t.Fatalf("mnemo MCP config was not removed:\n%s", config)
+	}
+
+	hooks := readTestFile(t, filepath.Join(home, ".codex", "hooks.json"))
+	if !strings.Contains(hooks, "/bin/other") {
+		t.Fatalf("user hook was not preserved:\n%s", hooks)
+	}
+	if strings.Contains(hooks, "session-start.sh") || strings.Contains(hooks, "stop.sh") {
+		t.Fatalf("mnemo hooks were not removed:\n%s", hooks)
+	}
+
+	assertMissing(t, filepath.Join(home, ".codex", "hooks", "session-start.sh"))
+	assertMissing(t, filepath.Join(home, ".codex", "hooks", "stop.sh"))
+	assertMissing(t, filepath.Join(home, ".codex", "hooks", "mnemo-protocol.md"))
+}
+
+func TestUninstallSetupRemovesCursorConfigAndRuntimeFiles(t *testing.T) {
+	home := t.TempDir()
+	writeFile(t, filepath.Join(home, ".cursor", "mcp.json"), `{"mcpServers":{"other":{"command":"other"}}}`)
+	writeFile(t, filepath.Join(home, ".cursor", "hooks.json"), `{"hooks":{"stop":[{"command":"/bin/other"}]}}`)
+
+	if _, err := refreshSetup(setupRefreshOptions{Agent: "cursor", Home: home, MnemoBin: "/bin/mnemo"}); err != nil {
+		t.Fatalf("refresh setup: %v", err)
+	}
+	if _, err := uninstallSetup(setupUninstallOptions{Agent: "cursor", Home: home}); err != nil {
+		t.Fatalf("uninstall setup: %v", err)
+	}
+
+	mcp := readTestFile(t, filepath.Join(home, ".cursor", "mcp.json"))
+	if !strings.Contains(mcp, "other") || strings.Contains(mcp, "mnemo") {
+		t.Fatalf("unexpected cursor MCP config:\n%s", mcp)
+	}
+	hooks := readTestFile(t, filepath.Join(home, ".cursor", "hooks.json"))
+	if !strings.Contains(hooks, "/bin/other") || strings.Contains(hooks, "before-submit-prompt.sh") || strings.Contains(hooks, "stop.sh") {
+		t.Fatalf("unexpected cursor hooks config:\n%s", hooks)
+	}
+	assertMissing(t, filepath.Join(home, ".cursor", "rules", "mnemo.mdc"))
+	assertMissing(t, filepath.Join(home, ".cursor", "hooks", "before-submit-prompt.sh"))
+	assertMissing(t, filepath.Join(home, ".cursor", "hooks", "stop.sh"))
+}
+
+func assertMissing(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("%s exists or stat failed: %v", path, err)
+	}
+}

--- a/cmd/mnemo/setup_uninstall_test.go
+++ b/cmd/mnemo/setup_uninstall_test.go
@@ -76,6 +76,36 @@ func TestUninstallSetupRemovesCodexFilesAndPreservesUserConfig(t *testing.T) {
 	assertMissing(t, filepath.Join(home, ".codex", "hooks", "mnemo-protocol.md"))
 }
 
+func TestRemoveCodexMCPConfigRemovesNestedTables(t *testing.T) {
+	home := t.TempDir()
+	configPath := filepath.Join(home, ".codex", "config.toml")
+	writeFile(t, configPath, `[mcp_servers.mnemo]
+command = "/bin/mnemo"
+
+[mcp_servers.mnemo.env]
+STALE = "yes"
+
+[mcp_servers.other]
+command = "other"
+`)
+
+	changed, err := removeCodexMCPConfig(configPath)
+	if err != nil {
+		t.Fatalf("remove codex MCP config: %v", err)
+	}
+	if !changed {
+		t.Fatal("remove codex MCP config did not report a change")
+	}
+
+	content := readTestFile(t, configPath)
+	if strings.Contains(content, `[mcp_servers.mnemo]`) || strings.Contains(content, `[mcp_servers.mnemo.env]`) || strings.Contains(content, "STALE") {
+		t.Fatalf("mnemo table was not fully removed:\n%s", content)
+	}
+	if !strings.Contains(content, `[mcp_servers.other]`) {
+		t.Fatalf("unrelated table was not preserved:\n%s", content)
+	}
+}
+
 func TestUninstallSetupRemovesCursorConfigAndRuntimeFiles(t *testing.T) {
 	home := t.TempDir()
 	writeFile(t, filepath.Join(home, ".cursor", "mcp.json"), `{"mcpServers":{"other":{"command":"other"}}}`)
@@ -99,6 +129,28 @@ func TestUninstallSetupRemovesCursorConfigAndRuntimeFiles(t *testing.T) {
 	assertMissing(t, filepath.Join(home, ".cursor", "rules", "mnemo.mdc"))
 	assertMissing(t, filepath.Join(home, ".cursor", "hooks", "before-submit-prompt.sh"))
 	assertMissing(t, filepath.Join(home, ".cursor", "hooks", "stop.sh"))
+}
+
+func TestUninstallAgentRuntimeFilesPreservesRemovedPathsOnError(t *testing.T) {
+	home := t.TempDir()
+	firstPath := filepath.Join(home, ".codex", "hooks", "session-start.sh")
+	secondPath := filepath.Join(home, ".codex", "hooks", "stop.sh")
+	writeFile(t, firstPath, "#!/bin/sh\n")
+	if err := os.MkdirAll(filepath.Join(secondPath, "child"), 0755); err != nil {
+		t.Fatalf("mkdir fixture: %v", err)
+	}
+
+	removed, err := uninstallAgentRuntimeFiles(home, "codex")
+	if err == nil {
+		t.Fatal("uninstall runtime files unexpectedly succeeded")
+	}
+	if len(removed) != 1 || removed[0] != firstPath {
+		t.Fatalf("removed = %v, want [%s]", removed, firstPath)
+	}
+	assertMissing(t, firstPath)
+	if _, statErr := os.Stat(secondPath); statErr != nil {
+		t.Fatalf("second path should remain after failed removal: %v", statErr)
+	}
 }
 
 func assertMissing(t *testing.T, path string) {

--- a/cmd/mnemo/templates/usage.txt
+++ b/cmd/mnemo/templates/usage.txt
@@ -15,6 +15,7 @@ Usage:
   mnemo setup status [--json] [--agent=AGENT] [--home=DIR]  Show global agent setup status
   mnemo setup print-config AGENT [--home=DIR] [--mnemo-bin=PATH]  Print manual setup config snippets
   mnemo setup refresh [--agent=AGENT] [--home=DIR] [--mnemo-bin=PATH]  Refresh installed global setup files
+  mnemo setup uninstall --agent=AGENT [--home=DIR]  Remove global setup files for an agent
   mnemo init [--agent=AGENT] [--path=DIR]  Activate mnemo in the current project (.mnemo)
   mnemo install-instructions [--agent=AGENT]  Install global agent instructions
   mnemo migrate [--path=DIR]              Migrate project from legacy key to UUID-based identity
@@ -52,6 +53,10 @@ Setup refresh options:
   --agent=AGENT        Refresh one agent or all agents (default: all)
   --home=DIR           Override home directory for global agent files
   --mnemo-bin=PATH     Use PATH as the mnemo binary in config files
+
+Setup uninstall options:
+  --agent=AGENT        Remove one agent or all agents (required)
+  --home=DIR           Override home directory for global agent files
 
 Tool profiles for mcp:
   --tools=agent    15 tools for AI agents (default when using plugin)

--- a/internal/agentinit/common.go
+++ b/internal/agentinit/common.go
@@ -183,6 +183,12 @@ func AppendSection(path, content string) error {
 	return upsertManagedSection(path, sectionStart, sectionEnd, content, "")
 }
 
+// RemoveSection removes the managed mnemo protocol section from path.
+// Content outside the markers is preserved.
+func RemoveSection(path string) (bool, error) {
+	return removeManagedSection(path, sectionStart, sectionEnd)
+}
+
 // AppendClaudeSection creates or updates the Claude-specific managed section.
 // It also adds @AGENTS.md once when creating the section.
 func AppendClaudeSection(path, content string) error {
@@ -254,6 +260,48 @@ func appendSection(existing, addition string) string {
 		return existing + "\n" + addition + "\n"
 	}
 	return existing + "\n\n" + addition + "\n"
+}
+
+func removeManagedSection(path, startMarker, endMarker string) (bool, error) {
+	existing, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+
+	current := string(existing)
+	startCount := strings.Count(current, startMarker)
+	endCount := strings.Count(current, endMarker)
+	if startCount != endCount || startCount > 1 {
+		return false, fmt.Errorf(
+			"malformed managed section: found %d %q marker(s) and %d %q marker(s)",
+			startCount, startMarker, endCount, endMarker,
+		)
+	}
+	if startCount == 0 {
+		return false, nil
+	}
+	start := strings.Index(current, startMarker)
+	end := strings.Index(current, endMarker)
+	if end < start {
+		return false, fmt.Errorf("malformed managed section: %q appears before %q", endMarker, startMarker)
+	}
+	end += len(endMarker)
+	updated := current[:start] + current[end:]
+	updated = strings.TrimRight(updated, "\n")
+	if strings.TrimSpace(updated) == "" {
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return false, err
+		}
+		return true, nil
+	}
+	updated += "\n"
+	if updated == current {
+		return false, nil
+	}
+	return true, os.WriteFile(path, []byte(updated), 0644)
 }
 
 // WriteFile writes data to path, creating parent directories. Overwrites if exists.

--- a/internal/agentinit/global.go
+++ b/internal/agentinit/global.go
@@ -2,6 +2,7 @@ package agentinit
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/jmeiracorbal/mnemo/templates"
@@ -62,4 +63,24 @@ func InstallGlobalInstructions(home, agent string) (string, error) {
 		return "", err
 	}
 	return path, nil
+}
+
+// RemoveGlobalInstructions removes mnemo's global instruction surface for an
+// agent while preserving user content outside the managed mnemo section.
+func RemoveGlobalInstructions(home, agent string) (string, bool, error) {
+	path, err := GlobalInstructionPath(home, agent)
+	if err != nil {
+		return "", false, err
+	}
+	if agent == "cursor" {
+		if err := os.Remove(path); err != nil {
+			if os.IsNotExist(err) {
+				return path, false, nil
+			}
+			return path, false, err
+		}
+		return path, true, nil
+	}
+	changed, err := RemoveSection(path)
+	return path, changed, err
 }

--- a/internal/agentinit/global_test.go
+++ b/internal/agentinit/global_test.go
@@ -75,3 +75,67 @@ func TestInstallGlobalInstructionsPreservesExistingMarkedFile(t *testing.T) {
 		t.Fatalf("managed section not idempotent:\n%s", content)
 	}
 }
+
+func TestRemoveGlobalInstructionsPreservesUserContent(t *testing.T) {
+	home := t.TempDir()
+	path := filepath.Join(home, ".codex", "AGENTS.md")
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("# Existing\n\nUser content.\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := InstallGlobalInstructions(home, "codex"); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+
+	gotPath, changed, err := RemoveGlobalInstructions(home, "codex")
+	if err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	if !changed {
+		t.Fatal("remove did not report a change")
+	}
+	if gotPath != path {
+		t.Fatalf("path = %q, want %q", gotPath, path)
+	}
+
+	content := string(mustReadFile(t, path))
+	if !strings.Contains(content, "# Existing\n\nUser content.") {
+		t.Fatalf("existing content was not preserved:\n%s", content)
+	}
+	if strings.Contains(content, sectionStart) || strings.Contains(content, sectionEnd) {
+		t.Fatalf("managed section was not removed:\n%s", content)
+	}
+}
+
+func TestRemoveGlobalInstructionsRemovesCursorRuleFile(t *testing.T) {
+	home := t.TempDir()
+	path, err := InstallGlobalInstructions(home, "cursor")
+	if err != nil {
+		t.Fatalf("install: %v", err)
+	}
+
+	gotPath, changed, err := RemoveGlobalInstructions(home, "cursor")
+	if err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	if !changed {
+		t.Fatal("remove did not report a change")
+	}
+	if gotPath != path {
+		t.Fatalf("path = %q, want %q", gotPath, path)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("cursor rule file still exists or stat failed: %v", err)
+	}
+}
+
+func mustReadFile(t *testing.T, path string) []byte {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return data
+}


### PR DESCRIPTION
Adds global per-agent setup uninstall for mnemo integrations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `mnemo setup uninstall` to remove Mnemo-managed setup files and configuration for a selected agent.
  * Supports optional custom home directories and preserves unrelated user configuration.
  * Added documentation and usage examples for the uninstall command.

* **Refactor**
  * Improved setup runtime file handling while preserving existing agent support.

* **Tests**
  * Added coverage for uninstall argument validation, cleanup behavior, and preservation of user content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->