### PR TITLE
Unificar schema.sql como fuente de verdad del DDL

### DIFF
--- a/internal/db/schema.go
+++ b/internal/db/schema.go
@@ -1,0 +1,55 @@
+package db
+
+import (
+	_ "embed"
+	"regexp"
+	"strings"
+)
+
+//go:embed schema.sql
+var Schema string
+
+var tableStatementPattern = regexp.MustCompile(`(?is)CREATE\s+TABLE\s+[^;]+;`)
+
+// ApplyTableSQL returns CREATE TABLE statements with IF NOT EXISTS, for the
+// first migration pass before column backfills. Virtual FTS tables are applied
+// later so ALTER TABLE does not corrupt external-content FTS.
+func ApplyTableSQL() string {
+	return withIfNotExists(joinStatements(tableStatements(Schema)))
+}
+
+// ApplyObjectSQL returns virtual tables, indexes, and triggers with IF NOT EXISTS.
+func ApplyObjectSQL() string {
+	sql := tableStatementPattern.ReplaceAllString(Schema, "")
+	return withIfNotExists(strings.TrimSpace(sql) + "\n")
+}
+
+func tableStatements(sql string) []string {
+	matches := tableStatementPattern.FindAllString(sql, -1)
+	out := make([]string, 0, len(matches))
+	for _, match := range matches {
+		out = append(out, strings.TrimSpace(match))
+	}
+	return out
+}
+
+func joinStatements(statements []string) string {
+	return strings.Join(statements, "\n\n") + "\n"
+}
+
+func withIfNotExists(sql string) string {
+	replacements := []struct {
+		old string
+		new string
+	}{
+		{"CREATE UNIQUE INDEX ", "CREATE UNIQUE INDEX IF NOT EXISTS "},
+		{"CREATE INDEX ", "CREATE INDEX IF NOT EXISTS "},
+		{"CREATE VIRTUAL TABLE ", "CREATE VIRTUAL TABLE IF NOT EXISTS "},
+		{"CREATE TRIGGER ", "CREATE TRIGGER IF NOT EXISTS "},
+		{"CREATE TABLE ", "CREATE TABLE IF NOT EXISTS "},
+	}
+	for _, replacement := range replacements {
+		sql = strings.ReplaceAll(sql, replacement.old, replacement.new)
+	}
+	return sql
+}

--- a/internal/db/schema_test.go
+++ b/internal/db/schema_test.go
@@ -1,0 +1,50 @@
+package db
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestApplyTableSQLUsesCanonicalTables(t *testing.T) {
+	sql := ApplyTableSQL()
+	required := []string{
+		"CREATE TABLE IF NOT EXISTS sessions",
+		"CREATE TABLE IF NOT EXISTS observations",
+		"CREATE TABLE IF NOT EXISTS user_prompts",
+		"CREATE TABLE IF NOT EXISTS sync_chunks",
+		"CREATE TABLE IF NOT EXISTS sync_state",
+		"CREATE TABLE IF NOT EXISTS sync_mutations",
+		"CREATE TABLE IF NOT EXISTS sync_enrolled_projects",
+		"CREATE TABLE IF NOT EXISTS observation_tags",
+		"CREATE TABLE IF NOT EXISTS session_tags",
+		"CREATE TABLE IF NOT EXISTS projects",
+	}
+	for _, want := range required {
+		if !strings.Contains(sql, want) {
+			t.Fatalf("ApplyTableSQL missing %q", want)
+		}
+	}
+	if strings.Contains(sql, "CREATE INDEX") || strings.Contains(sql, "CREATE TRIGGER") || strings.Contains(sql, "CREATE VIRTUAL TABLE") {
+		t.Fatal("ApplyTableSQL must not include indexes, triggers, or virtual tables")
+	}
+}
+
+func TestApplyObjectSQLUsesCanonicalIndexesAndTriggers(t *testing.T) {
+	sql := ApplyObjectSQL()
+	required := []string{
+		"CREATE VIRTUAL TABLE IF NOT EXISTS observations_fts",
+		"CREATE VIRTUAL TABLE IF NOT EXISTS prompts_fts",
+		"CREATE INDEX IF NOT EXISTS idx_obs_scope",
+		"CREATE UNIQUE INDEX IF NOT EXISTS ux_observations_sync_id",
+		"CREATE TRIGGER IF NOT EXISTS obs_fts_insert",
+		"CREATE TRIGGER IF NOT EXISTS prompt_fts_insert",
+	}
+	for _, want := range required {
+		if !strings.Contains(sql, want) {
+			t.Fatalf("ApplyObjectSQL missing %q", want)
+		}
+	}
+	if strings.Contains(sql, "CREATE TABLE IF NOT EXISTS sessions") {
+		t.Fatal("ApplyObjectSQL must not include base table statements")
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -13,6 +13,7 @@ import (
 	"regexp"
 	"time"
 
+	dbschema "github.com/jmeiracorbal/mnemo/internal/db"
 	dbgen "github.com/jmeiracorbal/mnemo/internal/db/generated"
 	_ "modernc.org/sqlite"
 )
@@ -218,106 +219,7 @@ func (s *Store) Close() error {
 // ─── Migrations ──────────────────────────────────────────────────────────────
 
 func (s *Store) migrate() error {
-	schema := `
-			CREATE TABLE IF NOT EXISTS sessions (
-				id         TEXT PRIMARY KEY,
-			project    TEXT NOT NULL,
-			directory  TEXT NOT NULL,
-			started_at TEXT NOT NULL DEFAULT (datetime('now')),
-			ended_at   TEXT,
-			summary    TEXT
-		);
-
-			CREATE TABLE IF NOT EXISTS observations (
-				id         INTEGER PRIMARY KEY AUTOINCREMENT,
-				sync_id    TEXT,
-				session_id TEXT    NOT NULL,
-			type       TEXT    NOT NULL,
-			title      TEXT    NOT NULL,
-			content    TEXT    NOT NULL,
-			tool_name  TEXT,
-			project    TEXT,
-			scope      TEXT    NOT NULL DEFAULT 'project',
-			topic_key  TEXT,
-			normalized_hash TEXT,
-			revision_count INTEGER NOT NULL DEFAULT 1,
-			duplicate_count INTEGER NOT NULL DEFAULT 1,
-			last_seen_at TEXT,
-			created_at TEXT    NOT NULL DEFAULT (datetime('now')),
-			updated_at TEXT    NOT NULL DEFAULT (datetime('now')),
-			deleted_at TEXT,
-			FOREIGN KEY (session_id) REFERENCES sessions(id)
-		);
-
-		CREATE INDEX IF NOT EXISTS idx_obs_session  ON observations(session_id);
-		CREATE INDEX IF NOT EXISTS idx_obs_type     ON observations(type);
-		CREATE INDEX IF NOT EXISTS idx_obs_project  ON observations(project);
-		CREATE INDEX IF NOT EXISTS idx_obs_created  ON observations(created_at DESC);
-
-		CREATE VIRTUAL TABLE IF NOT EXISTS observations_fts USING fts5(
-			title,
-			content,
-			tool_name,
-			type,
-			project,
-			content='observations',
-			content_rowid='id'
-		);
-
-			CREATE TABLE IF NOT EXISTS user_prompts (
-				id         INTEGER PRIMARY KEY AUTOINCREMENT,
-				sync_id    TEXT,
-				session_id TEXT    NOT NULL,
-			content    TEXT    NOT NULL,
-			project    TEXT,
-			created_at TEXT    NOT NULL DEFAULT (datetime('now')),
-			FOREIGN KEY (session_id) REFERENCES sessions(id)
-		);
-
-		CREATE INDEX IF NOT EXISTS idx_prompts_session ON user_prompts(session_id);
-		CREATE INDEX IF NOT EXISTS idx_prompts_project ON user_prompts(project);
-		CREATE INDEX IF NOT EXISTS idx_prompts_created ON user_prompts(created_at DESC);
-
-		CREATE VIRTUAL TABLE IF NOT EXISTS prompts_fts USING fts5(
-			content,
-			project,
-			content='user_prompts',
-			content_rowid='id'
-		);
-
-			CREATE TABLE IF NOT EXISTS sync_chunks (
-				chunk_id    TEXT PRIMARY KEY,
-				imported_at TEXT NOT NULL DEFAULT (datetime('now'))
-			);
-
-			CREATE TABLE IF NOT EXISTS sync_state (
-				target_key           TEXT PRIMARY KEY,
-				lifecycle            TEXT NOT NULL DEFAULT 'idle',
-				last_enqueued_seq    INTEGER NOT NULL DEFAULT 0,
-				last_acked_seq       INTEGER NOT NULL DEFAULT 0,
-				last_pulled_seq      INTEGER NOT NULL DEFAULT 0,
-				consecutive_failures INTEGER NOT NULL DEFAULT 0,
-				backoff_until        TEXT,
-				lease_owner          TEXT,
-				lease_until          TEXT,
-				last_error           TEXT,
-				updated_at           TEXT NOT NULL DEFAULT (datetime('now'))
-			);
-
-			CREATE TABLE IF NOT EXISTS sync_mutations (
-				seq         INTEGER PRIMARY KEY AUTOINCREMENT,
-				target_key  TEXT NOT NULL,
-				entity      TEXT NOT NULL,
-				entity_key  TEXT NOT NULL,
-				op          TEXT NOT NULL,
-				payload     TEXT NOT NULL,
-				source      TEXT NOT NULL DEFAULT 'local',
-				occurred_at TEXT NOT NULL DEFAULT (datetime('now')),
-				acked_at    TEXT,
-				FOREIGN KEY (target_key) REFERENCES sync_state(target_key)
-			);
-		`
-	if _, err := s.execHook(s.db, schema); err != nil {
+	if _, err := s.execHook(s.db, dbschema.ApplyTableSQL()); err != nil {
 		return err
 	}
 
@@ -349,53 +251,24 @@ func (s *Store) migrate() error {
 		return err
 	}
 
+	if err := s.addColumnIfNotExists("sync_mutations", "project", "TEXT NOT NULL DEFAULT ''"); err != nil {
+		return err
+	}
+
+	if _, err := s.execHook(s.db, dbschema.ApplyObjectSQL()); err != nil {
+		return err
+	}
 	if _, err := s.execHook(s.db, `
-		CREATE INDEX IF NOT EXISTS idx_obs_scope ON observations(scope);
-		CREATE INDEX IF NOT EXISTS idx_obs_sync_id ON observations(sync_id);
-		CREATE INDEX IF NOT EXISTS idx_obs_topic ON observations(topic_key, project, scope, updated_at DESC);
-		CREATE INDEX IF NOT EXISTS idx_obs_deleted ON observations(deleted_at);
-		CREATE INDEX IF NOT EXISTS idx_obs_dedupe ON observations(normalized_hash, project, scope, type, title, created_at DESC);
-		CREATE INDEX IF NOT EXISTS idx_prompts_sync_id ON user_prompts(sync_id);
-		CREATE INDEX IF NOT EXISTS idx_sync_mutations_target_seq ON sync_mutations(target_key, seq);
-		CREATE INDEX IF NOT EXISTS idx_sync_mutations_pending ON sync_mutations(target_key, acked_at, seq);
+		INSERT INTO observations_fts(observations_fts) VALUES('rebuild');
+		INSERT INTO prompts_fts(prompts_fts) VALUES('rebuild');
 	`); err != nil {
 		return err
 	}
 
-	if err := s.addColumnIfNotExists("sync_mutations", "project", "TEXT NOT NULL DEFAULT ''"); err != nil {
-		return err
-	}
-	if _, err := s.execHook(s.db, `
-		CREATE TABLE IF NOT EXISTS sync_enrolled_projects (
-			project     TEXT PRIMARY KEY,
-			enrolled_at TEXT NOT NULL DEFAULT (datetime('now'))
-		);
-		CREATE INDEX IF NOT EXISTS idx_sync_mutations_project ON sync_mutations(project);
-	`); err != nil {
-		return err
-	}
 	if _, err := s.execHook(s.db, `
 		UPDATE sync_mutations
 		SET project = COALESCE(json_extract(payload, '$.project'), '')
 		WHERE project = '' AND payload != ''
-	`); err != nil {
-		return err
-	}
-
-	if _, err := s.execHook(s.db, `
-		CREATE TABLE IF NOT EXISTS observation_tags (
-			observation_id INTEGER NOT NULL REFERENCES observations(id) ON DELETE CASCADE,
-			tag            TEXT    NOT NULL,
-			PRIMARY KEY (observation_id, tag)
-		);
-		CREATE TABLE IF NOT EXISTS session_tags (
-			session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
-			tag        TEXT NOT NULL,
-			PRIMARY KEY (session_id, tag)
-		);
-		CREATE INDEX IF NOT EXISTS idx_obs_tags_obs ON observation_tags(observation_id);
-		CREATE INDEX IF NOT EXISTS idx_obs_tags_tag ON observation_tags(tag);
-		CREATE INDEX IF NOT EXISTS idx_ses_tags_ses ON session_tags(session_id);
 	`); err != nil {
 		return err
 	}
@@ -429,72 +302,7 @@ func (s *Store) migrate() error {
 		return err
 	}
 
-	if err := s.ensureFTSTriggers(); err != nil {
-		return err
-	}
-
-	if _, err := s.execHook(s.db, `
-		CREATE TABLE IF NOT EXISTS projects (
-			id         TEXT PRIMARY KEY,
-			name       TEXT NOT NULL,
-			created_at TEXT NOT NULL DEFAULT (datetime('now'))
-		);
-	`); err != nil {
-		return err
-	}
-
-	if _, err := s.execHook(s.db, `
-		CREATE UNIQUE INDEX IF NOT EXISTS ux_observations_sync_id
-		ON observations(sync_id)
-		WHERE sync_id IS NOT NULL AND sync_id <> '';
-
-		CREATE UNIQUE INDEX IF NOT EXISTS ux_user_prompts_sync_id
-		ON user_prompts(sync_id)
-		WHERE sync_id IS NOT NULL AND sync_id <> '';
-	`); err != nil {
-		return err
-	}
-
 	return nil
-}
-
-func (s *Store) ensureFTSTriggers() error {
-	_, err := s.execHook(s.db, `
-		CREATE TRIGGER IF NOT EXISTS obs_fts_insert AFTER INSERT ON observations BEGIN
-			INSERT INTO observations_fts(rowid, title, content, tool_name, type, project)
-			VALUES (new.id, new.title, new.content, new.tool_name, new.type, new.project);
-		END;
-
-		CREATE TRIGGER IF NOT EXISTS obs_fts_delete AFTER DELETE ON observations BEGIN
-			INSERT INTO observations_fts(observations_fts, rowid, title, content, tool_name, type, project)
-			VALUES ('delete', old.id, old.title, old.content, old.tool_name, old.type, old.project);
-		END;
-
-		CREATE TRIGGER IF NOT EXISTS obs_fts_update AFTER UPDATE ON observations BEGIN
-			INSERT INTO observations_fts(observations_fts, rowid, title, content, tool_name, type, project)
-			VALUES ('delete', old.id, old.title, old.content, old.tool_name, old.type, old.project);
-			INSERT INTO observations_fts(rowid, title, content, tool_name, type, project)
-			VALUES (new.id, new.title, new.content, new.tool_name, new.type, new.project);
-		END;
-
-		CREATE TRIGGER IF NOT EXISTS prompt_fts_insert AFTER INSERT ON user_prompts BEGIN
-			INSERT INTO prompts_fts(rowid, content, project)
-			VALUES (new.id, new.content, new.project);
-		END;
-
-		CREATE TRIGGER IF NOT EXISTS prompt_fts_delete AFTER DELETE ON user_prompts BEGIN
-			INSERT INTO prompts_fts(prompts_fts, rowid, content, project)
-			VALUES ('delete', old.id, old.content, old.project);
-		END;
-
-		CREATE TRIGGER IF NOT EXISTS prompt_fts_update AFTER UPDATE ON user_prompts BEGIN
-			INSERT INTO prompts_fts(prompts_fts, rowid, content, project)
-			VALUES ('delete', old.id, old.content, old.project);
-			INSERT INTO prompts_fts(rowid, content, project)
-			VALUES (new.id, new.content, new.project);
-		END;
-	`)
-	return err
 }
 
 func (s *Store) addColumnIfNotExists(tableName, columnName, definition string) error {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1713,6 +1713,101 @@ func TestTimelineHandlesMissingSessionRecord(t *testing.T) {
 	}
 }
 
+func TestMigratedStoreHasCanonicalSchemaObjects(t *testing.T) {
+	s := newTestStore(t)
+	required := []string{
+		"sessions",
+		"observations",
+		"user_prompts",
+		"sync_chunks",
+		"sync_state",
+		"sync_mutations",
+		"sync_enrolled_projects",
+		"observation_tags",
+		"session_tags",
+		"projects",
+		"observations_fts",
+		"prompts_fts",
+		"idx_obs_scope",
+		"ux_observations_sync_id",
+		"obs_fts_insert",
+		"prompt_fts_insert",
+	}
+	for _, name := range required {
+		var count int
+		if err := s.db.QueryRow(`SELECT COUNT(*) FROM sqlite_master WHERE name = ?`, name).Scan(&count); err != nil {
+			t.Fatalf("lookup %s: %v", name, err)
+		}
+		if count == 0 {
+			t.Fatalf("migrated store missing canonical object %s", name)
+		}
+	}
+}
+
+func TestNewUpgradesPartialDatabaseToCanonicalSchema(t *testing.T) {
+	dataDir := t.TempDir()
+	dbPath := filepath.Join(dataDir, "memory.db")
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open partial db: %v", err)
+	}
+	_, err = db.Exec(`
+		CREATE TABLE sessions (
+			id TEXT PRIMARY KEY,
+			project TEXT NOT NULL,
+			directory TEXT NOT NULL,
+			started_at TEXT NOT NULL DEFAULT (datetime('now')),
+			ended_at TEXT,
+			summary TEXT
+		);
+		CREATE TABLE observations (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			session_id TEXT NOT NULL,
+			type TEXT NOT NULL,
+			title TEXT NOT NULL,
+			content TEXT NOT NULL,
+			tool_name TEXT,
+			project TEXT,
+			created_at TEXT NOT NULL DEFAULT (datetime('now')),
+			FOREIGN KEY (session_id) REFERENCES sessions(id)
+		);
+		INSERT INTO sessions (id, project, directory) VALUES ('s1', 'mnemo', '/tmp/mnemo');
+		INSERT INTO observations (session_id, type, title, content, project)
+		VALUES ('s1', 'manual', 'partial', 'partial content', 'mnemo');
+	`)
+	if err != nil {
+		_ = db.Close()
+		t.Fatalf("seed partial db: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close partial db: %v", err)
+	}
+
+	s, err := New(FallbackConfig(dataDir))
+	if err != nil {
+		t.Fatalf("new store after partial schema: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+
+	var scope string
+	if err := s.db.QueryRow(`SELECT scope FROM observations WHERE title = 'partial'`).Scan(&scope); err != nil {
+		t.Fatalf("query backfilled scope: %v", err)
+	}
+	if scope != "project" {
+		t.Fatalf("scope = %q, want project", scope)
+	}
+
+	for _, name := range []string{"projects", "observation_tags", "idx_obs_scope", "obs_fts_insert"} {
+		var count int
+		if err := s.db.QueryRow(`SELECT COUNT(*) FROM sqlite_master WHERE name = ?`, name).Scan(&count); err != nil {
+			t.Fatalf("lookup %s: %v", name, err)
+		}
+		if count == 0 {
+			t.Fatalf("upgraded store missing %s", name)
+		}
+	}
+}
+
 func TestMigrationAndHelperEdgeBranches(t *testing.T) {
 	t.Run("migrate is idempotent with existing triggers", func(t *testing.T) {
 		s := newTestStore(t)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`internal/db/schema.sql` pasa a ser la única fuente de DDL. `store.migrate()` deja de llevar un segundo script de `CREATE TABLE` / `CREATE INDEX` / `CREATE TRIGGER`.

## Qué cambia

- El binario embebe `schema.sql`.
- Primera pasada: tablas base (`CREATE TABLE IF NOT EXISTS`).
- Después: columnas que faltan en bases antiguas (`ALTER`) y reescritura legacy de `observations`.
- Segunda pasada: FTS, índices y triggers del mismo `schema.sql`.
- Tras crear FTS de contenido externo, se hace `rebuild` para que las bases con filas existentes no queden inconsistentes.

## Qué no cambia

- sqlc sigue leyendo `internal/db/schema.sql`.
- Las migraciones de datos (backfill de `sync_id`, `scope`, etc.) siguen en `store`, porque no son el esquema canónico.
- `observations_migrated` sigue siendo un puente de bases muy antiguas, no una segunda definición del esquema actual.

## Verificado

- `go test ./...`
- `go build ./...`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0124d-d401-7a3a-bf4d-29b27c2cf582?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0124d-d401-7a3a-bf4d-29b27c2cf582&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

