### PR TITLE
Add project maintenance skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ mnemo --version
 - **Portable Agent Skill:** teaches compatible agents the complete mnemo workflow without weakening the always-active safety rules
 - **Full CLI:** save, search, export, import, inspect, and diagnose memories from the terminal
 - **Project inventory:** `mnemo projects list` shows known projects; `mnemo projects merge` consolidates duplicate identities with dry-run planning
+- **Project maintenance skill:** helps agents detect duplicate project identities and propose safe merge plans
 - **Read-only diagnostics:** `mnemo doctor` checks project activation, global agent setup, MCP config, hooks/plugins, and local store health
 - **Setup lifecycle:** `mnemo setup status`, `print-config`, `refresh`, and `uninstall` inspect and maintain global agent configuration
 - **Own storage:** isolated `~/.mnemo/memory.db`, created automatically on first run
@@ -91,6 +92,14 @@ The skill is global, but it is guarded by the project marker. Its first step is 
 
 The skill is recommended rather than required. Hooks, MCP, and the always-active project protocol remain functional without it. `mnemo init` prints the installation command when the canonical global skill is missing.
 
+For project inventory cleanup, install the optional maintenance skill separately:
+
+```bash
+npx skills add jmeiracorbal/mnemo --skill mnemo-project-maintenance --global
+```
+
+Use it when an agent should inspect `mnemo projects list`, propose duplicate project merges, and apply only explicitly approved repairs.
+
 ### 3. Enable mnemo per project
 
 Run from the project root:
@@ -111,7 +120,7 @@ mnemo follows a CodeGraph-style split: installation configures agents globally, 
 | **MCP (always global)** | `~/.claude/.mcp.json` | `~/.cursor/mcp.json` | `~/.codeium/windsurf/mcp_config.json` | `~/.codex/config.toml` | `~/.config/opencode/opencode.json` |
 | **Hook config** | plugin hooks check `.mnemo` | `~/.cursor/hooks.json` | `~/.codeium/windsurf/hooks.json` | `~/.codex/hooks.json` checks `.mnemo` | global plugin checks `.mnemo` |
 | **Global protocol** | `~/.claude/CLAUDE.md` | `~/.cursor/rules/mnemo.mdc` | `~/.codeium/windsurf/memories/global_rules.md` | `~/.codex/AGENTS.md` | `~/.config/opencode/AGENTS.md` |
-| **Global skill access** | symlink at `~/.claude/skills/mnemo-memory` | canonical `~/.agents/skills/mnemo-memory` | symlink at `~/.codeium/windsurf/skills/mnemo-memory` | canonical `~/.agents/skills/mnemo-memory` | canonical `~/.agents/skills/mnemo-memory` |
+| **Global skill access** | symlinks under `~/.claude/skills/` | canonical `~/.agents/skills/` | symlinks under `~/.codeium/windsurf/skills/` | canonical `~/.agents/skills/` | canonical `~/.agents/skills/` |
 
 All supported agents now use global hook/configuration surfaces where available. Their global instructions are intentionally conditional: if `.mnemo` is missing or invalid, agents skip mnemo entirely and do not create fallback memory files.
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ For project inventory cleanup, install the optional maintenance skill separately
 npx skills add jmeiracorbal/mnemo --skill mnemo-project-maintenance --global
 ```
 
+This command installs only the skill and agent links. It does not install the `mnemo` binary, hooks, MCP configuration, or the Claude Code plugin. Install mnemo first and ensure `mnemo` is available in `PATH`, because the skill invokes the CLI.
+
 Use it when an agent should inspect `mnemo projects list`, propose duplicate project merges, and apply only explicitly approved repairs.
 
 ### 3. Enable mnemo per project

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -17,19 +17,16 @@ Near-term goals:
 - keep `prune` behind explicit safety checks after merge/consolidation is reliable;
 - revisit `rename` after consolidation, using explicit selectors (`--id`, `--path`, or a shared selector flag) instead of ambiguous positional arguments.
 
-## Project maintenance skill
+## Skill agent metadata coverage
 
-Add a separate Agent Skill for project inventory maintenance so agents can diagnose and resolve common project identity problems without requiring the user to manually inspect IDs and run every merge command.
+Add agent-specific metadata coverage for every shipped skill after the project maintenance skill lands.
 
-Planned responsibilities:
+Goals:
 
-- run `mnemo projects list --json` and identify likely duplicates by shared directory/path, legacy key patterns, and UUID project metadata;
-- produce a concise project maintenance report with proposed merge groups and destination projects;
-- execute high-confidence merge plans through `mnemo projects merge` when explicitly requested or when a user has opted into automatic project maintenance;
-- fall back to asking for confirmation when merge targets are ambiguous, when data would be moved across unrelated paths, or when destructive cleanup is involved;
-- record what was merged and why, so future agents understand previous consolidation decisions.
-
-The skill should be read-only by default, support dry-run planning, and require clear opt-in before broad mutation.
+- decide which `agents/` metadata files are required per supported agent and keep them consistent across all skills;
+- verify whether each agent detects metadata files, symlinked skill folders, or only real skill directories;
+- prefer canonical skill folders as the source of truth, using symlinks only for installed global agent locations when agents reliably support them;
+- update validation so new skills cannot ship with incomplete agent metadata.
 
 ## Local sync
 

--- a/cmd/mnemo/plugin_integrity_test.go
+++ b/cmd/mnemo/plugin_integrity_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"gopkg.in/yaml.v3"
 )
 
 // TestShippedHooksReferenceRealScripts validates that every command in
@@ -150,7 +152,29 @@ func TestShippedMnemoProjectMaintenanceSkill(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read shipped project maintenance skill metadata: %v", err)
 	}
-	if !strings.Contains(string(agentData), "$mnemo-project-maintenance") {
-		t.Fatalf("project maintenance skill metadata missing default prompt invocation")
+	var metadata struct {
+		Interface struct {
+			DisplayName      string `yaml:"display_name"`
+			ShortDescription string `yaml:"short_description"`
+			DefaultPrompt    string `yaml:"default_prompt"`
+		} `yaml:"interface"`
+	}
+	if err := yaml.Unmarshal(agentData, &metadata); err != nil {
+		t.Fatalf("parse shipped project maintenance skill metadata: %v", err)
+	}
+	wantMetadata := map[string]string{
+		"interface.display_name":      "mnemo Project Maintenance",
+		"interface.short_description": "Detect and safely merge duplicate projects",
+		"interface.default_prompt":    "Use $mnemo-project-maintenance to inspect mnemo project inventory, propose duplicate project merges, and apply only explicitly approved repairs.",
+	}
+	gotMetadata := map[string]string{
+		"interface.display_name":      metadata.Interface.DisplayName,
+		"interface.short_description": metadata.Interface.ShortDescription,
+		"interface.default_prompt":    metadata.Interface.DefaultPrompt,
+	}
+	for key, want := range wantMetadata {
+		if got := gotMetadata[key]; got != want {
+			t.Errorf("%s = %q, want %q", key, got, want)
+		}
 	}
 }

--- a/cmd/mnemo/plugin_integrity_test.go
+++ b/cmd/mnemo/plugin_integrity_test.go
@@ -122,3 +122,35 @@ func TestShippedMnemoMemorySkill(t *testing.T) {
 		}
 	}
 }
+
+func TestShippedMnemoProjectMaintenanceSkill(t *testing.T) {
+	skillPath := filepath.Join("..", "..", "skills", "mnemo-project-maintenance", "SKILL.md")
+	data, err := os.ReadFile(skillPath)
+	if err != nil {
+		t.Fatalf("read shipped project maintenance skill: %v", err)
+	}
+	content := string(data)
+	required := []string{
+		"name: mnemo-project-maintenance",
+		"description:",
+		"mnemo projects list --json",
+		"mnemo projects merge --auto-by-path --dry-run --json",
+		"Do not run `mnemo projects merge ... --yes` unless the user explicitly approves",
+		"`from` is the duplicate/source project",
+		"`to` is the canonical destination project",
+	}
+	for _, value := range required {
+		if !strings.Contains(content, value) {
+			t.Errorf("shipped project maintenance skill missing %q", value)
+		}
+	}
+
+	agentPath := filepath.Join("..", "..", "skills", "mnemo-project-maintenance", "agents", "openai.yaml")
+	agentData, err := os.ReadFile(agentPath)
+	if err != nil {
+		t.Fatalf("read shipped project maintenance skill metadata: %v", err)
+	}
+	if !strings.Contains(string(agentData), "$mnemo-project-maintenance") {
+		t.Fatalf("project maintenance skill metadata missing default prompt invocation")
+	}
+}

--- a/skills/mnemo-project-maintenance/SKILL.md
+++ b/skills/mnemo-project-maintenance/SKILL.md
@@ -72,4 +72,4 @@ Use mnemo CLI commands to find and consolidate duplicate project identities. Thi
 
    Confirm that the applied duplicates no longer appear and call out any remaining ambiguous candidates.
 
-9. Record the repair when memory tools are available and the current project has a valid `.mnemo` marker: save what was merged, why it was safe, and any remaining follow-up.
+9. Record the repair through `mem_save` by using `mnemo-memory` when memory tools are available and the current project has a valid `.mnemo` marker. The record must include what was merged, why it was safe, and any remaining follow-up. Never use native agent memory, `MEMORY.md`, arbitrary plaintext files, or alternative stores.

--- a/skills/mnemo-project-maintenance/SKILL.md
+++ b/skills/mnemo-project-maintenance/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: mnemo-project-maintenance
+description: Diagnose and safely repair duplicate mnemo project identities. Use when Codex needs to inspect `mnemo projects list`, find duplicate or stale project IDs, plan or apply `mnemo projects merge`, consolidate same-project records across UUID, path-derived, legacy, renamed, or moved directories, or perform project inventory maintenance. Default to read-only dry-run analysis and require explicit user approval before any `--yes` merge.
+---
+
+# mnemo Project Maintenance
+
+Use mnemo CLI commands to find and consolidate duplicate project identities. This skill is independent from `mnemo-memory`; use `mnemo-memory` separately only when the task also involves persistent memory.
+
+## Safety rules
+
+- Never edit `~/.mnemo/memory.db` or other mnemo store files directly.
+- Default to read-only commands: `mnemo projects list --json` and `mnemo projects merge --auto-by-path --dry-run --json`.
+- Do not run `mnemo projects merge ... --yes` unless the user explicitly approves applying the exact or described plan.
+- Ask for confirmation when paths, names, or merge targets are ambiguous.
+- Treat `mnemo projects merge --auto-by-path` without `--dry-run` or `--yes` as an intentional guardrail, not a broken command.
+
+## Workflow
+
+1. Verify the installed CLI supports project maintenance:
+
+   ```bash
+   mnemo version
+   ```
+
+   If the version is older than `v0.26.0` or the binary is missing, ask the user to update mnemo before planning merges.
+
+2. Build the project inventory:
+
+   ```bash
+   mnemo projects list --json
+   ```
+
+3. Generate the safe automatic merge plan:
+
+   ```bash
+   mnemo projects merge --auto-by-path --dry-run --json
+   ```
+
+4. Review the JSON results before suggesting changes:
+
+   - `from` is the duplicate/source project that would be absorbed.
+   - `to` is the canonical destination project that would keep the consolidated memories.
+   - Include only completed dry-run results in the proposed plan.
+   - If the command reports an error with partial results, show the successful results and the error separately.
+
+5. Classify candidates:
+
+   - **High confidence:** same normalized directory/path; UUID project plus legacy/path-derived project for the same directory; CLI auto plan clearly maps a stale duplicate into an active destination.
+   - **Medium confidence:** same repository name in different directories, likely moved project, or path plus ID records that appear related but not identical.
+   - **Low confidence:** similar names only, missing directory evidence, temporary/personal paths, or unrelated repositories.
+
+6. Report concisely:
+
+   - summarize candidate counts;
+   - list high-confidence `from -> to` merges first;
+   - mark medium/low-confidence items as requiring confirmation or manual review;
+   - show the command that would apply the approved plan, but do not execute it yet.
+
+7. Apply only after explicit opt-in:
+
+   - Use `mnemo projects merge --from=PROJECT --to=PROJECT --yes` for individually approved merges.
+   - Use `mnemo projects merge --auto-by-path --yes` only when the user explicitly approves the full dry-run plan.
+   - If a later merge fails, preserve and report earlier successful merge results before showing the error.
+
+8. Verify after applying:
+
+   ```bash
+   mnemo projects merge --auto-by-path --dry-run --json
+   mnemo projects list --json
+   ```
+
+   Confirm that the applied duplicates no longer appear and call out any remaining ambiguous candidates.
+
+9. Record the repair when memory tools are available and the current project has a valid `.mnemo` marker: save what was merged, why it was safe, and any remaining follow-up.

--- a/skills/mnemo-project-maintenance/agents/openai.yaml
+++ b/skills/mnemo-project-maintenance/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "mnemo Project Maintenance"
+  short_description: "Detect and safely merge duplicate projects"
+  default_prompt: "Use $mnemo-project-maintenance to inspect mnemo project inventory, propose duplicate project merges, and apply only explicitly approved repairs."


### PR DESCRIPTION
Adds an independent project maintenance skill for safe duplicate project merge planning.\n\nValidation:\n- go test ./...\n- go build ./...\n- golangci-lint run ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional project-maintenance skill for detecting duplicate project identities and proposing or applying approved merges.
  * Added safety guidance, including read-only defaults, dry-run planning, explicit approval, version checks, and post-merge verification.
  * Added agent metadata and a default prompt for accessing the project-maintenance capability.

* **Documentation**
  * Updated capability documentation and roadmap coverage for agent metadata, skill discovery, canonical directories, and validation.

* **Tests**
  * Added validation confirming the shipped skill and associated agent metadata contain the required guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->