### PR TITLE
chore: bump version to 0.27.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "mnemo",
       "description": "Persistent memory with session tracking, passive capture, and memory protocol. Gives Claude a brain that survives across sessions.",
-      "version": "0.27.2",
+      "version": "0.27.3",
       "author": {
         "name": "jmeiracorbal"
       },

--- a/plugin/claude-code/.claude-plugin/plugin.json
+++ b/plugin/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mnemo",
   "description": "Persistent memory for Claude Code. Stores decisions, bugs, and discoveries across sessions in a local SQLite database.",
-  "version": "0.27.2",
+  "version": "0.27.3",
   "author": {
     "name": "jmeiracorbal"
   },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Release del unificado de `schema.sql` como fuente de verdad del DDL (#47).

- `.claude-plugin/marketplace.json` → `0.27.3`
- `plugin/claude-code/.claude-plugin/plugin.json` → `0.27.3`
- No quedan referencias a `0.27.2`

El tag `v0.27.3` se crea desde `main` después de mergear esta PR.

Verificado: `go test ./...`, `go build ./...`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0124d-d401-7a3a-bf4d-29b27c2cf582?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0124d-d401-7a3a-bf4d-29b27c2cf582&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

