### PR TITLE
Alinear versión MCP e identidad de proyecto con este repo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ Known prior failure: `post-compaction.sh` referenced in hook config, real script
 
 ### 3. Never change version references partially
 
-The binary version is injected at build time via ldflags — no code change needed. Plugin metadata files contain the version string explicitly and must be updated on every release.
+The binary version is injected at build time via ldflags — no code change needed. The MCP server must advertise that same binary version; do not hardcode a separate MCP version string. Plugin metadata files contain the version string explicitly and must be updated on every release.
 
 Required files on every version bump:
 
@@ -66,14 +66,11 @@ Do not tag from a feature branch or from stale local `main`.
 
 Distinguish clearly between binary installation, plugin installation, hook registration, setup-side file modifications, and MCP configuration. If the plugin depends on the binary being in `PATH`, state that explicitly near the install steps.
 
-### 7. Project identity derivation must stay consistent across hooks
+### 7. Project identity is the `.mnemo` id
 
-All hooks must derive `PROJECT` the same way:
+In this repository, shipped hooks and plugins must resolve `PROJECT` from the `id` field of `.mnemo`. They must not derive identity from the filesystem path.
 
-- inside `HOME`: full path relative to `HOME`, normalized (`tr '/' '-'`, lowercased)
-- outside `HOME`: same normalization from CWD
-
-Any inconsistency fragments stored memory across sessions. Any change to this logic is a storage compatibility change.
+Any second identity scheme fragments stored memory. Changing this is a storage compatibility change.
 
 ### 8. Tests must validate the shipped plugin, not only installer internals
 
@@ -89,7 +86,7 @@ Before committing any change that touches hooks, plugin metadata, setup/install 
 - [ ] Affected hook or setup flow works end-to-end
 - [ ] Hook filenames in `hooks.json` match actual embedded scripts
 - [ ] Version strings updated in all required metadata files
-- [ ] PROJECT derivation is consistent across all hooks
+- [ ] Shipped hooks resolve PROJECT from `.mnemo` id
 - [ ] No previously working path was broken
 
 State what was verified in the commit message. Do not claim completion without verification evidence.
@@ -100,7 +97,8 @@ State what was verified in the commit message. Do not claim completion without v
 - Update only one version file
 - Trust tests that ignore shipped plugin files
 - Change docs without checking actual implementation
-- Introduce a second way to derive project identity
+- Introduce a second way to resolve project identity besides the `.mnemo` id
+- Hardcode an MCP server version separate from the binary version
 - Assume release metadata is centralized if it is not
 
 ## Expected output style

--- a/cmd/mnemo/main.go
+++ b/cmd/mnemo/main.go
@@ -116,7 +116,11 @@ func runMCP(s *store.Store) {
 	}
 
 	allowlist := mcpserver.ResolveTools(tools)
-	srv := mcpserver.NewServerWithTools(s, allowlist)
+	srv, err := mcpserver.NewServerWithTools(s, version, allowlist)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mnemo: mcp server: %v\n", err)
+		os.Exit(1)
+	}
 
 	if err := server.ServeStdio(srv); err != nil {
 		fmt.Fprintf(os.Stderr, "mnemo: mcp server error: %v\n", err)

--- a/cmd/mnemo/plugin_integrity_test.go
+++ b/cmd/mnemo/plugin_integrity_test.go
@@ -71,6 +71,67 @@ func TestShippedHooksReferenceRealScripts(t *testing.T) {
 	}
 }
 
+func TestShippedHooksResolveProjectFromMarker(t *testing.T) {
+	roots := []string{
+		filepath.Join("..", "..", "plugin", "claude-code", "scripts"),
+		filepath.Join("..", "..", "scripts", "cursor", "hooks"),
+		filepath.Join("..", "..", "scripts", "windsurf", "hooks"),
+		filepath.Join("..", "..", "scripts", "codex", "hooks"),
+		filepath.Join("..", "..", "scripts", "opencode", "plugins"),
+	}
+
+	checked := 0
+	for _, root := range roots {
+		err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() {
+				return nil
+			}
+			switch filepath.Ext(path) {
+			case ".sh", ".ts":
+			default:
+				return nil
+			}
+
+			data, err := os.ReadFile(path)
+			if err != nil {
+				t.Errorf("read %s: %v", path, err)
+				return nil
+			}
+			content := string(data)
+			usesProject := strings.Contains(content, "$PROJECT") ||
+				strings.Contains(content, "PROJECT=") ||
+				strings.Contains(content, "--project") ||
+				strings.Contains(content, "mnemoProject(")
+			if !usesProject {
+				return nil
+			}
+			checked++
+
+			if !strings.Contains(content, ".mnemo") {
+				t.Errorf("%s uses project identity but does not read .mnemo", path)
+			}
+			fromMarker := strings.Contains(content, "mnemo json id") ||
+				strings.Contains(content, ".id")
+			if !fromMarker {
+				t.Errorf("%s uses project identity but does not resolve it from .mnemo id", path)
+			}
+			if strings.Contains(content, "tr '/' '-'") || strings.Contains(content, `tr "/" "-"`) {
+				t.Errorf("%s still derives project identity from filesystem path", path)
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("walk %s: %v", root, err)
+		}
+	}
+	if checked == 0 {
+		t.Fatal("no shipped hooks that resolve PROJECT were found")
+	}
+}
+
 func TestShippedProtocolsForbidFallbackMemory(t *testing.T) {
 	files := []string{
 		filepath.Join("..", "..", "templates", "rules", "generic.md"),

--- a/internal/mcp/descriptions_test.go
+++ b/internal/mcp/descriptions_test.go
@@ -6,7 +6,10 @@ import (
 )
 
 func TestEmbeddedToolDescriptionsAreRegistered(t *testing.T) {
-	srv := NewServerWithTools(nil, nil)
+	srv, err := NewServerWithTools(nil, "test", nil)
+	if err != nil {
+		t.Fatalf("NewServerWithTools: %v", err)
+	}
 	tools := srv.ListTools()
 
 	cases := map[string]string{
@@ -33,5 +36,14 @@ func TestEmbeddedToolDescriptionsAreRegistered(t *testing.T) {
 		if got := tool.Tool.Description; got != strings.TrimSpace(want) {
 			t.Fatalf("%s description mismatch\nwant:\n%s\n\ngot:\n%s", name, strings.TrimSpace(want), got)
 		}
+	}
+}
+
+func TestNewServerWithToolsRequiresVersion(t *testing.T) {
+	if _, err := NewServerWithTools(nil, "", nil); err == nil {
+		t.Fatal("expected error when version is empty")
+	}
+	if _, err := NewServerWithTools(nil, "   ", nil); err == nil {
+		t.Fatal("expected error when version is whitespace")
 	}
 }

--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -158,22 +158,27 @@ func ResolveTools(input string) map[string]bool {
 }
 
 // NewServer creates an MCP server with ALL tools registered.
-func NewServer(s *store.Store) *server.MCPServer {
-	return NewServerWithTools(s, nil)
+func NewServer(s *store.Store, version string) (*server.MCPServer, error) {
+	return NewServerWithTools(s, version, nil)
 }
 
 // NewServerWithTools creates an MCP server registering only the tools in
 // the allowlist. If allowlist is nil, all tools are registered.
-func NewServerWithTools(s *store.Store, allowlist map[string]bool) *server.MCPServer {
+// version is the binary version advertised to MCP clients; it is required.
+func NewServerWithTools(s *store.Store, version string, allowlist map[string]bool) (*server.MCPServer, error) {
+	if strings.TrimSpace(version) == "" {
+		return nil, fmt.Errorf("mcp server version is required")
+	}
+
 	srv := server.NewMCPServer(
 		"mnemo",
-		"0.1.0",
+		version,
 		server.WithToolCapabilities(true),
 		server.WithInstructions(strings.TrimSpace(serverInstructions)),
 	)
 
 	registerTools(srv, s, allowlist)
-	return srv
+	return srv, nil
 }
 
 func shouldRegister(name string, allowlist map[string]bool) bool {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1,8 +1,8 @@
-// Package store implements the persistent memory engine for Engram.
+// Package store implements the persistent memory engine for mnemo.
 //
 // It uses SQLite with FTS5 full-text search to store and retrieve
-// observations from AI coding sessions. This is the core of Engram —
-// everything else (HTTP server, MCP server, CLI, plugins) talks to this.
+// observations from AI coding sessions. CLI, MCP, and agent integrations
+// talk to this package.
 package store
 
 import (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Tres inconsistencias de identidad en este repositorio: el servidor MCP anunciaba `0.1.0` fijo, `AGENTS.md` documentaba una derivación de `PROJECT` por ruta, y el comentario de `store` no nombraba a mnemo.

## Qué cambia

- El servidor MCP exige la versión del binario (`cmd/mnemo`) y falla si llega vacía. No hay fallback a `0.1.0`.
- `AGENTS.md` describe solo este proyecto: `PROJECT` es el `id` de `.mnemo`. Los hooks empaquetados no pueden derivar identidad por path.
- El comentario de `internal/store` nombra a mnemo.
- Tests nuevos: versión MCP requerida; hooks empaquetados resuelven `PROJECT` desde `.mnemo`.

## Qué no toca

- La versión de formato de export (`0.1.0` en `internal/store/export.go`) es contrato de datos, no versión de producto.
- No unifica hooks ni extrae una interfaz de agentes.

## Verificado

- `go test ./...`
- `go build ./...`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0124d-d401-7a3a-bf4d-29b27c2cf582?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0124d-d401-7a3a-bf4d-29b27c2cf582&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

