### PR TITLE
Sanitize projects list table output

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,18 +4,37 @@ This document tracks planned capabilities that are not yet released. Released be
 
 ## Project management
 
-Add project management commands for UUID-based projects:
+Build on project inventory and add consolidation before introducing more destructive cleanup flows:
 
 ```bash
+mnemo projects merge --from <project> --to <project> [--dry-run]
+mnemo projects merge --auto-by-path [--dry-run]
 mnemo projects prune
-mnemo projects merge <from> <to>
-mnemo projects rename <id> <name>
+mnemo projects rename --id <project> --name <name>
+mnemo projects rename --path <dir> --name <name>
 ```
 
-Goals:
+Near-term goals:
 
-- provide safe cleanup for stale projects;
-- support explicit consolidation when project identity changes.
+- detect duplicate project identities that point at the same directory/path, especially UUID-era IDs plus legacy path-derived keys;
+- provide safe project merge/consolidation with dry-run output before mutation;
+- update observations, sessions, prompts, sync mutations, enrollments, and project metadata consistently when consolidating projects;
+- keep `prune` behind explicit safety checks after merge/consolidation is reliable;
+- revisit `rename` after consolidation, using explicit selectors (`--id`, `--path`, or a shared selector flag) instead of ambiguous positional arguments.
+
+## Project maintenance skill
+
+Add a separate Agent Skill for project inventory maintenance so agents can diagnose and resolve common project identity problems without requiring the user to manually inspect IDs and run every merge command.
+
+Planned responsibilities:
+
+- run `mnemo projects list --json` and identify likely duplicates by shared directory/path, legacy key patterns, and UUID project metadata;
+- produce a concise project maintenance report with proposed merge groups and destination projects;
+- execute high-confidence merge plans through `mnemo projects merge` when explicitly requested or when a user has opted into automatic project maintenance;
+- fall back to asking for confirmation when merge targets are ambiguous, when data would be moved across unrelated paths, or when destructive cleanup is involved;
+- record what was merged and why, so future agents understand previous consolidation decisions.
+
+The skill should be read-only by default, support dry-run planning, and require clear opt-in before broad mutation.
 
 ## Local sync
 

--- a/cmd/mnemo/projects.go
+++ b/cmd/mnemo/projects.go
@@ -57,12 +57,10 @@ func runProjectsList(s *store.Store) {
 		os.Exit(1)
 	}
 	if opts.JSON {
-		out, err := json.MarshalIndent(projectsListReport{Total: len(projects), Projects: projects}, "", "  ")
-		if err != nil {
+		if err := printProjectsListJSONTo(os.Stdout, projects); err != nil {
 			fmt.Fprintf(os.Stderr, "mnemo projects list: json: %v\n", err)
 			os.Exit(1)
 		}
-		fmt.Println(string(out))
 		return
 	}
 	printProjectsList(projects)
@@ -246,6 +244,15 @@ func parseProjectTime(value string) (time.Time, error) {
 
 func printProjectsList(projects []store.ProjectSummary) {
 	printProjectsListTo(os.Stdout, projects)
+}
+
+func printProjectsListJSONTo(out io.Writer, projects []store.ProjectSummary) error {
+	data, err := json.MarshalIndent(projectsListReport{Total: len(projects), Projects: projects}, "", "  ")
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintln(out, string(data))
+	return err
 }
 
 func printProjectsListTo(out io.Writer, projects []store.ProjectSummary) {

--- a/cmd/mnemo/projects.go
+++ b/cmd/mnemo/projects.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"sort"
 	"strconv"
@@ -244,7 +245,11 @@ func parseProjectTime(value string) (time.Time, error) {
 }
 
 func printProjectsList(projects []store.ProjectSummary) {
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	printProjectsListTo(os.Stdout, projects)
+}
+
+func printProjectsListTo(out io.Writer, projects []store.ProjectSummary) {
+	w := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
 	_, _ = fmt.Fprintln(w, "ID\tName/Path\tObservations\tSessions\tPrompts\tLast Seen")
 	for _, project := range projects {
 		lastSeen := project.LastSeenAt
@@ -256,13 +261,21 @@ func printProjectsList(projects []store.ProjectSummary) {
 			nameOrPath = project.Directory
 		}
 		_, _ = fmt.Fprintf(w, "%s\t%s\t%d\t%d\t%d\t%s\n",
-			project.ID,
-			nameOrPath,
+			projectsTableCell(project.ID),
+			projectsTableCell(nameOrPath),
 			project.ObservationCount,
 			project.SessionCount,
 			project.PromptCount,
-			lastSeen,
+			projectsTableCell(lastSeen),
 		)
 	}
 	_ = w.Flush()
+}
+
+func projectsTableCell(value string) string {
+	fields := strings.Fields(value)
+	if len(fields) == 0 {
+		return ""
+	}
+	return strings.Join(fields, " ")
 }

--- a/cmd/mnemo/projects_test.go
+++ b/cmd/mnemo/projects_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"strings"
 	"testing"
 	"time"
@@ -90,6 +91,35 @@ func TestPrintProjectsListSanitizesTableOutput(t *testing.T) {
 	}
 	if !strings.Contains(got, "project one") || !strings.Contains(got, "Alpha Project Demo Suite") || !strings.Contains(got, "2026-01-15 10:00:00") {
 		t.Fatalf("table output missing sanitized values:\n%s", got)
+	}
+}
+
+func TestPrintProjectsListJSONPreservesWhitespace(t *testing.T) {
+	project := store.ProjectSummary{
+		ID:               "project\tone",
+		Name:             "Alpha\nProject\t Demo\r\nSuite",
+		CreatedAt:        "2026-01-01\n09:00:00",
+		Directory:        "/tmp/alpha\tproject\nsuite",
+		ObservationCount: 1,
+		SessionCount:     2,
+		PromptCount:      3,
+		LastSeenAt:       "2026-01-15\n10:00:00",
+	}
+	var out bytes.Buffer
+
+	if err := printProjectsListJSONTo(&out, []store.ProjectSummary{project}); err != nil {
+		t.Fatalf("print projects json: %v", err)
+	}
+
+	var got projectsListReport
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal projects json: %v", err)
+	}
+	if got.Total != 1 || len(got.Projects) != 1 {
+		t.Fatalf("unexpected report: %+v", got)
+	}
+	if got.Projects[0] != project {
+		t.Fatalf("json project = %+v, want %+v", got.Projects[0], project)
 	}
 }
 

--- a/cmd/mnemo/projects_test.go
+++ b/cmd/mnemo/projects_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"bytes"
+	"strings"
 	"testing"
 	"time"
 
@@ -59,6 +61,35 @@ func TestProjectsListFiltersAndSorts(t *testing.T) {
 	}
 	if got[0].ID != "gamma" || got[1].ID != "alpha" {
 		t.Fatalf("unexpected order: %+v", got)
+	}
+}
+
+func TestProjectsTableCellSanitizesWhitespace(t *testing.T) {
+	got := projectsTableCell(" Alpha\nProject\t Demo\r\nSuite  ")
+	if got != "Alpha Project Demo Suite" {
+		t.Fatalf("sanitized cell = %q, want %q", got, "Alpha Project Demo Suite")
+	}
+}
+
+func TestPrintProjectsListSanitizesTableOutput(t *testing.T) {
+	projects := []store.ProjectSummary{{
+		ID:               "project\tone",
+		Name:             "Alpha\nProject\t Demo\r\nSuite",
+		ObservationCount: 1,
+		SessionCount:     2,
+		PromptCount:      3,
+		LastSeenAt:       "2026-01-15\n10:00:00",
+	}}
+	var out bytes.Buffer
+
+	printProjectsListTo(&out, projects)
+
+	got := out.String()
+	if strings.Contains(got, "Alpha\nProject") || strings.Contains(got, "\t") || strings.Contains(got, "project\tone") {
+		t.Fatalf("table output was not sanitized:\n%s", got)
+	}
+	if !strings.Contains(got, "project one") || !strings.Contains(got, "Alpha Project Demo Suite") || !strings.Contains(got, "2026-01-15 10:00:00") {
+		t.Fatalf("table output missing sanitized values:\n%s", got)
 	}
 }
 


### PR DESCRIPTION
Summary:
- Sanitize whitespace in projects list table output.
- Keep JSON output unchanged.
- Update roadmap for upcoming consolidation work.

Tests:
- go test ./cmd/mnemo
- golangci-lint run ./cmd/mnemo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded the project management roadmap with merge, auto-merge, rename, duplicate detection, consolidation, pruning safeguards, and deferred rename planning.
  * Added guidance for project maintenance workflows, including inventory, dry runs, confirmations, audit records, and read-only defaults.

* **Bug Fixes**
  * Improved project list output by removing excess whitespace and ensuring blank values display cleanly.
  * Preserved original whitespace in JSON project output.

* **Tests**
  * Added coverage validating sanitized project table cells, complete project list output, and whitespace preservation in JSON.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->