### PR TITLE
Add projects merge command

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ mnemo --version
 - **Passive capture:** extracts learnings from conversation transcripts automatically at session end
 - **Portable Agent Skill:** teaches compatible agents the complete mnemo workflow without weakening the always-active safety rules
 - **Full CLI:** save, search, export, import, inspect, and diagnose memories from the terminal
-- **Project inventory:** `mnemo projects list` shows known projects with readable table output, sorting, age filters, empty-project filters, and JSON output
+- **Project inventory:** `mnemo projects list` shows known projects; `mnemo projects merge` consolidates duplicate identities with dry-run planning
 - **Read-only diagnostics:** `mnemo doctor` checks project activation, global agent setup, MCP config, hooks/plugins, and local store health
 - **Setup lifecycle:** `mnemo setup status`, `print-config`, `refresh`, and `uninstall` inspect and maintain global agent configuration
 - **Own storage:** isolated `~/.mnemo/memory.db`, created automatically on first run
@@ -269,6 +269,8 @@ mnemo setup print-config AGENT [--home=DIR] [--mnemo-bin=PATH]  Print manual set
 mnemo setup refresh [--agent=AGENT] [--home=DIR] [--mnemo-bin=PATH]  Refresh installed global setup files
 mnemo setup uninstall --agent=AGENT [--home=DIR]  Remove global setup files for an agent
 mnemo projects list [--sort=FIELD] [--asc|--desc] [--unused-since=DURATION|DATE] [--empty] [--json]  List known projects
+mnemo projects merge --from=PROJECT --to=PROJECT [--dry-run|--yes] [--json]  Merge one project into another
+mnemo projects merge --auto-by-path [--dry-run|--yes] [--json]  Merge duplicate project identities by shared directory
 mnemo save <title> <content>         Save a memory
 mnemo search <query>                 Search memories
 mnemo context [project]              Show context from previous sessions

--- a/README.md
+++ b/README.md
@@ -269,8 +269,8 @@ mnemo setup print-config AGENT [--home=DIR] [--mnemo-bin=PATH]  Print manual set
 mnemo setup refresh [--agent=AGENT] [--home=DIR] [--mnemo-bin=PATH]  Refresh installed global setup files
 mnemo setup uninstall --agent=AGENT [--home=DIR]  Remove global setup files for an agent
 mnemo projects list [--sort=FIELD] [--asc|--desc] [--unused-since=DURATION|DATE] [--empty] [--json]  List known projects
-mnemo projects merge --from=PROJECT --to=PROJECT [--dry-run|--yes] [--json]  Merge one project into another
-mnemo projects merge --auto-by-path [--dry-run|--yes] [--json]  Merge duplicate project identities by shared directory
+mnemo projects merge --from=PROJECT --to=PROJECT (--dry-run|--yes) [--json]  Merge one project into another
+mnemo projects merge --auto-by-path (--dry-run|--yes) [--json]  Merge duplicate project identities by shared directory
 mnemo save <title> <content>         Save a memory
 mnemo search <query>                 Search memories
 mnemo context [project]              Show context from previous sessions

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,13 +2,11 @@
 
 This document tracks planned capabilities that are not yet released. Released behavior belongs in release notes, not here.
 
-## Project management
+## Project management safety flows
 
-Build on project inventory and add consolidation before introducing more destructive cleanup flows:
+Build on project inventory and consolidation before introducing more destructive cleanup flows:
 
 ```bash
-mnemo projects merge --from <project> --to <project> [--dry-run]
-mnemo projects merge --auto-by-path [--dry-run]
 mnemo projects prune
 mnemo projects rename --id <project> --name <name>
 mnemo projects rename --path <dir> --name <name>
@@ -16,9 +14,6 @@ mnemo projects rename --path <dir> --name <name>
 
 Near-term goals:
 
-- detect duplicate project identities that point at the same directory/path, especially UUID-era IDs plus legacy path-derived keys;
-- provide safe project merge/consolidation with dry-run output before mutation;
-- update observations, sessions, prompts, sync mutations, enrollments, and project metadata consistently when consolidating projects;
 - keep `prune` behind explicit safety checks after merge/consolidation is reliable;
 - revisit `rename` after consolidation, using explicit selectors (`--id`, `--path`, or a shared selector flag) instead of ambiguous positional arguments.
 

--- a/cmd/mnemo/projects.go
+++ b/cmd/mnemo/projects.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -27,6 +28,22 @@ type projectsListReport struct {
 	Projects []store.ProjectSummary `json:"projects"`
 }
 
+type projectsMergeOptions struct {
+	From       string
+	To         string
+	AutoByPath bool
+	DryRun     bool
+	Yes        bool
+	JSON       bool
+}
+
+type projectsMergeReport struct {
+	DryRun  bool                       `json:"dry_run"`
+	Total   int                        `json:"total"`
+	Plans   []store.ProjectMergePlan   `json:"plans,omitempty"`
+	Results []store.ProjectMergeResult `json:"results,omitempty"`
+}
+
 func runProjects(s *store.Store) {
 	if len(os.Args) < 3 {
 		printProjectsUsage()
@@ -35,6 +52,8 @@ func runProjects(s *store.Store) {
 	switch os.Args[2] {
 	case "list":
 		runProjectsList(s)
+	case "merge":
+		runProjectsMerge(s)
 	default:
 		printProjectsUsage()
 		os.Exit(1)
@@ -43,6 +62,8 @@ func runProjects(s *store.Store) {
 
 func printProjectsUsage() {
 	fmt.Fprintln(os.Stderr, "usage: mnemo projects list [--sort=FIELD] [--asc|--desc] [--unused-since=DURATION|DATE] [--empty] [--json]")
+	fmt.Fprintln(os.Stderr, "       mnemo projects merge --from=PROJECT --to=PROJECT [--dry-run|--yes] [--json]")
+	fmt.Fprintln(os.Stderr, "       mnemo projects merge --auto-by-path [--dry-run|--yes] [--json]")
 }
 
 func runProjectsList(s *store.Store) {
@@ -64,6 +85,48 @@ func runProjectsList(s *store.Store) {
 		return
 	}
 	printProjectsList(projects)
+}
+
+func runProjectsMerge(s *store.Store) {
+	opts, err := parseProjectsMergeArgs(os.Args[3:])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mnemo projects merge: %v\n", err)
+		os.Exit(1)
+	}
+	plans, err := buildProjectsMergePlans(s, opts)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mnemo projects merge: %v\n", err)
+		os.Exit(1)
+	}
+	if opts.DryRun {
+		if opts.JSON {
+			if err := printProjectsMergeJSONTo(os.Stdout, projectsMergeReport{DryRun: true, Total: len(plans), Plans: plans}); err != nil {
+				fmt.Fprintf(os.Stderr, "mnemo projects merge: json: %v\n", err)
+				os.Exit(1)
+			}
+			return
+		}
+		printProjectsMergePlans(os.Stdout, plans)
+		return
+	}
+
+	results := make([]store.ProjectMergeResult, 0, len(plans))
+	for _, plan := range plans {
+		result, err := s.MergeProjects(plan.From.ID, plan.To.ID)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "mnemo projects merge: %s -> %s: %v\n", plan.From.ID, plan.To.ID, err)
+			os.Exit(1)
+		}
+		results = append(results, *result)
+	}
+	if opts.JSON {
+		if err := printProjectsMergeJSONTo(os.Stdout, projectsMergeReport{DryRun: false, Total: len(results), Results: results}); err != nil {
+			fmt.Fprintf(os.Stderr, "mnemo projects merge: json: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
+	printProjectsMergeResults(os.Stdout, results)
 }
 
 func parseProjectsListArgs(args []string, now func() time.Time) (projectsListOptions, error) {
@@ -93,6 +156,44 @@ func parseProjectsListArgs(args []string, now func() time.Time) (projectsListOpt
 		default:
 			return opts, fmt.Errorf("unknown argument %q", arg)
 		}
+	}
+	return opts, nil
+}
+
+func parseProjectsMergeArgs(args []string) (projectsMergeOptions, error) {
+	var opts projectsMergeOptions
+	for _, arg := range args {
+		switch {
+		case arg == "--auto-by-path":
+			opts.AutoByPath = true
+		case arg == "--dry-run":
+			opts.DryRun = true
+		case arg == "--yes":
+			opts.Yes = true
+		case arg == "--json":
+			opts.JSON = true
+		case strings.HasPrefix(arg, "--from="):
+			opts.From = strings.TrimSpace(arg[len("--from="):])
+		case strings.HasPrefix(arg, "--to="):
+			opts.To = strings.TrimSpace(arg[len("--to="):])
+		default:
+			return opts, fmt.Errorf("unknown argument %q", arg)
+		}
+	}
+	if opts.DryRun && opts.Yes {
+		return opts, fmt.Errorf("--dry-run and --yes are mutually exclusive")
+	}
+	if !opts.DryRun && !opts.Yes {
+		return opts, fmt.Errorf("refusing to merge without --dry-run or --yes")
+	}
+	if opts.AutoByPath {
+		if opts.From != "" || opts.To != "" {
+			return opts, fmt.Errorf("--auto-by-path cannot be combined with --from or --to")
+		}
+		return opts, nil
+	}
+	if opts.From == "" || opts.To == "" {
+		return opts, fmt.Errorf("explicit merge requires --from and --to")
 	}
 	return opts, nil
 }
@@ -144,6 +245,53 @@ func buildProjectsList(s *store.Store, opts projectsListOptions) ([]store.Projec
 	return projects, nil
 }
 
+func buildProjectsMergePlans(s *store.Store, opts projectsMergeOptions) ([]store.ProjectMergePlan, error) {
+	if !opts.AutoByPath {
+		plan, err := s.BuildProjectMergePlan(opts.From, opts.To)
+		if err != nil {
+			return nil, err
+		}
+		return []store.ProjectMergePlan{*plan}, nil
+	}
+
+	projects, err := s.ListProjectSummaries()
+	if err != nil {
+		return nil, err
+	}
+	groups := make(map[string][]store.ProjectSummary)
+	for _, project := range projects {
+		directory := normalizedProjectDirectory(project.Directory)
+		if directory == "" {
+			continue
+		}
+		groups[directory] = append(groups[directory], project)
+	}
+	directories := make([]string, 0, len(groups))
+	for directory, group := range groups {
+		if len(group) > 1 {
+			directories = append(directories, directory)
+		}
+	}
+	sort.Strings(directories)
+
+	var plans []store.ProjectMergePlan
+	for _, directory := range directories {
+		group := groups[directory]
+		sort.SliceStable(group, func(i, j int) bool {
+			return preferProjectMergeDestination(group[i], group[j])
+		})
+		destination := group[0]
+		for _, source := range group[1:] {
+			plan, err := s.BuildProjectMergePlan(source.ID, destination.ID)
+			if err != nil {
+				return nil, err
+			}
+			plans = append(plans, *plan)
+		}
+	}
+	return plans, nil
+}
+
 func filterProjectsList(projects []store.ProjectSummary, opts projectsListOptions) []store.ProjectSummary {
 	filtered := projects[:0]
 	for _, project := range projects {
@@ -156,6 +304,55 @@ func filterProjectsList(projects []store.ProjectSummary, opts projectsListOption
 		filtered = append(filtered, project)
 	}
 	return filtered
+}
+
+func normalizedProjectDirectory(directory string) string {
+	directory = strings.TrimSpace(directory)
+	if directory == "" {
+		return ""
+	}
+	return filepath.Clean(directory)
+}
+
+func preferProjectMergeDestination(a, b store.ProjectSummary) bool {
+	aUUID := isUUIDProjectID(a.ID)
+	bUUID := isUUIDProjectID(b.ID)
+	if aUUID != bUUID {
+		return aUUID
+	}
+	aActivity := projectActivityTotal(a)
+	bActivity := projectActivityTotal(b)
+	if aActivity != bActivity {
+		return aActivity > bActivity
+	}
+	lastSeen := compareLastSeen(a.LastSeenAt, b.LastSeenAt)
+	if lastSeen != 0 {
+		return lastSeen > 0
+	}
+	return a.ID < b.ID
+}
+
+func projectActivityTotal(project store.ProjectSummary) int {
+	return project.ObservationCount + project.SessionCount + project.PromptCount
+}
+
+func isUUIDProjectID(id string) bool {
+	if len(id) != 36 {
+		return false
+	}
+	for i, r := range id {
+		switch i {
+		case 8, 13, 18, 23:
+			if r != '-' {
+				return false
+			}
+		default:
+			if (r < '0' || r > '9') && (r < 'a' || r > 'f') && (r < 'A' || r > 'F') {
+				return false
+			}
+		}
+	}
+	return true
 }
 
 func projectUnusedSince(project store.ProjectSummary, cutoff time.Time) bool {
@@ -255,6 +452,15 @@ func printProjectsListJSONTo(out io.Writer, projects []store.ProjectSummary) err
 	return err
 }
 
+func printProjectsMergeJSONTo(out io.Writer, report projectsMergeReport) error {
+	data, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintln(out, string(data))
+	return err
+}
+
 func printProjectsListTo(out io.Writer, projects []store.ProjectSummary) {
 	w := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
 	_, _ = fmt.Fprintln(w, "ID\tName/Path\tObservations\tSessions\tPrompts\tLast Seen")
@@ -277,6 +483,67 @@ func printProjectsListTo(out io.Writer, projects []store.ProjectSummary) {
 		)
 	}
 	_ = w.Flush()
+}
+
+func printProjectsMergePlans(out io.Writer, plans []store.ProjectMergePlan) {
+	if len(plans) == 0 {
+		_, _ = fmt.Fprintln(out, "No project merge candidates found.")
+		return
+	}
+	w := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+	_, _ = fmt.Fprintln(w, "From\tTo\tObservations\tSessions\tPrompts\tSync\tEnrollment")
+	for _, plan := range plans {
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%d\t%d\t%d\t%d\t%s\n",
+			projectsTableCell(plan.From.ID),
+			projectsTableCell(plan.To.ID),
+			plan.Observations,
+			plan.Sessions,
+			plan.Prompts,
+			plan.SyncMutations,
+			projectMergeEnrollmentCell(plan),
+		)
+	}
+	_, _ = fmt.Fprintln(w, "\nDry run only. Re-run with --yes to apply.")
+	_ = w.Flush()
+}
+
+func printProjectsMergeResults(out io.Writer, results []store.ProjectMergeResult) {
+	if len(results) == 0 {
+		_, _ = fmt.Fprintln(out, "No project merge candidates found.")
+		return
+	}
+	w := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+	_, _ = fmt.Fprintln(w, "From\tTo\tObservations\tSessions\tPrompts\tSync\tSource Project")
+	for _, result := range results {
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%d\t%d\t%d\t%d\t%s\n",
+			projectsTableCell(result.Plan.From.ID),
+			projectsTableCell(result.Plan.To.ID),
+			result.ObservationsUpdated,
+			result.SessionsUpdated,
+			result.PromptsUpdated,
+			result.SyncMutationsUpdated,
+			projectMergeDeletedCell(result.SourceProjectDeleted),
+		)
+	}
+	_ = w.Flush()
+}
+
+func projectMergeEnrollmentCell(plan store.ProjectMergePlan) string {
+	switch {
+	case plan.WillCopyEnrollment:
+		return "copy"
+	case plan.SourceEnrolled:
+		return "already"
+	default:
+		return "-"
+	}
+}
+
+func projectMergeDeletedCell(deleted bool) string {
+	if deleted {
+		return "deleted"
+	}
+	return "-"
 }
 
 func projectsTableCell(value string) string {

--- a/cmd/mnemo/projects.go
+++ b/cmd/mnemo/projects.go
@@ -62,8 +62,8 @@ func runProjects(s *store.Store) {
 
 func printProjectsUsage() {
 	fmt.Fprintln(os.Stderr, "usage: mnemo projects list [--sort=FIELD] [--asc|--desc] [--unused-since=DURATION|DATE] [--empty] [--json]")
-	fmt.Fprintln(os.Stderr, "       mnemo projects merge --from=PROJECT --to=PROJECT [--dry-run|--yes] [--json]")
-	fmt.Fprintln(os.Stderr, "       mnemo projects merge --auto-by-path [--dry-run|--yes] [--json]")
+	fmt.Fprintln(os.Stderr, "       mnemo projects merge --from=PROJECT --to=PROJECT (--dry-run|--yes) [--json]")
+	fmt.Fprintln(os.Stderr, "       mnemo projects merge --auto-by-path (--dry-run|--yes) [--json]")
 }
 
 func runProjectsList(s *store.Store) {
@@ -110,23 +110,20 @@ func runProjectsMerge(s *store.Store) {
 		return
 	}
 
-	results := make([]store.ProjectMergeResult, 0, len(plans))
-	for _, plan := range plans {
-		result, err := s.MergeProjects(plan.From.ID, plan.To.ID)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "mnemo projects merge: %s -> %s: %v\n", plan.From.ID, plan.To.ID, err)
-			os.Exit(1)
+	results, err := applyProjectsMergePlans(s, plans)
+	if err != nil {
+		if len(results) > 0 {
+			if emitErr := printProjectsMergeApplyOutput(os.Stdout, opts.JSON, results); emitErr != nil {
+				fmt.Fprintf(os.Stderr, "mnemo projects merge: json: %v\n", emitErr)
+			}
 		}
-		results = append(results, *result)
+		fmt.Fprintf(os.Stderr, "mnemo projects merge: %v\n", err)
+		os.Exit(1)
 	}
-	if opts.JSON {
-		if err := printProjectsMergeJSONTo(os.Stdout, projectsMergeReport{DryRun: false, Total: len(results), Results: results}); err != nil {
-			fmt.Fprintf(os.Stderr, "mnemo projects merge: json: %v\n", err)
-			os.Exit(1)
-		}
-		return
+	if err := printProjectsMergeApplyOutput(os.Stdout, opts.JSON, results); err != nil {
+		fmt.Fprintf(os.Stderr, "mnemo projects merge: json: %v\n", err)
+		os.Exit(1)
 	}
-	printProjectsMergeResults(os.Stdout, results)
 }
 
 func parseProjectsListArgs(args []string, now func() time.Time) (projectsListOptions, error) {
@@ -290,6 +287,18 @@ func buildProjectsMergePlans(s *store.Store, opts projectsMergeOptions) ([]store
 		}
 	}
 	return plans, nil
+}
+
+func applyProjectsMergePlans(s *store.Store, plans []store.ProjectMergePlan) ([]store.ProjectMergeResult, error) {
+	results := make([]store.ProjectMergeResult, 0, len(plans))
+	for _, plan := range plans {
+		result, err := s.MergeProjects(plan.From.ID, plan.To.ID)
+		if err != nil {
+			return results, fmt.Errorf("%s -> %s: %w", plan.From.ID, plan.To.ID, err)
+		}
+		results = append(results, *result)
+	}
+	return results, nil
 }
 
 func filterProjectsList(projects []store.ProjectSummary, opts projectsListOptions) []store.ProjectSummary {
@@ -459,6 +468,14 @@ func printProjectsMergeJSONTo(out io.Writer, report projectsMergeReport) error {
 	}
 	_, err = fmt.Fprintln(out, string(data))
 	return err
+}
+
+func printProjectsMergeApplyOutput(out io.Writer, jsonOutput bool, results []store.ProjectMergeResult) error {
+	if jsonOutput {
+		return printProjectsMergeJSONTo(out, projectsMergeReport{DryRun: false, Total: len(results), Results: results})
+	}
+	printProjectsMergeResults(out, results)
+	return nil
 }
 
 func printProjectsListTo(out io.Writer, projects []store.ProjectSummary) {

--- a/cmd/mnemo/projects_test.go
+++ b/cmd/mnemo/projects_test.go
@@ -125,6 +125,48 @@ func TestBuildProjectsMergePlansAutoByPath(t *testing.T) {
 	}
 }
 
+func TestApplyProjectsMergePlansReturnsCompletedResultsOnLaterFailure(t *testing.T) {
+	s := newProjectsTestStore(t)
+	source := "projects-alpha"
+	destination := "11111111-2222-3333-4444-555555555555"
+
+	if err := s.EnsureProject(destination, "Alpha"); err != nil {
+		t.Fatalf("ensure destination: %v", err)
+	}
+	if err := s.CreateSession("s-alpha", source, "/tmp/alpha"); err != nil {
+		t.Fatalf("create source session: %v", err)
+	}
+	if _, err := s.AddObservation(testObservationParams(source, "s-alpha", "Alpha source")); err != nil {
+		t.Fatalf("add source observation: %v", err)
+	}
+	plans := []store.ProjectMergePlan{
+		{From: store.ProjectSummary{ID: source}, To: store.ProjectSummary{ID: destination}},
+		{From: store.ProjectSummary{ID: "missing-source"}, To: store.ProjectSummary{ID: destination}},
+	}
+
+	results, err := applyProjectsMergePlans(s, plans)
+	if err == nil {
+		t.Fatal("expected second merge to fail")
+	}
+	if len(results) != 1 {
+		t.Fatalf("completed results = %d, want 1 (%+v)", len(results), results)
+	}
+	if results[0].Plan.From.ID != source || results[0].Plan.To.ID != destination {
+		t.Fatalf("unexpected completed result: %+v", results[0])
+	}
+	var out bytes.Buffer
+	if err := printProjectsMergeApplyOutput(&out, true, results); err != nil {
+		t.Fatalf("print partial results: %v", err)
+	}
+	var report projectsMergeReport
+	if err := json.Unmarshal(out.Bytes(), &report); err != nil {
+		t.Fatalf("unmarshal partial results: %v", err)
+	}
+	if report.Total != 1 || len(report.Results) != 1 {
+		t.Fatalf("unexpected partial report: %+v", report)
+	}
+}
+
 func TestPreferProjectMergeDestinationPrefersUUIDThenActivity(t *testing.T) {
 	uuidProject := store.ProjectSummary{ID: "11111111-2222-3333-4444-555555555555", ObservationCount: 1}
 	legacyProject := store.ProjectSummary{ID: "projects-alpha", ObservationCount: 10}

--- a/cmd/mnemo/projects_test.go
+++ b/cmd/mnemo/projects_test.go
@@ -41,6 +41,36 @@ func TestParseProjectsListArgsRejectsUnknownSort(t *testing.T) {
 	}
 }
 
+func TestParseProjectsMergeArgsExplicitDryRun(t *testing.T) {
+	opts, err := parseProjectsMergeArgs([]string{"--from=alpha-legacy", "--to=alpha", "--dry-run", "--json"})
+	if err != nil {
+		t.Fatalf("parse projects merge args: %v", err)
+	}
+	if opts.From != "alpha-legacy" || opts.To != "alpha" || !opts.DryRun || !opts.JSON || opts.Yes || opts.AutoByPath {
+		t.Fatalf("unexpected options: %+v", opts)
+	}
+}
+
+func TestParseProjectsMergeArgsRequiresSafetyFlag(t *testing.T) {
+	_, err := parseProjectsMergeArgs([]string{"--from=alpha-legacy", "--to=alpha"})
+	if err == nil {
+		t.Fatal("expected safety flag error")
+	}
+}
+
+func TestParseProjectsMergeArgsAutoByPath(t *testing.T) {
+	opts, err := parseProjectsMergeArgs([]string{"--auto-by-path", "--dry-run"})
+	if err != nil {
+		t.Fatalf("parse projects merge args: %v", err)
+	}
+	if !opts.AutoByPath || !opts.DryRun {
+		t.Fatalf("unexpected options: %+v", opts)
+	}
+	if _, err := parseProjectsMergeArgs([]string{"--auto-by-path", "--from=alpha", "--dry-run"}); err == nil {
+		t.Fatal("expected auto-by-path/from conflict")
+	}
+}
+
 func TestProjectsListFiltersAndSorts(t *testing.T) {
 	projects := []store.ProjectSummary{
 		{ID: "beta", Name: "Beta", ObservationCount: 2, LastSeenAt: "2026-01-15 10:00:00"},
@@ -62,6 +92,50 @@ func TestProjectsListFiltersAndSorts(t *testing.T) {
 	}
 	if got[0].ID != "gamma" || got[1].ID != "alpha" {
 		t.Fatalf("unexpected order: %+v", got)
+	}
+}
+
+func TestBuildProjectsMergePlansAutoByPath(t *testing.T) {
+	s := newProjectsTestStore(t)
+	uuidProject := "11111111-2222-3333-4444-555555555555"
+	legacyProject := "projects-alpha"
+
+	if err := s.CreateSession("s-uuid", uuidProject, "/tmp/alpha"); err != nil {
+		t.Fatalf("create uuid session: %v", err)
+	}
+	if err := s.CreateSession("s-legacy", legacyProject, "/tmp/alpha"); err != nil {
+		t.Fatalf("create legacy session: %v", err)
+	}
+	if _, err := s.AddObservation(testObservationParams(uuidProject, "s-uuid", "UUID project")); err != nil {
+		t.Fatalf("add uuid observation: %v", err)
+	}
+	if _, err := s.AddObservation(testObservationParams(legacyProject, "s-legacy", "Legacy project")); err != nil {
+		t.Fatalf("add legacy observation: %v", err)
+	}
+
+	plans, err := buildProjectsMergePlans(s, projectsMergeOptions{AutoByPath: true, DryRun: true})
+	if err != nil {
+		t.Fatalf("build auto merge plans: %v", err)
+	}
+	if len(plans) != 1 {
+		t.Fatalf("plans = %d, want 1 (%+v)", len(plans), plans)
+	}
+	if plans[0].From.ID != legacyProject || plans[0].To.ID != uuidProject {
+		t.Fatalf("unexpected auto merge plan: %+v", plans[0])
+	}
+}
+
+func TestPreferProjectMergeDestinationPrefersUUIDThenActivity(t *testing.T) {
+	uuidProject := store.ProjectSummary{ID: "11111111-2222-3333-4444-555555555555", ObservationCount: 1}
+	legacyProject := store.ProjectSummary{ID: "projects-alpha", ObservationCount: 10}
+	if !preferProjectMergeDestination(uuidProject, legacyProject) {
+		t.Fatal("expected UUID project to be preferred")
+	}
+
+	activeProject := store.ProjectSummary{ID: "22222222-3333-4444-5555-666666666666", ObservationCount: 5}
+	lessActiveProject := store.ProjectSummary{ID: "11111111-2222-3333-4444-555555555555", ObservationCount: 1}
+	if !preferProjectMergeDestination(activeProject, lessActiveProject) {
+		t.Fatal("expected more active UUID project to be preferred")
 	}
 }
 
@@ -125,4 +199,27 @@ func TestPrintProjectsListJSONPreservesWhitespace(t *testing.T) {
 
 func fixedProjectsNow() time.Time {
 	return time.Date(2026, 2, 1, 12, 0, 0, 0, time.UTC)
+}
+
+func newProjectsTestStore(t *testing.T) *store.Store {
+	t.Helper()
+	s, err := store.New(store.FallbackConfig(t.TempDir()))
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = s.Close()
+	})
+	return s
+}
+
+func testObservationParams(project, sessionID, title string) store.AddObservationParams {
+	return store.AddObservationParams{
+		SessionID: sessionID,
+		Type:      "decision",
+		Title:     title,
+		Content:   title + " content",
+		Project:   project,
+		Scope:     "project",
+	}
 }

--- a/cmd/mnemo/templates/usage.txt
+++ b/cmd/mnemo/templates/usage.txt
@@ -12,6 +12,8 @@ Usage:
   mnemo import <file.json>             Import memories from JSON
   mnemo capture <content>|-            Extract learnings from text (passive capture; "-" reads stdin)
   mnemo projects list [--sort=FIELD] [--asc|--desc] [--unused-since=DURATION|DATE] [--empty] [--json]  List known projects
+  mnemo projects merge --from=PROJECT --to=PROJECT [--dry-run|--yes] [--json]  Merge one project into another
+  mnemo projects merge --auto-by-path [--dry-run|--yes] [--json]  Merge duplicate project identities by shared directory
   mnemo doctor [--json] [--agent=AGENT] [--path=DIR]  Run read-only diagnostics
   mnemo setup status [--json] [--agent=AGENT] [--home=DIR]  Show global agent setup status
   mnemo setup print-config AGENT [--home=DIR] [--mnemo-bin=PATH]  Print manual setup config snippets

--- a/cmd/mnemo/templates/usage.txt
+++ b/cmd/mnemo/templates/usage.txt
@@ -12,8 +12,8 @@ Usage:
   mnemo import <file.json>             Import memories from JSON
   mnemo capture <content>|-            Extract learnings from text (passive capture; "-" reads stdin)
   mnemo projects list [--sort=FIELD] [--asc|--desc] [--unused-since=DURATION|DATE] [--empty] [--json]  List known projects
-  mnemo projects merge --from=PROJECT --to=PROJECT [--dry-run|--yes] [--json]  Merge one project into another
-  mnemo projects merge --auto-by-path [--dry-run|--yes] [--json]  Merge duplicate project identities by shared directory
+  mnemo projects merge --from=PROJECT --to=PROJECT (--dry-run|--yes) [--json]  Merge one project into another
+  mnemo projects merge --auto-by-path (--dry-run|--yes) [--json]  Merge duplicate project identities by shared directory
   mnemo doctor [--json] [--agent=AGENT] [--path=DIR]  Run read-only diagnostics
   mnemo setup status [--json] [--agent=AGENT] [--home=DIR]  Show global agent setup status
   mnemo setup print-config AGENT [--home=DIR] [--mnemo-bin=PATH]  Print manual setup config snippets

--- a/internal/db/generated/projects.sql.go
+++ b/internal/db/generated/projects.sql.go
@@ -9,6 +9,29 @@ import (
 	"context"
 )
 
+const countProjectRows = `-- name: CountProjectRows :one
+SELECT COUNT(*) FROM projects WHERE id = ?
+`
+
+func (q *Queries) CountProjectRows(ctx context.Context, id string) (int64, error) {
+	row := q.db.QueryRowContext(ctx, countProjectRows, id)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
+const deleteProjectByID = `-- name: DeleteProjectByID :execrows
+DELETE FROM projects WHERE id = ?
+`
+
+func (q *Queries) DeleteProjectByID(ctx context.Context, id string) (int64, error) {
+	result, err := q.db.ExecContext(ctx, deleteProjectByID, id)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
 const ensureProject = `-- name: EnsureProject :exec
 INSERT OR IGNORE INTO projects (id, name) VALUES (?, ?)
 `

--- a/internal/db/generated/querier.go
+++ b/internal/db/generated/querier.go
@@ -18,16 +18,22 @@ type Querier interface {
 	CopyProjectEnrollment(ctx context.Context, arg CopyProjectEnrollmentParams) error
 	CopySessionTag(ctx context.Context, arg CopySessionTagParams) error
 	CountLiveObservations(ctx context.Context) (int64, error)
+	CountObservationProjectRows(ctx context.Context, projectName sql.NullString) (int64, error)
 	CountObservationsByHash(ctx context.Context, normalizedHash sql.NullString) (int64, error)
 	CountObservationsForSessionProject(ctx context.Context, sessionID string) (int64, error)
 	CountPendingMutations(ctx context.Context, targetKey string) (int64, error)
+	CountProjectRows(ctx context.Context, id string) (int64, error)
+	CountPromptProjectRows(ctx context.Context, projectName sql.NullString) (int64, error)
 	CountPrompts(ctx context.Context) (int64, error)
 	CountSessionObservations(ctx context.Context, sessionID string) (int64, error)
 	CountSessionObservationsByScope(ctx context.Context, arg CountSessionObservationsByScopeParams) (int64, error)
+	CountSessionProjectRows(ctx context.Context, projectName string) (int64, error)
 	CountSessions(ctx context.Context) (int64, error)
+	CountSyncMutationProjectRows(ctx context.Context, projectName string) (int64, error)
 	DeleteObservationByID(ctx context.Context, id int64) error
 	DeleteObservationTagByName(ctx context.Context, tag string) error
 	DeleteObservationTags(ctx context.Context, observationID int64) error
+	DeleteProjectByID(ctx context.Context, id string) (int64, error)
 	DeleteProjectEnrollment(ctx context.Context, project string) error
 	DeleteSessionTagByName(ctx context.Context, tag string) error
 	DeleteSessionTags(ctx context.Context, sessionID string) error

--- a/internal/db/generated/sync_runtime.sql.go
+++ b/internal/db/generated/sync_runtime.sql.go
@@ -99,6 +99,17 @@ func (q *Queries) CopyProjectEnrollment(ctx context.Context, arg CopyProjectEnro
 	return err
 }
 
+const countObservationProjectRows = `-- name: CountObservationProjectRows :one
+SELECT COUNT(*) FROM observations WHERE project = ?1
+`
+
+func (q *Queries) CountObservationProjectRows(ctx context.Context, projectName sql.NullString) (int64, error) {
+	row := q.db.QueryRowContext(ctx, countObservationProjectRows, projectName)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const countPendingMutations = `-- name: CountPendingMutations :one
 SELECT COUNT(*) FROM sync_mutations
 WHERE target_key = ? AND acked_at IS NULL
@@ -106,6 +117,39 @@ WHERE target_key = ? AND acked_at IS NULL
 
 func (q *Queries) CountPendingMutations(ctx context.Context, targetKey string) (int64, error) {
 	row := q.db.QueryRowContext(ctx, countPendingMutations, targetKey)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
+const countPromptProjectRows = `-- name: CountPromptProjectRows :one
+SELECT COUNT(*) FROM user_prompts WHERE project = ?1
+`
+
+func (q *Queries) CountPromptProjectRows(ctx context.Context, projectName sql.NullString) (int64, error) {
+	row := q.db.QueryRowContext(ctx, countPromptProjectRows, projectName)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
+const countSessionProjectRows = `-- name: CountSessionProjectRows :one
+SELECT COUNT(*) FROM sessions WHERE project = ?1
+`
+
+func (q *Queries) CountSessionProjectRows(ctx context.Context, projectName string) (int64, error) {
+	row := q.db.QueryRowContext(ctx, countSessionProjectRows, projectName)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
+const countSyncMutationProjectRows = `-- name: CountSyncMutationProjectRows :one
+SELECT COUNT(*) FROM sync_mutations WHERE project = ?1
+`
+
+func (q *Queries) CountSyncMutationProjectRows(ctx context.Context, projectName string) (int64, error) {
+	row := q.db.QueryRowContext(ctx, countSyncMutationProjectRows, projectName)
 	var count int64
 	err := row.Scan(&count)
 	return count, err

--- a/internal/db/queries/projects.sql
+++ b/internal/db/queries/projects.sql
@@ -4,6 +4,12 @@ INSERT OR IGNORE INTO projects (id, name) VALUES (?, ?);
 -- name: GetProjectByID :one
 SELECT id, name, created_at FROM projects WHERE id = ?;
 
+-- name: CountProjectRows :one
+SELECT COUNT(*) FROM projects WHERE id = ?;
+
+-- name: DeleteProjectByID :execrows
+DELETE FROM projects WHERE id = ?;
+
 -- name: ListProjects :many
 SELECT id, name, created_at FROM projects ORDER BY created_at ASC;
 

--- a/internal/db/queries/sync_runtime.sql
+++ b/internal/db/queries/sync_runtime.sql
@@ -97,6 +97,18 @@ SELECT EXISTS(
   UNION SELECT 1 FROM sync_enrolled_projects e WHERE e.project = sqlc.arg('project_name')
 );
 
+-- name: CountObservationProjectRows :one
+SELECT COUNT(*) FROM observations WHERE project = sqlc.arg('project_name');
+
+-- name: CountSessionProjectRows :one
+SELECT COUNT(*) FROM sessions WHERE project = sqlc.arg('project_name');
+
+-- name: CountPromptProjectRows :one
+SELECT COUNT(*) FROM user_prompts WHERE project = sqlc.arg('project_name');
+
+-- name: CountSyncMutationProjectRows :one
+SELECT COUNT(*) FROM sync_mutations WHERE project = sqlc.arg('project_name');
+
 -- name: RenameObservationProject :execrows
 UPDATE observations SET project = sqlc.arg('new_name') WHERE project = sqlc.arg('old_name');
 

--- a/internal/store/project.go
+++ b/internal/store/project.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 
 	dbgen "github.com/jmeiracorbal/mnemo/internal/db/generated"
 )
@@ -53,6 +54,154 @@ func (s *Store) ListProjectSummaries() ([]ProjectSummary, error) {
 		})
 	}
 	return projects, nil
+}
+
+func (s *Store) BuildProjectMergePlan(from, to string) (*ProjectMergePlan, error) {
+	from = strings.TrimSpace(from)
+	to = strings.TrimSpace(to)
+	if from == "" {
+		return nil, fmt.Errorf("source project must not be empty")
+	}
+	if to == "" {
+		return nil, fmt.Errorf("destination project must not be empty")
+	}
+	if from == to {
+		return nil, fmt.Errorf("source and destination projects must differ")
+	}
+
+	projects, err := s.ListProjectSummaries()
+	if err != nil {
+		return nil, err
+	}
+	byID := make(map[string]ProjectSummary, len(projects))
+	for _, project := range projects {
+		byID[project.ID] = project
+	}
+	source, ok := byID[from]
+	if !ok {
+		return nil, fmt.Errorf("source project %q not found", from)
+	}
+	destination, ok := byID[to]
+	if !ok {
+		return nil, fmt.Errorf("destination project %q not found", to)
+	}
+
+	q := s.q
+	ctx := context.Background()
+	observations, err := q.CountObservationProjectRows(ctx, sqlNullString(from))
+	if err != nil {
+		return nil, fmt.Errorf("count source observations: %w", err)
+	}
+	sessions, err := q.CountSessionProjectRows(ctx, from)
+	if err != nil {
+		return nil, fmt.Errorf("count source sessions: %w", err)
+	}
+	prompts, err := q.CountPromptProjectRows(ctx, sqlNullString(from))
+	if err != nil {
+		return nil, fmt.Errorf("count source prompts: %w", err)
+	}
+	syncMutations, err := q.CountSyncMutationProjectRows(ctx, from)
+	if err != nil {
+		return nil, fmt.Errorf("count source sync mutations: %w", err)
+	}
+	sourceProjectRows, err := q.CountProjectRows(ctx, from)
+	if err != nil {
+		return nil, fmt.Errorf("count source project metadata: %w", err)
+	}
+	sourceEnrolled, err := q.IsProjectEnrolled(ctx, from)
+	if err != nil {
+		return nil, fmt.Errorf("check source enrollment: %w", err)
+	}
+	destinationEnrolled, err := q.IsProjectEnrolled(ctx, to)
+	if err != nil {
+		return nil, fmt.Errorf("check destination enrollment: %w", err)
+	}
+
+	return &ProjectMergePlan{
+		From:                    source,
+		To:                      destination,
+		Observations:            observations,
+		Sessions:                sessions,
+		Prompts:                 prompts,
+		SyncMutations:           syncMutations,
+		SourceProjectRows:       sourceProjectRows,
+		SourceEnrolled:          sourceEnrolled,
+		DestinationEnrolled:     destinationEnrolled,
+		WillCopyEnrollment:      sourceEnrolled && !destinationEnrolled,
+		WillDeleteSourceProject: sourceProjectRows > 0,
+	}, nil
+}
+
+func (s *Store) MergeProjects(from, to string) (*ProjectMergeResult, error) {
+	plan, err := s.BuildProjectMergePlan(from, to)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &ProjectMergeResult{
+		Plan:                  *plan,
+		Merged:                true,
+		EnrollmentTransferred: plan.WillCopyEnrollment,
+	}
+
+	err = s.withTx(func(tx *sql.Tx) error {
+		q := s.q.WithTx(tx)
+		ctx := context.Background()
+		params := dbgen.RenameObservationProjectParams{
+			NewName: sqlNullString(plan.To.ID),
+			OldName: sqlNullString(plan.From.ID),
+		}
+		n, err := q.RenameObservationProject(ctx, params)
+		if err != nil {
+			return fmt.Errorf("merge observations: %w", err)
+		}
+		result.ObservationsUpdated = n
+
+		result.SessionsUpdated, err = q.RenameSessionProject(ctx, dbgen.RenameSessionProjectParams{
+			NewName: plan.To.ID,
+			OldName: plan.From.ID,
+		})
+		if err != nil {
+			return fmt.Errorf("merge sessions: %w", err)
+		}
+
+		result.PromptsUpdated, err = q.RenamePromptProject(ctx, dbgen.RenamePromptProjectParams{
+			NewName: sqlNullString(plan.To.ID),
+			OldName: sqlNullString(plan.From.ID),
+		})
+		if err != nil {
+			return fmt.Errorf("merge prompts: %w", err)
+		}
+
+		result.SyncMutationsUpdated, err = q.RenameMutationProject(ctx, dbgen.RenameMutationProjectParams{
+			NewName: plan.To.ID,
+			OldName: plan.From.ID,
+		})
+		if err != nil {
+			return fmt.Errorf("merge sync_mutations: %w", err)
+		}
+
+		if err = q.CopyProjectEnrollment(ctx, dbgen.CopyProjectEnrollmentParams{
+			NewName: plan.To.ID,
+			OldName: plan.From.ID,
+		}); err != nil {
+			return fmt.Errorf("merge sync_enrolled_projects insert: %w", err)
+		}
+		if err = q.DeleteProjectEnrollment(ctx, plan.From.ID); err != nil {
+			return fmt.Errorf("merge sync_enrolled_projects delete: %w", err)
+		}
+
+		deleted, err := q.DeleteProjectByID(ctx, plan.From.ID)
+		if err != nil {
+			return fmt.Errorf("merge project metadata: %w", err)
+		}
+		result.SourceProjectDeleted = deleted > 0
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
 }
 
 func (s *Store) MigrateProject(oldName, newName string) (*MigrateResult, error) {

--- a/internal/store/project_test.go
+++ b/internal/store/project_test.go
@@ -62,6 +62,164 @@ func TestListProjectSummariesIncludesRegisteredAndActivityProjects(t *testing.T)
 	}
 }
 
+func TestBuildProjectMergePlan(t *testing.T) {
+	s := newTestStore(t)
+
+	if err := s.EnsureProject("alpha-legacy", "Alpha Legacy"); err != nil {
+		t.Fatalf("ensure source project: %v", err)
+	}
+	if err := s.EnsureProject("11111111-2222-3333-4444-555555555555", "Alpha"); err != nil {
+		t.Fatalf("ensure destination project: %v", err)
+	}
+	if err := s.CreateSession("s-alpha-legacy", "alpha-legacy", "/tmp/alpha"); err != nil {
+		t.Fatalf("create source session: %v", err)
+	}
+	if _, err := s.AddObservation(AddObservationParams{
+		SessionID: "s-alpha-legacy",
+		Type:      "decision",
+		Title:     "Alpha decision",
+		Content:   "Alpha memory",
+		Project:   "alpha-legacy",
+		Scope:     "project",
+	}); err != nil {
+		t.Fatalf("add source observation: %v", err)
+	}
+	if _, err := s.AddPrompt(AddPromptParams{SessionID: "s-alpha-legacy", Content: "Alpha prompt", Project: "alpha-legacy"}); err != nil {
+		t.Fatalf("add source prompt: %v", err)
+	}
+	if err := s.EnrollProject("alpha-legacy"); err != nil {
+		t.Fatalf("enroll source project: %v", err)
+	}
+
+	plan, err := s.BuildProjectMergePlan("alpha-legacy", "11111111-2222-3333-4444-555555555555")
+	if err != nil {
+		t.Fatalf("build project merge plan: %v", err)
+	}
+	if plan.From.ID != "alpha-legacy" || plan.To.ID != "11111111-2222-3333-4444-555555555555" {
+		t.Fatalf("unexpected plan endpoints: %+v", plan)
+	}
+	if plan.Observations != 1 || plan.Sessions != 1 || plan.Prompts != 1 || plan.SyncMutations != 3 {
+		t.Fatalf("unexpected plan counts: %+v", plan)
+	}
+	if !plan.SourceEnrolled || plan.DestinationEnrolled || !plan.WillCopyEnrollment || !plan.WillDeleteSourceProject {
+		t.Fatalf("unexpected plan flags: %+v", plan)
+	}
+}
+
+func TestMergeProjectsConsolidatesProjectData(t *testing.T) {
+	s := newTestStore(t)
+	source := "alpha-legacy"
+	destination := "11111111-2222-3333-4444-555555555555"
+
+	if err := s.EnsureProject(source, "Alpha Legacy"); err != nil {
+		t.Fatalf("ensure source project: %v", err)
+	}
+	if err := s.EnsureProject(destination, "Alpha"); err != nil {
+		t.Fatalf("ensure destination project: %v", err)
+	}
+	if err := s.CreateSession("s-alpha-legacy", source, "/tmp/alpha"); err != nil {
+		t.Fatalf("create source session: %v", err)
+	}
+	if _, err := s.AddObservation(AddObservationParams{
+		SessionID: "s-alpha-legacy",
+		Type:      "decision",
+		Title:     "Alpha merge",
+		Content:   "Merge source data",
+		Project:   source,
+		Scope:     "project",
+	}); err != nil {
+		t.Fatalf("add source observation: %v", err)
+	}
+	if _, err := s.AddPrompt(AddPromptParams{SessionID: "s-alpha-legacy", Content: "Alpha prompt", Project: source}); err != nil {
+		t.Fatalf("add source prompt: %v", err)
+	}
+	if err := s.EnrollProject(source); err != nil {
+		t.Fatalf("enroll source project: %v", err)
+	}
+
+	result, err := s.MergeProjects(source, destination)
+	if err != nil {
+		t.Fatalf("merge projects: %v", err)
+	}
+	if !result.Merged || result.ObservationsUpdated != 1 || result.SessionsUpdated != 1 || result.PromptsUpdated != 1 || result.SyncMutationsUpdated != 3 {
+		t.Fatalf("unexpected merge result: %+v", result)
+	}
+	if !result.SourceProjectDeleted || !result.EnrollmentTransferred {
+		t.Fatalf("expected source metadata deletion and enrollment transfer: %+v", result)
+	}
+
+	if project, err := s.GetProjectByID(source); err != nil {
+		t.Fatalf("get source project: %v", err)
+	} else if project != nil {
+		t.Fatalf("source project metadata still exists: %+v", project)
+	}
+	sourceEnrolled, err := s.IsProjectEnrolled(source)
+	if err != nil {
+		t.Fatalf("check source enrollment: %v", err)
+	}
+	destinationEnrolled, err := s.IsProjectEnrolled(destination)
+	if err != nil {
+		t.Fatalf("check destination enrollment: %v", err)
+	}
+	if sourceEnrolled || !destinationEnrolled {
+		t.Fatalf("unexpected enrollment state: source=%v destination=%v", sourceEnrolled, destinationEnrolled)
+	}
+
+	projects, err := s.ListProjectSummaries()
+	if err != nil {
+		t.Fatalf("list project summaries: %v", err)
+	}
+	if findProjectSummary(projects, source) != nil {
+		t.Fatalf("source project still appears in summaries: %+v", projects)
+	}
+	summary := findProjectSummary(projects, destination)
+	if summary == nil {
+		t.Fatalf("destination project missing from summaries: %+v", projects)
+	}
+	if summary.ObservationCount != 1 || summary.SessionCount != 1 || summary.PromptCount != 1 {
+		t.Fatalf("unexpected destination summary: %+v", summary)
+	}
+
+	results, err := s.Search("Alpha merge", SearchOptions{Project: destination, Limit: 10})
+	if err != nil {
+		t.Fatalf("search destination project: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected destination search result, got %d", len(results))
+	}
+	results, err = s.Search("Alpha merge", SearchOptions{Project: source, Limit: 10})
+	if err != nil {
+		t.Fatalf("search source project: %v", err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("expected no source search results, got %d", len(results))
+	}
+
+	var sourceMutations, destinationMutations int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM sync_mutations WHERE project = ?`, source).Scan(&sourceMutations); err != nil {
+		t.Fatalf("count source sync mutations: %v", err)
+	}
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM sync_mutations WHERE project = ?`, destination).Scan(&destinationMutations); err != nil {
+		t.Fatalf("count destination sync mutations: %v", err)
+	}
+	if sourceMutations != 0 || destinationMutations != 3 {
+		t.Fatalf("unexpected sync mutation counts: source=%d destination=%d", sourceMutations, destinationMutations)
+	}
+}
+
+func TestBuildProjectMergePlanRejectsMissingProjects(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.EnsureProject("alpha", "Alpha"); err != nil {
+		t.Fatalf("ensure project: %v", err)
+	}
+	if _, err := s.BuildProjectMergePlan("missing", "alpha"); err == nil {
+		t.Fatal("expected missing source error")
+	}
+	if _, err := s.BuildProjectMergePlan("alpha", "missing"); err == nil {
+		t.Fatal("expected missing destination error")
+	}
+}
+
 func findProjectSummary(projects []ProjectSummary, id string) *ProjectSummary {
 	for i := range projects {
 		if projects[i].ID == id {

--- a/internal/store/types.go
+++ b/internal/store/types.go
@@ -296,6 +296,31 @@ type MigrateResult struct {
 	SyncMutationsUpdated int64 `json:"sync_mutations_updated"`
 }
 
+type ProjectMergePlan struct {
+	From                    ProjectSummary `json:"from"`
+	To                      ProjectSummary `json:"to"`
+	Observations            int64          `json:"observations"`
+	Sessions                int64          `json:"sessions"`
+	Prompts                 int64          `json:"prompts"`
+	SyncMutations           int64          `json:"sync_mutations"`
+	SourceProjectRows       int64          `json:"source_project_rows"`
+	SourceEnrolled          bool           `json:"source_enrolled"`
+	DestinationEnrolled     bool           `json:"destination_enrolled"`
+	WillCopyEnrollment      bool           `json:"will_copy_enrollment"`
+	WillDeleteSourceProject bool           `json:"will_delete_source_project"`
+}
+
+type ProjectMergeResult struct {
+	Plan                  ProjectMergePlan `json:"plan"`
+	Merged                bool             `json:"merged"`
+	ObservationsUpdated   int64            `json:"observations_updated"`
+	SessionsUpdated       int64            `json:"sessions_updated"`
+	PromptsUpdated        int64            `json:"prompts_updated"`
+	SyncMutationsUpdated  int64            `json:"sync_mutations_updated"`
+	SourceProjectDeleted  bool             `json:"source_project_deleted"`
+	EnrollmentTransferred bool             `json:"enrollment_transferred"`
+}
+
 type PassiveCaptureParams struct {
 	SessionID string `json:"session_id"`
 	Content   string `json:"content"`


### PR DESCRIPTION
Summary:
- Add explicit and auto-by-path project merge planning.
- Require --dry-run or --yes before merging.
- Update project references, sync data, docs, and tests.

Tests:
- go tool sqlc generate
- go test ./...
- go test -race ./...
- go build ./...
- golangci-lint run ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `mnemo projects merge` to consolidate projects explicitly or by shared directory.
  * Supports dry runs, confirmation safeguards, JSON output, and automatic destination selection.
  * Preserves project data, transfers enrollment when applicable, and removes the merged source project.
* **Documentation**
  * Updated README and command help with merge usage and options.
  * Refined roadmap priorities around safer project management flows.
* **Bug Fixes**
  * Added validation and safety checks for missing, conflicting, or invalid merge selections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->