### PR TITLE
feat: auto-detect and prioritize mnemo memory over native markdown memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,10 +130,16 @@ All supported agents now use global hook/configuration surfaces where available.
 
 ```
 project/
-└── .mnemo                        ← project ID + configured agents
+├── .mnemo                        ← project ID + configured agents
+├── AGENTS.md                     ← mnemo memory authority (managed section)
+├── CLAUDE.md                     ← Claude-specific block (when --agent=claudecode)
+├── .cursor/rules/mnemo.mdc       ← Cursor project rules (when --agent=cursor)
+└── .windsurf/rules/mnemo.md      ← Windsurf project rules (when --agent=windsurf)
 ```
 
-`mnemo init` no longer appends mnemo protocol sections to project `AGENTS.md`, `CLAUDE.md`, Cursor rules, or Windsurf rules. Those instructions are installed globally by `install.sh` / `mnemo install-instructions` and are activated by the `.mnemo` marker.
+By default, `mnemo init` writes project-level memory authority rules so agents in cloud/CI workspaces prioritize mnemo over `MEMORY.md` and native memory. Use `--no-project-rules` to create only the `.mnemo` marker. Global hooks, MCP, and the optional `mnemo-memory` skill are installed by `install.sh` / `mnemo setup refresh` (or `mnemo setup <agent>`).
+
+Run `mnemo setup cursor` (or any supported agent) as an Engram-style alias for `mnemo setup refresh --agent=cursor`.
 
 ## The `.mnemo` marker
 

--- a/assets.go
+++ b/assets.go
@@ -5,5 +5,5 @@ import "embed"
 // SetupAssets contains the files that `mnemo setup refresh` can reinstall
 // from the compiled binary.
 //
-//go:embed scripts/codex/hooks/* scripts/cursor/hooks/* scripts/opencode/plugins/* scripts/windsurf/hooks/*
+//go:embed scripts/codex/hooks/* scripts/cursor/hooks/* scripts/opencode/plugins/* scripts/windsurf/hooks/* assets/protocol/* skills/mnemo-memory/**
 var SetupAssets embed.FS

--- a/assets/protocol/codex-compact-prompt.md
+++ b/assets/protocol/codex-compact-prompt.md
@@ -1,0 +1,9 @@
+You are compacting a long Codex session for a project that uses mnemo persistent memory.
+
+Before continuing with the user's next request:
+
+1. Call mem_session_summary with a structured summary of everything accomplished before compaction.
+2. Call mem_context for the current project to recover durable memory.
+3. Never write to MEMORY.md, native agent memory directories, or plaintext fallback files.
+
+Preserve decision reasoning, active files, blocking issues, and next steps in the compaction summary.

--- a/assets/protocol/session-start-protocol.md
+++ b/assets/protocol/session-start-protocol.md
@@ -1,0 +1,10 @@
+
+### MEMORY AUTHORITY
+mnemo is the ONLY persistent memory system for this project.
+NEVER use native agent memory, `MEMORY.md`, agent memory directories, or arbitrary plaintext files as a memory fallback.
+If mnemo tools are unavailable, continue without persistent memory and do not create an alternative store.
+Load the `mnemo-memory` skill when available, but keep these rules active if it is absent.
+
+### FIRST ACTION — load memory tools
+Memory tools are deferred and must be loaded before use. Call ToolSearch NOW with:
+select:mcp__mnemo__mem_save,mcp__mnemo__mem_context,mcp__mnemo__mem_search,mcp__mnemo__mem_session_summary,mcp__mnemo__mem_session_end

--- a/cmd/mnemo/doctor.go
+++ b/cmd/mnemo/doctor.go
@@ -1,55 +1,17 @@
 package main
 
 import (
-	"database/sql"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
-	"os/exec"
-	"path/filepath"
 	"strings"
 
-	"github.com/jmeiracorbal/mnemo/internal/agentinit"
-	_ "modernc.org/sqlite"
+	"github.com/jmeiracorbal/mnemo/internal/doctor"
 )
-
-type doctorOptions struct {
-	JSON    bool
-	Agent   string
-	Path    string
-	Home    string
-	DataDir string
-}
-
-type doctorReport struct {
-	Status      string        `json:"status"`
-	ProjectRoot string        `json:"project_root"`
-	Agent       string        `json:"agent"`
-	Summary     doctorSummary `json:"summary"`
-	Checks      []doctorCheck `json:"checks"`
-}
-
-type doctorSummary struct {
-	Total    int `json:"total"`
-	OK       int `json:"ok"`
-	Warnings int `json:"warnings"`
-	Errors   int `json:"errors"`
-}
-
-type doctorCheck struct {
-	ID       string            `json:"id"`
-	Status   string            `json:"status"`
-	Severity string            `json:"severity"`
-	Message  string            `json:"message"`
-	Agent    string            `json:"agent,omitempty"`
-	Path     string            `json:"path,omitempty"`
-	Details  map[string]string `json:"details,omitempty"`
-}
 
 func runDoctor() {
 	opts := parseDoctorArgs(os.Args[2:])
-	report := buildDoctorReport(opts)
+	report := doctor.BuildReport(toDoctorOptions(opts))
 
 	if opts.JSON {
 		out, err := json.MarshalIndent(report, "", "  ")
@@ -92,84 +54,16 @@ func parseDoctorArgs(args []string) doctorOptions {
 	return opts
 }
 
-func buildDoctorReport(opts doctorOptions) doctorReport {
-	report := doctorReport{Status: "ok", Agent: opts.Agent}
-	absPath, err := filepath.Abs(opts.Path)
-	if err != nil {
-		report.addCheck(errorCheck("project_path", "resolve project path: "+err.Error(), opts.Path))
-	} else {
-		report.ProjectRoot = agentinit.ProjectRoot(absPath)
-		report.addCheck(okCheck("project_path", "project path resolved", report.ProjectRoot))
-		report.addCheck(checkProjectMarker(report.ProjectRoot))
-	}
-
-	home := opts.Home
-	if home == "" {
-		resolved, err := os.UserHomeDir()
-		if err != nil {
-			report.addCheck(errorCheck("home", "resolve home directory: "+err.Error(), ""))
-		} else {
-			home = resolved
-			report.addCheck(okCheck("home", "home directory resolved", home))
-		}
-	} else {
-		report.addCheck(okCheck("home", "home directory override provided", home))
-	}
-
-	report.addCheck(checkBinaryOnPath())
-
-	if home != "" {
-		agents, err := agentinit.ExpandAgents(opts.Agent)
-		if err != nil {
-			report.addCheck(errorCheck("agent", err.Error(), opts.Agent))
-		} else {
-			for _, agent := range agents {
-				report.addCheck(toDoctorCheck(agentinit.CheckInstructions(home, agent)))
-				report.addCheck(toDoctorCheck(agentinit.CheckMCP(home, agent)))
-				if check := agentinit.CheckRuntime(home, agent); check.ID != "" {
-					report.addCheck(toDoctorCheck(check))
-				}
-			}
-		}
-	}
-
-	if opts.DataDir == "" && home != "" {
-		opts.DataDir = filepath.Join(home, ".mnemo")
-	}
-	if opts.DataDir != "" {
-		report.addCheck(checkStoreReadOnly(opts.DataDir))
-	}
-
-	report.finalize()
-	return report
-}
-
-func (r *doctorReport) addCheck(check doctorCheck) {
-	r.Checks = append(r.Checks, check)
-}
-
-func (r *doctorReport) finalize() {
-	for _, check := range r.Checks {
-		r.Summary.Total++
-		switch check.Status {
-		case "ok":
-			r.Summary.OK++
-		case "warning":
-			r.Summary.Warnings++
-		case "error":
-			r.Summary.Errors++
-		}
-	}
-	if r.Summary.Errors > 0 {
-		r.Status = "error"
-	} else if r.Summary.Warnings > 0 {
-		r.Status = "warning"
-	} else {
-		r.Status = "ok"
+func toDoctorOptions(opts doctorOptions) doctor.Options {
+	return doctor.Options{
+		Agent:   opts.Agent,
+		Path:    opts.Path,
+		Home:    opts.Home,
+		DataDir: opts.DataDir,
 	}
 }
 
-func printDoctorReport(report doctorReport) {
+func printDoctorReport(report doctor.Report) {
 	fmt.Printf("mnemo doctor: %s (%d ok, %d warnings, %d errors)\n", report.Status, report.Summary.OK, report.Summary.Warnings, report.Summary.Errors)
 	if report.ProjectRoot != "" {
 		fmt.Printf("project: %s\n", report.ProjectRoot)
@@ -192,92 +86,4 @@ func printDoctorReport(report doctorReport) {
 		}
 		fmt.Printf("%s %-8s %s%s\n", marker, check.Status, check.Message, suffix)
 	}
-}
-
-func toDoctorCheck(c agentinit.Check) doctorCheck {
-	return doctorCheck{
-		ID:       c.ID,
-		Status:   c.Status,
-		Severity: c.Severity,
-		Message:  c.Message,
-		Agent:    c.Agent,
-		Path:     c.Path,
-		Details:  c.Details,
-	}
-}
-
-func okCheck(id, message, path string) doctorCheck {
-	return doctorCheck{ID: id, Status: "ok", Severity: "info", Message: message, Path: path}
-}
-
-func warningCheck(id, message, path string) doctorCheck {
-	return doctorCheck{ID: id, Status: "warning", Severity: "warning", Message: message, Path: path}
-}
-
-func errorCheck(id, message, path string) doctorCheck {
-	return doctorCheck{ID: id, Status: "error", Severity: "error", Message: message, Path: path}
-}
-
-func checkProjectMarker(root string) doctorCheck {
-	path := filepath.Join(root, ".mnemo")
-	data, err := os.ReadFile(path)
-	if errors.Is(err, os.ErrNotExist) {
-		return warningCheck("project_marker", ".mnemo not found; run mnemo init to activate this project", path)
-	}
-	if err != nil {
-		return errorCheck("project_marker", "read .mnemo: "+err.Error(), path)
-	}
-	var marker agentinit.Marker
-	if err := json.Unmarshal(data, &marker); err != nil {
-		return errorCheck("project_marker", "malformed .mnemo: "+err.Error(), path)
-	}
-	if strings.TrimSpace(marker.ID) == "" {
-		return errorCheck("project_marker", ".mnemo has no project id", path)
-	}
-	return doctorCheck{ID: "project_marker", Status: "ok", Severity: "info", Message: ".mnemo marker is valid", Path: path, Details: map[string]string{"id": marker.ID, "agents": strings.Join(marker.Agents, ",")}}
-}
-
-func checkBinaryOnPath() doctorCheck {
-	path, err := exec.LookPath("mnemo")
-	if err != nil {
-		return warningCheck("binary_path", "mnemo binary is not available on PATH; plugin integrations may fail", "")
-	}
-	return okCheck("binary_path", "mnemo binary found on PATH", path)
-}
-
-func checkStoreReadOnly(dataDir string) doctorCheck {
-	dbPath := filepath.Join(dataDir, "memory.db")
-	if _, err := os.Stat(dbPath); errors.Is(err, os.ErrNotExist) {
-		return warningCheck("store", "memory database not found yet", dbPath)
-	} else if err != nil {
-		return errorCheck("store", "stat memory database: "+err.Error(), dbPath)
-	}
-	db, err := sql.Open("sqlite", sqliteReadOnlyDBURI(dbPath))
-	if err != nil {
-		return errorCheck("store", "open memory database read-only: "+err.Error(), dbPath)
-	}
-	defer func() {
-		_ = db.Close()
-	}()
-	if err := db.Ping(); err != nil {
-		return errorCheck("store", "ping memory database read-only: "+err.Error(), dbPath)
-	}
-	counts := map[string]string{}
-	queries := map[string]string{
-		"sessions":     "SELECT COUNT(*) FROM sessions",
-		"observations": "SELECT COUNT(*) FROM observations",
-		"user_prompts": "SELECT COUNT(*) FROM user_prompts",
-	}
-	for table, query := range queries {
-		var count int
-		if err := db.QueryRow(query).Scan(&count); err != nil {
-			return errorCheck("store", "query "+table+": "+err.Error(), dbPath)
-		}
-		counts[table] = fmt.Sprintf("%d", count)
-	}
-	return doctorCheck{ID: "store", Status: "ok", Severity: "info", Message: "memory database opens read-only", Path: dbPath, Details: counts}
-}
-
-func sqliteReadOnlyDBURI(dbPath string) string {
-	return "file:" + filepath.ToSlash(dbPath) + "?mode=ro&immutable=1"
 }

--- a/cmd/mnemo/doctor_test.go
+++ b/cmd/mnemo/doctor_test.go
@@ -1,13 +1,12 @@
 package main
 
 import (
-	"database/sql"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/jmeiracorbal/mnemo/internal/agentinit"
+	"github.com/jmeiracorbal/mnemo/internal/doctor"
 )
 
 func TestParseDoctorArgs(t *testing.T) {
@@ -34,7 +33,7 @@ func TestBuildDoctorReportChecksCodexGlobalInstall(t *testing.T) {
 	writeExecutable(t, filepath.Join(home, ".codex", "hooks", "stop.sh"))
 	writeFile(t, filepath.Join(home, ".codex", "hooks", "mnemo-protocol.md"), "protocol")
 
-	report := buildDoctorReport(doctorOptions{Agent: "codex", Path: project, Home: home, DataDir: dataDir})
+	report := doctor.BuildReport(doctor.Options{Agent: "codex", Path: project, Home: home, DataDir: dataDir})
 
 	assertCheckStatus(t, report, "project_marker", "ok")
 	assertCheckStatus(t, report, "global_instructions.codex", "ok")
@@ -45,55 +44,23 @@ func TestBuildDoctorReportChecksCodexGlobalInstall(t *testing.T) {
 func TestBuildDoctorReportWarnsWhenProjectMarkerMissing(t *testing.T) {
 	home := t.TempDir()
 	project := t.TempDir()
-	report := buildDoctorReport(doctorOptions{Agent: "codex", Path: project, Home: home, DataDir: t.TempDir()})
+	report := doctor.BuildReport(doctor.Options{Agent: "codex", Path: project, Home: home, DataDir: t.TempDir()})
 	assertCheckStatus(t, report, "project_marker", "warning")
 }
 
-func TestCheckStoreReadOnlyUsesWALSafeImmutableURI(t *testing.T) {
-	dataDir := t.TempDir()
-	dbPath := filepath.Join(dataDir, "memory.db")
-	db, err := sql.Open("sqlite", dbPath)
-	if err != nil {
-		t.Fatalf("open sqlite: %v", err)
+func TestBuildDoctorReportWarnsOnCompetingMemory(t *testing.T) {
+	home := t.TempDir()
+	project := t.TempDir()
+	if err := agentinit.EnsureMarkerWithID(project, "project-123"); err != nil {
+		t.Fatalf("marker: %v", err)
 	}
-	if _, err := db.Exec("PRAGMA journal_mode = WAL"); err != nil {
-		closeTestDB(t, db)
-		t.Fatalf("enable WAL: %v", err)
-	}
-	for _, query := range []string{
-		"CREATE TABLE sessions (id TEXT)",
-		"CREATE TABLE observations (id TEXT)",
-		"CREATE TABLE user_prompts (id TEXT)",
-		"PRAGMA wal_checkpoint(FULL)",
-	} {
-		if _, err := db.Exec(query); err != nil {
-			closeTestDB(t, db)
-			t.Fatalf("exec %q: %v", query, err)
-		}
-	}
-	closeTestDB(t, db)
+	writeFile(t, filepath.Join(project, "MEMORY.md"), "# native memory\n")
 
-	uri := sqliteReadOnlyDBURI(dbPath)
-	if !strings.Contains(uri, "mode=ro") || !strings.Contains(uri, "immutable=1") {
-		t.Fatalf("read-only URI is not WAL-safe: %s", uri)
-	}
-
-	if err := os.Chmod(dataDir, 0555); err != nil {
-		t.Fatalf("chmod read-only dir: %v", err)
-	}
-	t.Cleanup(func() {
-		if err := os.Chmod(dataDir, 0755); err != nil {
-			t.Errorf("restore dir permissions: %v", err)
-		}
-	})
-
-	check := checkStoreReadOnly(dataDir)
-	if check.Status != "ok" {
-		t.Fatalf("store check status = %q, want ok (message: %s)", check.Status, check.Message)
-	}
+	report := doctor.BuildReport(doctor.Options{Agent: "codex", Path: project, Home: home, DataDir: t.TempDir()})
+	assertCheckStatus(t, report, "competing_memory", "warning")
 }
 
-func assertCheckStatus(t *testing.T, report doctorReport, id, want string) {
+func assertCheckStatus(t *testing.T, report doctor.Report, id, want string) {
 	t.Helper()
 	for _, check := range report.Checks {
 		if check.ID == id {
@@ -123,12 +90,5 @@ func writeExecutable(t *testing.T, path string) {
 	}
 	if err := os.WriteFile(path, []byte("#!/bin/sh\n"), 0755); err != nil {
 		t.Fatal(err)
-	}
-}
-
-func closeTestDB(t *testing.T, db *sql.DB) {
-	t.Helper()
-	if err := db.Close(); err != nil {
-		t.Errorf("close sqlite: %v", err)
 	}
 }

--- a/cmd/mnemo/doctor_types.go
+++ b/cmd/mnemo/doctor_types.go
@@ -1,0 +1,9 @@
+package main
+
+type doctorOptions struct {
+	JSON    bool
+	Agent   string
+	Path    string
+	Home    string
+	DataDir string
+}

--- a/cmd/mnemo/init.go
+++ b/cmd/mnemo/init.go
@@ -15,6 +15,7 @@ import (
 func runInit(s *store.Store) {
 	agent := "claudecode"
 	dir := "."
+	projectRules := true
 
 	for _, arg := range os.Args[2:] {
 		switch {
@@ -22,6 +23,8 @@ func runInit(s *store.Store) {
 			agent = arg[len("--agent="):]
 		case strings.HasPrefix(arg, "--path="):
 			dir = arg[len("--path="):]
+		case arg == "--no-project-rules":
+			projectRules = false
 		}
 	}
 
@@ -53,6 +56,16 @@ func runInit(s *store.Store) {
 		if err := agentinit.AddAgent(root, a); err != nil {
 			fmt.Fprintf(os.Stderr, "mnemo init: %s: %v\n", a, err)
 			os.Exit(1)
+		}
+		if projectRules {
+			paths, err := agentinit.InstallProjectInstructions(root, a)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "mnemo init: %s project rules: %v\n", a, err)
+				os.Exit(1)
+			}
+			for _, path := range paths {
+				fmt.Printf("mnemo init: project rules updated %s\n", path)
+			}
 		}
 		fmt.Printf("mnemo init: %s activated in %s\n", a, root)
 	}

--- a/cmd/mnemo/setup_alias_test.go
+++ b/cmd/mnemo/setup_alias_test.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/jmeiracorbal/mnemo/internal/agentinit"
+)
+
+func TestIsSetupAgentAlias(t *testing.T) {
+	if !isSetupAgentAlias("cursor") {
+		t.Fatal("cursor should be a setup alias")
+	}
+	if !isSetupAgentAlias("all") {
+		t.Fatal("all should be a setup alias")
+	}
+	if isSetupAgentAlias("status") {
+		t.Fatal("status should not be a setup alias")
+	}
+	for _, agent := range agentinit.SupportedAgents {
+		if !isSetupAgentAlias(agent) {
+			t.Fatalf("%q should be a setup alias", agent)
+		}
+	}
+}

--- a/cmd/mnemo/setup_refresh.go
+++ b/cmd/mnemo/setup_refresh.go
@@ -71,6 +71,13 @@ func refreshSetup(opts setupRefreshOptions) ([]string, error) {
 		return nil, err
 	}
 	var updated []string
+
+	skillFiles, err := agentinit.InstallGlobalSkill(opts.Home)
+	if err != nil {
+		return nil, fmt.Errorf("global skill: %w", err)
+	}
+	updated = append(updated, skillFiles...)
+
 	for _, agent := range agents {
 		agentUpdated, err := agentinit.Refresh(opts.Home, opts.MnemoBin, agent)
 		if err != nil {

--- a/cmd/mnemo/setup_refresh_test.go
+++ b/cmd/mnemo/setup_refresh_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/jmeiracorbal/mnemo/internal/agentinit"
 )
 
 func TestParseSetupRefreshArgs(t *testing.T) {
@@ -33,13 +35,19 @@ func TestRefreshSetupWritesCodexFiles(t *testing.T) {
 	if err != nil {
 		t.Fatalf("refresh setup: %v", err)
 	}
-	if len(updated) != 6 {
-		t.Fatalf("updated paths = %d, want 6 (%v)", len(updated), updated)
+	if len(updated) != 12 {
+		t.Fatalf("updated paths = %d, want 12 (%v)", len(updated), updated)
 	}
 
 	config := readTestFile(t, filepath.Join(home, ".codex", "config.toml"))
 	if !strings.Contains(config, `[mcp_servers.mnemo]`) || !strings.Contains(config, `command = "/bin/mnemo"`) {
 		t.Fatalf("unexpected codex config:\n%s", config)
+	}
+	if !strings.Contains(config, "experimental_compact_prompt_file") {
+		t.Fatalf("codex config missing compact prompt file:\n%s", config)
+	}
+	if !agentinit.GlobalSkillInstalled(home) {
+		t.Fatal("global skill not installed by setup refresh")
 	}
 	hooks := readTestFile(t, filepath.Join(home, ".codex", "hooks.json"))
 	if !strings.Contains(hooks, filepath.Join(home, ".codex", "hooks", "session-start.sh")) {

--- a/cmd/mnemo/setup_status.go
+++ b/cmd/mnemo/setup_status.go
@@ -16,11 +16,18 @@ type setupStatusOptions struct {
 	Home  string
 }
 
+type setupStatusSummary struct {
+	Total    int `json:"total"`
+	OK       int `json:"ok"`
+	Warnings int `json:"warnings"`
+	Errors   int `json:"errors"`
+}
+
 type setupStatusReport struct {
-	Status  string           `json:"status"`
-	Agent   string           `json:"agent"`
-	Summary doctorSummary    `json:"summary"`
-	Rows    []setupStatusRow `json:"agents"`
+	Status  string             `json:"status"`
+	Agent   string             `json:"agent"`
+	Summary setupStatusSummary `json:"summary"`
+	Rows    []setupStatusRow   `json:"agents"`
 }
 
 type setupStatusRow struct {
@@ -46,15 +53,30 @@ func runSetup() {
 	case "uninstall":
 		runSetupUninstall()
 	default:
+		if isSetupAgentAlias(os.Args[2]) {
+			os.Args = append([]string{os.Args[0], os.Args[1], "refresh", "--agent=" + os.Args[2]}, os.Args[3:]...)
+			runSetupRefresh()
+			return
+		}
 		printSetupUsage()
 		os.Exit(1)
 	}
+}
+
+func isSetupAgentAlias(value string) bool {
+	for _, agent := range agentinit.SupportedAgents {
+		if value == agent {
+			return true
+		}
+	}
+	return value == "all"
 }
 
 func printSetupUsage() {
 	fmt.Fprintln(os.Stderr, "usage: mnemo setup status [--json] [--agent=AGENT] [--home=DIR]")
 	fmt.Fprintln(os.Stderr, "       mnemo setup print-config AGENT [--home=DIR] [--mnemo-bin=PATH]")
 	fmt.Fprintln(os.Stderr, "       mnemo setup refresh [--agent=AGENT] [--home=DIR] [--mnemo-bin=PATH]")
+	fmt.Fprintln(os.Stderr, "       mnemo setup AGENT [--home=DIR] [--mnemo-bin=PATH]")
 	fmt.Fprintln(os.Stderr, "       mnemo setup uninstall --agent=AGENT [--home=DIR]")
 }
 

--- a/internal/agentinit/codex_compact.go
+++ b/internal/agentinit/codex_compact.go
@@ -1,0 +1,66 @@
+package agentinit
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	mnemoassets "github.com/jmeiracorbal/mnemo"
+)
+
+func writeCodexCompactionPrompt(home string) ([]string, error) {
+	data, err := mnemoassets.SetupAssets.ReadFile("assets/protocol/codex-compact-prompt.md")
+	if err != nil {
+		return nil, fmt.Errorf("read codex compact prompt asset: %w", err)
+	}
+
+	promptPath := filepath.Join(home, ".codex", "mnemo-compact-prompt.md")
+	if err := WriteFile(promptPath, data); err != nil {
+		return nil, fmt.Errorf("write codex compact prompt: %w", err)
+	}
+
+	configPath := filepath.Join(home, ".codex", "config.toml")
+	if err := upsertCodexCompactPromptFile(configPath, promptPath); err != nil {
+		return nil, err
+	}
+
+	return []string{promptPath, configPath}, nil
+}
+
+func upsertCodexCompactPromptFile(path, promptPath string) error {
+	line := fmt.Sprintf("experimental_compact_prompt_file = %q", promptPath)
+	data, err := os.ReadFile(path)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("read %s: %w", path, err)
+	}
+
+	lines := strings.Split(string(data), "\n")
+	var out []string
+	replaced := false
+	for _, lineText := range lines {
+		trimmed := strings.TrimSpace(lineText)
+		if strings.HasPrefix(trimmed, "experimental_compact_prompt_file") {
+			if !replaced {
+				out = append(out, line)
+				replaced = true
+			}
+			continue
+		}
+		out = append(out, lineText)
+	}
+
+	content := strings.TrimRight(strings.Join(out, "\n"), "\n")
+	if !replaced {
+		if content != "" {
+			content += "\n\n"
+		}
+		content += line
+	}
+	content += "\n"
+
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, []byte(content), 0644)
+}

--- a/internal/agentinit/common.go
+++ b/internal/agentinit/common.go
@@ -180,6 +180,18 @@ func GlobalSkillInstalled(home string) bool {
 	return err == nil && !info.IsDir()
 }
 
+// ReadProjectMarker returns the parsed .mnemo marker for root.
+func ReadProjectMarker(root string) (*Marker, error) {
+	m, err := readMarker(root)
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(m.ID) == "" {
+		return nil, fmt.Errorf(".mnemo has no project ID in %s — run mnemo init", root)
+	}
+	return m, nil
+}
+
 // AppendSection creates or updates the managed mnemo protocol section in path.
 // Content outside the markers is preserved.
 func AppendSection(path, content string) error {

--- a/internal/agentinit/competing_memory.go
+++ b/internal/agentinit/competing_memory.go
@@ -1,0 +1,100 @@
+package agentinit
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+var competingMemoryFilenames = []string{
+	"MEMORY.md",
+	"memory.md",
+}
+
+// CheckCompetingMemory reports native or plaintext memory surfaces that conflict
+// with mnemo when a valid .mnemo marker exists.
+func CheckCompetingMemory(root, home string) Check {
+	if _, err := ReadProjectID(root); err != nil {
+		return Check{}
+	}
+
+	var conflicts []string
+	for _, name := range competingMemoryFilenames {
+		path := filepath.Join(root, name)
+		if info, err := os.Stat(path); err == nil && !info.IsDir() && info.Size() > 0 {
+			conflicts = append(conflicts, path)
+		}
+	}
+
+	if home != "" {
+		if path := claudeNativeMemoryPath(home, root); path != "" {
+			if info, err := os.Stat(path); err == nil && !info.IsDir() && info.Size() > 0 {
+				conflicts = append(conflicts, path)
+			}
+		}
+	}
+
+	if len(conflicts) == 0 {
+		return checkOK("", "competing_memory", "no competing native memory surfaces detected", root)
+	}
+
+	return checkWarning(
+		"",
+		"competing_memory",
+		"mnemo is authoritative for this project; do not write to native or plaintext memory surfaces: "+strings.Join(conflicts, ", "),
+		root,
+	)
+}
+
+func claudeNativeMemoryPath(home, root string) string {
+	candidates := claudeProjectDirCandidates(home, root)
+	for _, dir := range candidates {
+		path := filepath.Join(dir, "memory", "MEMORY.md")
+		if _, err := os.Stat(path); err == nil {
+			return path
+		}
+	}
+	return ""
+}
+
+func claudeProjectDirCandidates(home, root string) []string {
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return nil
+	}
+	home, err = filepath.Abs(home)
+	if err != nil {
+		return nil
+	}
+
+	var encoded []string
+	rel := absRoot
+	if strings.HasPrefix(absRoot, home+string(os.PathSeparator)) {
+		rel = strings.TrimPrefix(absRoot, home+string(os.PathSeparator))
+	} else if absRoot == home {
+		rel = ""
+	} else if strings.HasPrefix(absRoot, "/") {
+		rel = strings.TrimPrefix(absRoot, "/")
+	}
+	if rel != "" {
+		encoded = append(encoded, strings.ToLower(strings.ReplaceAll(rel, string(os.PathSeparator), "-")))
+	}
+	encoded = append(encoded, strings.ToLower(strings.ReplaceAll(strings.TrimPrefix(absRoot, "/"), string(os.PathSeparator), "-")))
+
+	seen := make(map[string]struct{}, len(encoded))
+	var dirs []string
+	for _, name := range encoded {
+		if name == "" {
+			continue
+		}
+		if !strings.HasPrefix(name, "-") {
+			name = "-" + name
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		dirs = append(dirs, filepath.Join(home, ".claude", "projects", name))
+	}
+	return dirs
+}

--- a/internal/agentinit/cursor.go
+++ b/internal/agentinit/cursor.go
@@ -64,6 +64,7 @@ func cursorRuntimeAssets() []assetTarget {
 	return []assetTarget{
 		{Asset: "scripts/cursor/hooks/before-submit-prompt.sh", Path: filepath.Join(".cursor", "hooks", "before-submit-prompt.sh"), Mode: 0755},
 		{Asset: "scripts/cursor/hooks/stop.sh", Path: filepath.Join(".cursor", "hooks", "stop.sh"), Mode: 0755},
+		{Asset: "assets/protocol/session-start-protocol.md", Path: filepath.Join(".cursor", "hooks", "session-start-protocol.md"), Mode: 0644},
 	}
 }
 

--- a/internal/agentinit/init_test.go
+++ b/internal/agentinit/init_test.go
@@ -3,30 +3,92 @@ package agentinit
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
-func TestProjectInitDoesNotWriteProjectInstructionFiles(t *testing.T) {
+func TestInstallProjectInstructionsWritesExpectedFiles(t *testing.T) {
 	root := t.TempDir()
-	for _, agent := range SupportedAgents {
-		if err := AddAgent(root, agent); err != nil {
-			t.Fatalf("init agent %s: %v", agent, err)
+
+	paths, err := InstallProjectInstructions(root, "cursor")
+	if err != nil {
+		t.Fatalf("install cursor project instructions: %v", err)
+	}
+	if len(paths) != 2 {
+		t.Fatalf("expected 2 updated paths, got %d: %v", len(paths), paths)
+	}
+
+	agentsData, err := os.ReadFile(filepath.Join(root, "AGENTS.md"))
+	if err != nil {
+		t.Fatalf("read AGENTS.md: %v", err)
+	}
+	if !strings.Contains(string(agentsData), sectionStart) {
+		t.Fatal("AGENTS.md missing managed mnemo section")
+	}
+
+	cursorData, err := os.ReadFile(filepath.Join(root, ".cursor", "rules", "mnemo.mdc"))
+	if err != nil {
+		t.Fatalf("read cursor rule: %v", err)
+	}
+	if !strings.Contains(string(cursorData), "MEMORY AUTHORITY") {
+		t.Fatal("cursor rule missing memory authority")
+	}
+}
+
+func TestInstallProjectInstructionsIsIdempotent(t *testing.T) {
+	root := t.TempDir()
+
+	for i := 0; i < 2; i++ {
+		if _, err := InstallProjectInstructions(root, "codex"); err != nil {
+			t.Fatalf("install attempt %d: %v", i+1, err)
 		}
 	}
 
-	for _, rel := range []string{
-		"AGENTS.md",
-		"CLAUDE.md",
-		filepath.Join(".cursor", "hooks.json"),
-		filepath.Join(".cursor", "rules", "mnemo.mdc"),
-		filepath.Join(".windsurf", "hooks.json"),
-		filepath.Join(".windsurf", "rules", "mnemo.md"),
-	} {
-		path := filepath.Join(root, rel)
-		if _, err := os.Stat(path); err == nil {
-			t.Fatalf("project init unexpectedly wrote %s", rel)
-		} else if !os.IsNotExist(err) {
-			t.Fatalf("stat %s: %v", rel, err)
-		}
+	data, err := os.ReadFile(filepath.Join(root, "AGENTS.md"))
+	if err != nil {
+		t.Fatalf("read AGENTS.md: %v", err)
+	}
+	if strings.Count(string(data), sectionStart) != 1 {
+		t.Fatalf("expected one managed section, got %d", strings.Count(string(data), sectionStart))
+	}
+}
+
+func TestInstallProjectInstructionsClaudeCode(t *testing.T) {
+	root := t.TempDir()
+
+	paths, err := InstallProjectInstructions(root, "claudecode")
+	if err != nil {
+		t.Fatalf("install claudecode project instructions: %v", err)
+	}
+	if len(paths) != 2 {
+		t.Fatalf("expected 2 paths, got %d", len(paths))
+	}
+
+	claudeData, err := os.ReadFile(filepath.Join(root, "CLAUDE.md"))
+	if err != nil {
+		t.Fatalf("read CLAUDE.md: %v", err)
+	}
+	if !strings.Contains(string(claudeData), claudeSectionStart) {
+		t.Fatal("CLAUDE.md missing claude managed section")
+	}
+	if !strings.Contains(string(claudeData), "@AGENTS.md") {
+		t.Fatal("CLAUDE.md missing @AGENTS.md reference")
+	}
+}
+
+func TestInstallProjectInstructionsWindsurf(t *testing.T) {
+	root := t.TempDir()
+
+	paths, err := InstallProjectInstructions(root, "windsurf")
+	if err != nil {
+		t.Fatalf("install windsurf project instructions: %v", err)
+	}
+	if len(paths) != 2 {
+		t.Fatalf("expected 2 paths, got %d", len(paths))
+	}
+
+	windsurfPath := filepath.Join(root, ".windsurf", "rules", "mnemo.md")
+	if _, err := os.Stat(windsurfPath); err != nil {
+		t.Fatalf("windsurf rule missing: %v", err)
 	}
 }

--- a/internal/agentinit/project_instructions.go
+++ b/internal/agentinit/project_instructions.go
@@ -1,0 +1,47 @@
+package agentinit
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/jmeiracorbal/mnemo/templates"
+)
+
+// InstallProjectInstructions writes agent-specific memory authority rules into
+// the project repository. Idempotent via managed sections or dedicated paths.
+func InstallProjectInstructions(root, agent string) ([]string, error) {
+	var updated []string
+
+	agentsPath := filepath.Join(root, "AGENTS.md")
+	if err := AppendSection(agentsPath, templates.Generic); err != nil {
+		return nil, fmt.Errorf("AGENTS.md: %w", err)
+	}
+	updated = append(updated, agentsPath)
+
+	switch agent {
+	case "claudecode":
+		claudePath := filepath.Join(root, "CLAUDE.md")
+		if err := AppendClaudeSection(claudePath, templates.ClaudeCode); err != nil {
+			return nil, fmt.Errorf("CLAUDE.md: %w", err)
+		}
+		updated = append(updated, claudePath)
+	case "cursor":
+		cursorPath := filepath.Join(root, ".cursor", "rules", "mnemo.mdc")
+		if err := WriteFile(cursorPath, []byte(templates.Cursor)); err != nil {
+			return nil, fmt.Errorf(".cursor/rules/mnemo.mdc: %w", err)
+		}
+		updated = append(updated, cursorPath)
+	case "windsurf":
+		windsurfPath := filepath.Join(root, ".windsurf", "rules", "mnemo.md")
+		if err := AppendSection(windsurfPath, templates.Windsurf); err != nil {
+			return nil, fmt.Errorf(".windsurf/rules/mnemo.md: %w", err)
+		}
+		updated = append(updated, windsurfPath)
+	case "codex", "opencode":
+		// AGENTS.md covers codex and opencode project authority.
+	default:
+		return nil, fmt.Errorf("unsupported agent %q for project instructions", agent)
+	}
+
+	return updated, nil
+}

--- a/internal/agentinit/setup.go
+++ b/internal/agentinit/setup.go
@@ -50,6 +50,15 @@ func Refresh(home, mnemoBin, agent string) ([]string, error) {
 		return nil, err
 	}
 	updated = append(updated, runtimeFiles...)
+
+	if agent == "codex" {
+		codexFiles, err := writeCodexCompactionPrompt(home)
+		if err != nil {
+			return nil, err
+		}
+		updated = append(updated, codexFiles...)
+	}
+
 	return updated, nil
 }
 

--- a/internal/agentinit/setup_test.go
+++ b/internal/agentinit/setup_test.go
@@ -50,13 +50,16 @@ func TestRefreshWritesCodexFiles(t *testing.T) {
 	if err != nil {
 		t.Fatalf("refresh: %v", err)
 	}
-	if len(updated) != 6 {
-		t.Fatalf("updated paths = %d, want 6 (%v)", len(updated), updated)
+	if len(updated) != 8 {
+		t.Fatalf("updated paths = %d, want 8 (%v)", len(updated), updated)
 	}
 
 	config := readTestFile(t, filepath.Join(home, ".codex", "config.toml"))
 	if !strings.Contains(config, `[mcp_servers.mnemo]`) || !strings.Contains(config, `command = "/bin/mnemo"`) {
 		t.Fatalf("unexpected codex config:\n%s", config)
+	}
+	if !strings.Contains(config, "experimental_compact_prompt_file") {
+		t.Fatalf("codex config missing compact prompt file:\n%s", config)
 	}
 	assertExecutable(t, filepath.Join(home, ".codex", "hooks", "session-start.sh"))
 }

--- a/internal/agentinit/skill.go
+++ b/internal/agentinit/skill.go
@@ -1,0 +1,96 @@
+package agentinit
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	mnemoassets "github.com/jmeiracorbal/mnemo"
+)
+
+var globalSkillFiles = []struct {
+	asset string
+	rel   string
+	mode  os.FileMode
+}{
+	{asset: "skills/mnemo-memory/SKILL.md", rel: "SKILL.md", mode: 0644},
+	{asset: "skills/mnemo-memory/agents/openai.yaml", rel: "agents/openai.yaml", mode: 0644},
+}
+
+type skillSymlink struct {
+	link   string
+	target string
+}
+
+// InstallGlobalSkill copies the embedded mnemo-memory skill to the canonical
+// global path and links agent-specific skill directories to it.
+func InstallGlobalSkill(home string) ([]string, error) {
+	destRoot := filepath.Join(home, ".agents", "skills", globalSkillName)
+	var updated []string
+
+	for _, file := range globalSkillFiles {
+		data, err := mnemoassets.SetupAssets.ReadFile(file.asset)
+		if err != nil {
+			return nil, fmt.Errorf("read embedded skill asset %s: %w", file.asset, err)
+		}
+		path := filepath.Join(destRoot, file.rel)
+		if err := WriteFile(path, data); err != nil {
+			return nil, fmt.Errorf("write skill file %s: %w", path, err)
+		}
+		if err := os.Chmod(path, file.mode); err != nil {
+			return nil, fmt.Errorf("chmod skill file %s: %w", path, err)
+		}
+		updated = append(updated, path)
+	}
+
+	for _, spec := range globalSkillSymlinks(home, destRoot) {
+		if err := ensureDirSymlink(spec.link, spec.target); err != nil {
+			return nil, err
+		}
+		updated = append(updated, spec.link)
+	}
+
+	return updated, nil
+}
+
+func globalSkillSymlinks(home, destRoot string) []skillSymlink {
+	return []skillSymlink{
+		{
+			link:   filepath.Join(home, ".claude", "skills", globalSkillName),
+			target: destRoot,
+		},
+		{
+			link:   filepath.Join(home, ".codeium", "windsurf", "skills", globalSkillName),
+			target: destRoot,
+		},
+	}
+}
+
+func ensureDirSymlink(link, target string) error {
+	if err := os.MkdirAll(filepath.Dir(link), 0755); err != nil {
+		return fmt.Errorf("create skill link parent %s: %w", link, err)
+	}
+
+	info, err := os.Lstat(link)
+	switch {
+	case err == nil:
+		if info.Mode()&os.ModeSymlink != 0 {
+			current, readErr := filepath.EvalSymlinks(link)
+			if readErr == nil && current == target {
+				return nil
+			}
+			if removeErr := os.Remove(link); removeErr != nil {
+				return fmt.Errorf("replace skill symlink %s: %w", link, removeErr)
+			}
+			break
+		}
+		return fmt.Errorf("skill link path %s exists and is not a symlink", link)
+	case !os.IsNotExist(err):
+		return fmt.Errorf("stat skill link %s: %w", link, err)
+	}
+
+	if err := os.Symlink(target, link); err != nil {
+		return fmt.Errorf("create skill symlink %s -> %s: %w", link, target, err)
+	}
+	return nil
+}

--- a/internal/agentinit/skill_test.go
+++ b/internal/agentinit/skill_test.go
@@ -1,0 +1,72 @@
+package agentinit
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCheckCompetingMemoryDetectsProjectMEMORYmd(t *testing.T) {
+	root := t.TempDir()
+	home := t.TempDir()
+	if err := EnsureMarkerWithID(root, "project-123"); err != nil {
+		t.Fatalf("marker: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "MEMORY.md"), []byte("# memory\n"), 0644); err != nil {
+		t.Fatalf("write MEMORY.md: %v", err)
+	}
+
+	check := CheckCompetingMemory(root, home)
+	if check.Status != "warning" {
+		t.Fatalf("status = %q, want warning", check.Status)
+	}
+	if !strings.Contains(check.Message, "MEMORY.md") {
+		t.Fatalf("message = %q, want MEMORY.md mention", check.Message)
+	}
+}
+
+func TestInstallGlobalSkillCopiesCanonicalFiles(t *testing.T) {
+	home := t.TempDir()
+	paths, err := InstallGlobalSkill(home)
+	if err != nil {
+		t.Fatalf("install global skill: %v", err)
+	}
+	if len(paths) < 2 {
+		t.Fatalf("expected skill paths, got %v", paths)
+	}
+	if !GlobalSkillInstalled(home) {
+		t.Fatal("global skill not detected after install")
+	}
+}
+
+func TestUpsertCodexCompactPromptFile(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+	promptPath := filepath.Join(dir, "mnemo-compact-prompt.md")
+
+	if err := upsertCodexCompactPromptFile(configPath, promptPath); err != nil {
+		t.Fatalf("first upsert: %v", err)
+	}
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if !strings.Contains(string(data), "experimental_compact_prompt_file") || !strings.Contains(string(data), promptPath) {
+		t.Fatalf("config missing compact prompt setting: %s", data)
+	}
+
+	if err := os.WriteFile(configPath, []byte("model = \"gpt\"\nexperimental_compact_prompt_file = \"/old/path\"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := upsertCodexCompactPromptFile(configPath, promptPath); err != nil {
+		t.Fatalf("replace upsert: %v", err)
+	}
+	data, err = os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Count(string(data), "experimental_compact_prompt_file") != 1 {
+		t.Fatalf("expected one compact prompt key, got: %s", data)
+	}
+}

--- a/internal/agentinit/windsurf.go
+++ b/internal/agentinit/windsurf.go
@@ -57,6 +57,7 @@ func windsurfRuntimeAssets() []assetTarget {
 	return []assetTarget{
 		{Asset: "scripts/windsurf/hooks/pre-user-prompt.sh", Path: filepath.Join(".codeium", "windsurf", "hooks", "pre-user-prompt.sh"), Mode: 0755},
 		{Asset: "scripts/windsurf/hooks/post-cascade-response.sh", Path: filepath.Join(".codeium", "windsurf", "hooks", "post-cascade-response.sh"), Mode: 0755},
+		{Asset: "assets/protocol/session-start-protocol.md", Path: filepath.Join(".codeium", "windsurf", "hooks", "session-start-protocol.md"), Mode: 0644},
 	}
 }
 

--- a/internal/doctor/report.go
+++ b/internal/doctor/report.go
@@ -1,0 +1,220 @@
+package doctor
+
+import (
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/jmeiracorbal/mnemo/internal/agentinit"
+	_ "modernc.org/sqlite"
+)
+
+type Options struct {
+	Agent   string
+	Path    string
+	Home    string
+	DataDir string
+}
+
+type Report struct {
+	Status      string  `json:"status"`
+	ProjectRoot string  `json:"project_root"`
+	Agent       string  `json:"agent"`
+	Summary     Summary `json:"summary"`
+	Checks      []Check `json:"checks"`
+}
+
+type Summary struct {
+	Total    int `json:"total"`
+	OK       int `json:"ok"`
+	Warnings int `json:"warnings"`
+	Errors   int `json:"errors"`
+}
+
+type Check struct {
+	ID       string            `json:"id"`
+	Status   string            `json:"status"`
+	Severity string            `json:"severity"`
+	Message  string            `json:"message"`
+	Agent    string            `json:"agent,omitempty"`
+	Path     string            `json:"path,omitempty"`
+	Details  map[string]string `json:"details,omitempty"`
+}
+
+// BuildReport assembles the mnemo integration diagnostic report.
+func BuildReport(opts Options) Report {
+	report := Report{Status: "ok", Agent: opts.Agent}
+	absPath, err := filepath.Abs(opts.Path)
+	if err != nil {
+		report.addCheck(errorCheck("project_path", "resolve project path: "+err.Error(), opts.Path))
+	} else {
+		report.ProjectRoot = agentinit.ProjectRoot(absPath)
+		report.addCheck(okCheck("project_path", "project path resolved", report.ProjectRoot))
+		report.addCheck(checkProjectMarker(report.ProjectRoot))
+	}
+
+	home := opts.Home
+	if home == "" {
+		resolved, err := os.UserHomeDir()
+		if err != nil {
+			report.addCheck(errorCheck("home", "resolve home directory: "+err.Error(), ""))
+		} else {
+			home = resolved
+			report.addCheck(okCheck("home", "home directory resolved", home))
+		}
+	} else {
+		report.addCheck(okCheck("home", "home directory override provided", home))
+	}
+
+	report.addCheck(checkBinaryOnPath())
+
+	if home != "" && report.ProjectRoot != "" {
+		report.addCheck(toCheck(agentinit.CheckCompetingMemory(report.ProjectRoot, home)))
+	}
+
+	if home != "" {
+		agents, err := agentinit.ExpandAgents(opts.Agent)
+		if err != nil {
+			report.addCheck(errorCheck("agent", err.Error(), opts.Agent))
+		} else {
+			for _, agent := range agents {
+				report.addCheck(toCheck(agentinit.CheckInstructions(home, agent)))
+				report.addCheck(toCheck(agentinit.CheckMCP(home, agent)))
+				if check := agentinit.CheckRuntime(home, agent); check.ID != "" {
+					report.addCheck(toCheck(check))
+				}
+			}
+		}
+	}
+
+	if opts.DataDir == "" && home != "" {
+		opts.DataDir = filepath.Join(home, ".mnemo")
+	}
+	if opts.DataDir != "" {
+		report.addCheck(checkStoreReadOnly(opts.DataDir))
+	}
+
+	report.finalize()
+	return report
+}
+
+func (r *Report) addCheck(check Check) {
+	r.Checks = append(r.Checks, check)
+}
+
+func (r *Report) finalize() {
+	for _, check := range r.Checks {
+		r.Summary.Total++
+		switch check.Status {
+		case "ok":
+			r.Summary.OK++
+		case "warning":
+			r.Summary.Warnings++
+		case "error":
+			r.Summary.Errors++
+		}
+	}
+	if r.Summary.Errors > 0 {
+		r.Status = "error"
+	} else if r.Summary.Warnings > 0 {
+		r.Status = "warning"
+	} else {
+		r.Status = "ok"
+	}
+}
+
+func toCheck(c agentinit.Check) Check {
+	return Check{
+		ID:       c.ID,
+		Status:   c.Status,
+		Severity: c.Severity,
+		Message:  c.Message,
+		Agent:    c.Agent,
+		Path:     c.Path,
+		Details:  c.Details,
+	}
+}
+
+func okCheck(id, message, path string) Check {
+	return Check{ID: id, Status: "ok", Severity: "info", Message: message, Path: path}
+}
+
+func warningCheck(id, message, path string) Check {
+	return Check{ID: id, Status: "warning", Severity: "warning", Message: message, Path: path}
+}
+
+func errorCheck(id, message, path string) Check {
+	return Check{ID: id, Status: "error", Severity: "error", Message: message, Path: path}
+}
+
+func checkProjectMarker(root string) Check {
+	path := filepath.Join(root, ".mnemo")
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return warningCheck("project_marker", ".mnemo not found; run mnemo init to activate this project", path)
+	}
+	if err != nil {
+		return errorCheck("project_marker", "read .mnemo: "+err.Error(), path)
+	}
+	var marker agentinit.Marker
+	if err := json.Unmarshal(data, &marker); err != nil {
+		return errorCheck("project_marker", "malformed .mnemo: "+err.Error(), path)
+	}
+	if strings.TrimSpace(marker.ID) == "" {
+		return errorCheck("project_marker", ".mnemo has no project id", path)
+	}
+	return Check{
+		ID: "project_marker", Status: "ok", Severity: "info", Message: ".mnemo marker is valid", Path: path,
+		Details: map[string]string{"id": marker.ID, "agents": strings.Join(marker.Agents, ",")},
+	}
+}
+
+func checkBinaryOnPath() Check {
+	path, err := exec.LookPath("mnemo")
+	if err != nil {
+		return warningCheck("binary_path", "mnemo binary is not available on PATH; plugin integrations may fail", "")
+	}
+	return okCheck("binary_path", "mnemo binary found on PATH", path)
+}
+
+func checkStoreReadOnly(dataDir string) Check {
+	dbPath := filepath.Join(dataDir, "memory.db")
+	if _, err := os.Stat(dbPath); errors.Is(err, os.ErrNotExist) {
+		return warningCheck("store", "memory database not found yet", dbPath)
+	} else if err != nil {
+		return errorCheck("store", "stat memory database: "+err.Error(), dbPath)
+	}
+	db, err := sql.Open("sqlite", sqliteReadOnlyDBURI(dbPath))
+	if err != nil {
+		return errorCheck("store", "open memory database read-only: "+err.Error(), dbPath)
+	}
+	defer func() {
+		_ = db.Close()
+	}()
+	if err := db.Ping(); err != nil {
+		return errorCheck("store", "ping memory database read-only: "+err.Error(), dbPath)
+	}
+	counts := map[string]string{}
+	queries := map[string]string{
+		"sessions":     "SELECT COUNT(*) FROM sessions",
+		"observations": "SELECT COUNT(*) FROM observations",
+		"user_prompts": "SELECT COUNT(*) FROM user_prompts",
+	}
+	for table, query := range queries {
+		var count int
+		if err := db.QueryRow(query).Scan(&count); err != nil {
+			return errorCheck("store", "query "+table+": "+err.Error(), dbPath)
+		}
+		counts[table] = fmt.Sprintf("%d", count)
+	}
+	return Check{ID: "store", Status: "ok", Severity: "info", Message: "memory database opens read-only", Path: dbPath, Details: counts}
+}
+
+func sqliteReadOnlyDBURI(dbPath string) string {
+	return "file:" + filepath.ToSlash(dbPath) + "?mode=ro&immutable=1"
+}

--- a/internal/doctor/report_test.go
+++ b/internal/doctor/report_test.go
@@ -1,0 +1,60 @@
+package doctor
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCheckStoreReadOnlyUsesWALSafeImmutableURI(t *testing.T) {
+	dataDir := t.TempDir()
+	dbPath := filepath.Join(dataDir, "memory.db")
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if _, err := db.Exec("PRAGMA journal_mode = WAL"); err != nil {
+		closeTestDB(t, db)
+		t.Fatalf("enable WAL: %v", err)
+	}
+	for _, query := range []string{
+		"CREATE TABLE sessions (id TEXT)",
+		"CREATE TABLE observations (id TEXT)",
+		"CREATE TABLE user_prompts (id TEXT)",
+		"PRAGMA wal_checkpoint(FULL)",
+	} {
+		if _, err := db.Exec(query); err != nil {
+			closeTestDB(t, db)
+			t.Fatalf("exec %q: %v", query, err)
+		}
+	}
+	closeTestDB(t, db)
+
+	uri := sqliteReadOnlyDBURI(dbPath)
+	if !strings.Contains(uri, "mode=ro") || !strings.Contains(uri, "immutable=1") {
+		t.Fatalf("read-only URI is not WAL-safe: %s", uri)
+	}
+
+	if err := os.Chmod(dataDir, 0555); err != nil {
+		t.Fatalf("chmod read-only dir: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chmod(dataDir, 0755); err != nil {
+			t.Errorf("restore dir permissions: %v", err)
+		}
+	})
+
+	check := checkStoreReadOnly(dataDir)
+	if check.Status != "ok" {
+		t.Fatalf("store check status = %q, want ok (message: %s)", check.Status, check.Message)
+	}
+}
+
+func closeTestDB(t *testing.T, db *sql.DB) {
+	t.Helper()
+	if err := db.Close(); err != nil {
+		t.Errorf("close sqlite: %v", err)
+	}
+}

--- a/internal/mcp/descriptions/mem_current_project.md
+++ b/internal/mcp/descriptions/mem_current_project.md
@@ -1,0 +1,3 @@
+Resolve the active mnemo project from a workspace path. Call this first when you need to confirm mnemo is initialized and which project ID to use in other memory tools.
+
+Returns the project root, `.mnemo` marker status, configured agents, and project ID when valid. Errors clearly when `.mnemo` is missing or invalid.

--- a/internal/mcp/descriptions/mem_doctor.md
+++ b/internal/mcp/descriptions/mem_doctor.md
@@ -1,0 +1,3 @@
+Run mnemo integration diagnostics for the current workspace. Returns the same structured report as `mnemo doctor --json`, including MCP setup, hooks, project marker, competing memory surfaces, and store health.
+
+Use when memory tools seem unavailable, `.mnemo` exists but context is empty, or you need to explain setup gaps to the user.

--- a/internal/mcp/diagnostics.go
+++ b/internal/mcp/diagnostics.go
@@ -1,0 +1,141 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/jmeiracorbal/mnemo/internal/agentinit"
+	"github.com/jmeiracorbal/mnemo/internal/doctor"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+func registerDiagnosticTools(srv *server.MCPServer, allowlist map[string]bool) {
+	if shouldRegister("mem_current_project", allowlist) {
+		srv.AddTool(
+			mcp.NewTool("mem_current_project",
+				mcp.WithDescription(strings.TrimSpace(memCurrentProjectDescription)),
+				mcp.WithTitleAnnotation("Current Project"),
+				mcp.WithReadOnlyHintAnnotation(true),
+				mcp.WithDestructiveHintAnnotation(false),
+				mcp.WithIdempotentHintAnnotation(true),
+				mcp.WithOpenWorldHintAnnotation(false),
+				mcp.WithString("path",
+					mcp.Description("Workspace path to resolve (default: current working directory)"),
+				),
+			),
+			handleCurrentProject(),
+		)
+	}
+
+	if shouldRegister("mem_doctor", allowlist) {
+		srv.AddTool(
+			mcp.NewTool("mem_doctor",
+				mcp.WithDescription(strings.TrimSpace(memDoctorDescription)),
+				mcp.WithTitleAnnotation("Integration Doctor"),
+				mcp.WithReadOnlyHintAnnotation(true),
+				mcp.WithDestructiveHintAnnotation(false),
+				mcp.WithIdempotentHintAnnotation(true),
+				mcp.WithOpenWorldHintAnnotation(false),
+				mcp.WithString("path",
+					mcp.Description("Project path to diagnose (default: current working directory)"),
+				),
+				mcp.WithString("agent",
+					mcp.Description("Agent integration to check: claudecode, cursor, windsurf, codex, opencode, or all (default: all)"),
+				),
+			),
+			handleDoctor(),
+		)
+	}
+}
+
+type currentProjectResult struct {
+	Status      string   `json:"status"`
+	ProjectRoot string   `json:"project_root"`
+	ProjectID   string   `json:"project_id,omitempty"`
+	Agents      []string `json:"agents,omitempty"`
+	MarkerPath  string   `json:"marker_path"`
+	Message     string   `json:"message,omitempty"`
+}
+
+func handleCurrentProject() server.ToolHandlerFunc {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		path, _ := req.GetArguments()["path"].(string)
+		if strings.TrimSpace(path) == "" {
+			path = "."
+		}
+
+		abs, err := filepath.Abs(path)
+		if err != nil {
+			return mcp.NewToolResultError("resolve path: " + err.Error()), nil
+		}
+
+		root := agentinit.ProjectRoot(abs)
+		markerPath := filepath.Join(root, ".mnemo")
+		result := currentProjectResult{
+			ProjectRoot: root,
+			MarkerPath:  markerPath,
+		}
+
+		projectID, err := agentinit.ReadProjectID(root)
+		if err != nil {
+			result.Status = "inactive"
+			result.Message = err.Error()
+			out, marshalErr := json.MarshalIndent(result, "", "  ")
+			if marshalErr != nil {
+				return nil, fmt.Errorf("marshal current project result: %w", marshalErr)
+			}
+			return mcp.NewToolResultText(string(out)), nil
+		}
+
+		marker, err := agentinit.ReadProjectMarker(root)
+		if err != nil {
+			return mcp.NewToolResultError("read project marker: " + err.Error()), nil
+		}
+
+		result.Status = "active"
+		result.ProjectID = projectID
+		result.Agents = append([]string(nil), marker.Agents...)
+		result.Message = "mnemo is active for this project; use this project ID in memory tool calls"
+
+		out, err := json.MarshalIndent(result, "", "  ")
+		if err != nil {
+			return nil, fmt.Errorf("marshal current project result: %w", err)
+		}
+		return mcp.NewToolResultText(string(out)), nil
+	}
+}
+
+func handleDoctor() server.ToolHandlerFunc {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		path, _ := req.GetArguments()["path"].(string)
+		if strings.TrimSpace(path) == "" {
+			path = "."
+		}
+		agent, _ := req.GetArguments()["agent"].(string)
+		if strings.TrimSpace(agent) == "" {
+			agent = "all"
+		}
+
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return mcp.NewToolResultError("resolve home directory: " + err.Error()), nil
+		}
+
+		report := doctor.BuildReport(doctor.Options{
+			Agent: agent,
+			Path:  path,
+			Home:  home,
+		})
+
+		out, err := json.MarshalIndent(report, "", "  ")
+		if err != nil {
+			return nil, fmt.Errorf("marshal doctor report: %w", err)
+		}
+		return mcp.NewToolResultText(string(out)), nil
+	}
+}

--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -90,6 +90,12 @@ var memSessionSummaryDescription string
 //go:embed descriptions/mem_capture_passive.md
 var memCapturePassiveDescription string
 
+//go:embed descriptions/mem_current_project.md
+var memCurrentProjectDescription string
+
+//go:embed descriptions/mem_doctor.md
+var memDoctorDescription string
+
 // ─── Tool Profiles ───────────────────────────────────────────────────────────
 
 // ProfileAgent contains the tool names that AI agents need during coding sessions.
@@ -109,6 +115,8 @@ var ProfileAgent = map[string]bool{
 	"mem_merge_tags":        true,
 	"mem_tag_stats":         true,
 	"mem_related_tags":      true,
+	"mem_current_project":   true,
+	"mem_doctor":            true,
 }
 
 // ProfileAdmin contains tools for CLI curation and dashboards.
@@ -697,6 +705,8 @@ func registerTools(srv *server.MCPServer, s *store.Store, allowlist map[string]b
 			handleCapturePassive(s),
 		)
 	}
+
+	registerDiagnosticTools(srv, allowlist)
 }
 
 // ─── Tool Handlers ───────────────────────────────────────────────────────────

--- a/plugin/claude-code/hooks/hooks.json
+++ b/plugin/claude-code/hooks/hooks.json
@@ -86,6 +86,18 @@
         ]
       }
     ],
+    "UserPromptSubmit": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/user-prompt-submit.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Edit|Write",

--- a/plugin/claude-code/scripts/user-prompt-submit.sh
+++ b/plugin/claude-code/scripts/user-prompt-submit.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# mnemo — UserPromptSubmit hook for Claude Code plugin
+# Re-emits deferred tool loading on the first user message and periodic save nudges.
+#
+# Input: {
+#   "session_id": "...", "cwd": "...", "prompt": "...",
+#   "hook_event_name": "UserPromptSubmit"
+# }
+
+HOOKS_DIR="$(dirname "$0")"
+
+INPUT=$(cat)
+SESSION_ID=$(echo "$INPUT" | mnemo json session_id 2>/dev/null)
+CWD=$(echo "$INPUT" | mnemo json cwd 2>/dev/null)
+
+[ -z "$SESSION_ID" ] && exit 0
+[ -z "$CWD" ] && CWD="$(pwd)"
+
+PROJECT_ROOT=$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null || echo "$CWD")
+MNEMO_FILE="${PROJECT_ROOT}/.mnemo"
+[ -f "$MNEMO_FILE" ] && PROJECT=$(mnemo json id < "$MNEMO_FILE" 2>/dev/null)
+[ -z "$PROJECT" ] && exit 0
+
+STATE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/mnemo/user-prompt"
+mkdir -p "$STATE_DIR"
+STATE_FILE="${STATE_DIR}/${SESSION_ID}"
+NOW=$(date +%s)
+
+PROMPT_COUNT=0
+LAST_NUDGE=0
+if [ -f "$STATE_FILE" ]; then
+  # shellcheck disable=SC1090
+  read -r PROMPT_COUNT LAST_NUDGE < "$STATE_FILE" 2>/dev/null || true
+fi
+PROMPT_COUNT=$((PROMPT_COUNT + 1))
+
+OUTPUT=""
+if [ "$PROMPT_COUNT" -eq 1 ]; then
+  OUTPUT=$(cat "${HOOKS_DIR}/session-start-protocol.md" 2>/dev/null)
+elif [ "$((NOW - LAST_NUDGE))" -ge 900 ]; then
+  LAST_NUDGE=$NOW
+  OUTPUT="[mnemo] Reminder: call mem_save after significant decisions, fixes, or discoveries in this session."
+fi
+
+printf '%s %s\n' "$PROMPT_COUNT" "$LAST_NUDGE" > "$STATE_FILE"
+
+if [ -n "$OUTPUT" ]; then
+  printf '%s\n' "$OUTPUT"
+fi
+
+exit 0

--- a/scripts/cursor/hooks/before-submit-prompt.sh
+++ b/scripts/cursor/hooks/before-submit-prompt.sh
@@ -46,4 +46,7 @@ if [ "$PROMPT_LEN" -gt 20 ]; then
   fi
 fi
 
+HOOKS_DIR="$(dirname "$0")"
+cat "${HOOKS_DIR}/session-start-protocol.md" 2>/dev/null
+
 exit 0

--- a/scripts/windsurf/hooks/pre-user-prompt.sh
+++ b/scripts/windsurf/hooks/pre-user-prompt.sh
@@ -44,4 +44,7 @@ if [ "$PROMPT_LEN" -gt 20 ]; then
   fi
 fi
 
+HOOKS_DIR="$(dirname "$0")"
+cat "${HOOKS_DIR}/session-start-protocol.md" 2>/dev/null
+
 exit 0

--- a/skills/mnemo-memory/SKILL.md
+++ b/skills/mnemo-memory/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mnemo-memory
-description: Use mnemo as the only persistent memory for an initialized project. Use when starting or resuming work, recovering context after compaction, recalling prior decisions, saving important decisions or fixes, recording conventions or user preferences, and closing a task or session. Always verify a valid .mnemo marker first; never fall back to native, file-based, or plaintext memory.
+description: ALWAYS ACTIVE when .mnemo exists — mnemo is the ONLY persistent memory for initialized projects. Never use MEMORY.md or native agent memory. Use for session start, compaction recovery, recalls, saves, and session close. Verify a valid .mnemo marker first.
 ---
 
 # mnemo Memory


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Engram-style automatic memory prioritization for mnemo across all supported agents (Claude Code, Cursor, Codex, Windsurf, OpenCode). When mnemo is installed globally and a project has a valid `.mnemo` marker, agents receive layered instructions and runtime signals to use mnemo MCP tools instead of `MEMORY.md` or native agent memory.

## Changes

- **`mnemo init`**: writes project-level memory authority rules by default (`AGENTS.md`, agent-specific files). Opt out with `--no-project-rules`.
- **Hooks**: Cursor and Windsurf now inject shared `session-start-protocol.md` (MEMORY AUTHORITY + ToolSearch) on first prompt.
- **Claude Code plugin**: adds `UserPromptSubmit` hook for deferred tool loading and periodic save nudges.
- **Setup**: embeds `mnemo-memory` skill during `setup refresh`, adds `mnemo setup <agent>` alias, configures Codex `experimental_compact_prompt_file`.
- **MCP**: adds `mem_current_project` and `mem_doctor` to the agent tool profile.
- **Doctor**: warns when competing memory surfaces (`MEMORY.md`, Claude native memory) coexist with an active `.mnemo` marker.

## Verification

- `go build ./...`
- `go test ./...`

## Notes

- Agent-agnostic: no Cursor-only publishing or positioning.
- Does not remove the `.mnemo` opt-in gate.
- Native memory APIs cannot be disabled programmatically; priority is enforced via rules, hooks, and diagnostics.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0150a-d411-7aa5-aa6a-f405ada73b59?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0150a-d411-7aa5-aa6a-f405ada73b59&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

