### PR TITLE
Allow Claude setup without plugin

### DIFF
--- a/cmd/mnemo/setup_status_test.go
+++ b/cmd/mnemo/setup_status_test.go
@@ -100,6 +100,24 @@ func TestBuildSetupStatusReportChecksClaudeCodePluginHooks(t *testing.T) {
 	}
 }
 
+func TestBuildSetupStatusReportAllowsClaudeCodeWithoutPluginRegistry(t *testing.T) {
+	home := t.TempDir()
+
+	if _, err := agentinit.InstallGlobalInstructions(home, "claudecode"); err != nil {
+		t.Fatalf("install instructions: %v", err)
+	}
+	writeFile(t, filepath.Join(home, ".claude", ".mcp.json"), `{"mcpServers":{"mnemo":{"command":"mnemo"}}}`)
+
+	report := buildSetupStatusReport(setupStatusOptions{Agent: "claudecode", Home: home})
+	if report.Status != "ok" || report.Summary.OK != 1 || report.Summary.Warnings != 0 || report.Summary.Errors != 0 {
+		t.Fatalf("unexpected report: %+v", report)
+	}
+	row := report.Rows[0]
+	if row.Agent != "Claude" || row.Detected != "yes" || row.MCP != "yes" || row.Hooks != "n/a" || row.Instructions != "yes" {
+		t.Fatalf("unexpected row: %+v", row)
+	}
+}
+
 func TestBuildSetupStatusReportCountsRuntimeErrors(t *testing.T) {
 	home := t.TempDir()
 

--- a/internal/agentinit/claudecode.go
+++ b/internal/agentinit/claudecode.go
@@ -72,10 +72,13 @@ func claudeCodeCheckMCP(home string) Check {
 func claudeCodeCheckRuntime(home string) Check {
 	installPath, err := claudeMnemoPluginInstallPath(home)
 	if err != nil {
-		path := filepath.Join(home, ".claude", "plugins", "installed_plugins.json")
+		// install.sh/setup refresh configure Claude Code through MCP and global
+		// instructions. The Claude plugin is optional in that path, so an absent
+		// plugin registry or mnemo plugin is not a broken runtime surface.
 		if errors.Is(err, errClaudePluginRegistryNotFound) || errors.Is(err, errClaudeMnemoPluginNotFound) {
-			return checkWarning("claudecode", "runtime_files.claudecode", err.Error(), path)
+			return Check{}
 		}
+		path := filepath.Join(home, ".claude", "plugins", "installed_plugins.json")
 		return checkError("claudecode", "runtime_files.claudecode", err.Error(), path)
 	}
 	paths := []string{


### PR DESCRIPTION
Fix setup status for install.sh-based Claude Code setup without a plugin registry.

Validated with tests, lint, govulncheck, and a fresh HOME smoke test.