### PR TITLE
Add projects rename command

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -97,7 +97,7 @@ mnemo search "SQLite" --project miapp
 | **Agent Skills portables** | Enseñan a los agentes compatibles cuándo y cómo usar mnemo sin recurrir a memoria nativa. |
 | **Captura pasiva** | Extrae aprendizajes útiles de transcripciones y salidas de subagentes. |
 | **Diagnóstico** | `mnemo doctor` comprueba activación, setup global, MCP, hooks, memorias competidoras y salud del store. |
-| **Mantenimiento de proyectos** | `mnemo projects list` y `mnemo projects merge` consolidan identidades duplicadas. |
+| **Mantenimiento de proyectos** | `mnemo projects list`, `mnemo projects merge` y `mnemo projects rename` ayudan a depurar identidades duplicadas o poco claras. |
 | **Curación de memoria** | `mnemo memories review` detecta observaciones duplicadas o conflictivas para reparación aprobada. |
 
 ## Agentes soportados

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ mnemo search "SQLite" --project myapp
 | **Portable Agent Skills** | Skills teach compatible agents when and how to use mnemo without falling back to native memory. |
 | **Passive capture** | Extracts useful learnings from transcripts and subagent output. |
 | **Diagnostics** | `mnemo doctor` checks project activation, global setup, MCP, hooks, competing memory surfaces and store health. |
-| **Project maintenance** | `mnemo projects list` and `mnemo projects merge` help consolidate duplicate project identities. |
+| **Project maintenance** | `mnemo projects list`, `mnemo projects merge` and `mnemo projects rename` help curate duplicate or unclear project identities. |
 | **Memory curation** | `mnemo memories review` surfaces duplicate or conflicting observations for approved repair. |
 
 ## Supported Agents

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,14 +8,12 @@ Build on project inventory and consolidation before introducing more destructive
 
 ```bash
 mnemo projects prune
-mnemo projects rename --id <project> --name <name>
-mnemo projects rename --path <dir> --name <name>
 ```
 
 Near-term goals:
 
 - keep `prune` behind explicit safety checks after merge/consolidation is reliable;
-- revisit `rename` after consolidation, using explicit selectors (`--id`, `--path`, or a shared selector flag) instead of ambiguous positional arguments.
+- continue using explicit selectors and dry-run/apply guardrails for project maintenance commands.
 
 ## Local sync
 

--- a/cmd/mnemo/projects.go
+++ b/cmd/mnemo/projects.go
@@ -37,11 +37,26 @@ type projectsMergeOptions struct {
 	JSON       bool
 }
 
+type projectsRenameOptions struct {
+	ID     string
+	Path   string
+	Name   string
+	DryRun bool
+	Yes    bool
+	JSON   bool
+}
+
 type projectsMergeReport struct {
 	DryRun  bool                       `json:"dry_run"`
 	Total   int                        `json:"total"`
 	Plans   []store.ProjectMergePlan   `json:"plans,omitempty"`
 	Results []store.ProjectMergeResult `json:"results,omitempty"`
+}
+
+type projectsRenameReport struct {
+	DryRun bool                       `json:"dry_run"`
+	Plan   *store.ProjectRenamePlan   `json:"plan,omitempty"`
+	Result *store.ProjectRenameResult `json:"result,omitempty"`
 }
 
 func runProjects(s *store.Store) {
@@ -54,6 +69,8 @@ func runProjects(s *store.Store) {
 		runProjectsList(s)
 	case "merge":
 		runProjectsMerge(s)
+	case "rename":
+		runProjectsRename(s)
 	default:
 		printProjectsUsage()
 		os.Exit(1)
@@ -64,6 +81,7 @@ func printProjectsUsage() {
 	fmt.Fprintln(os.Stderr, "usage: mnemo projects list [--sort=FIELD] [--asc|--desc] [--unused-since=DURATION|DATE] [--empty] [--json]")
 	fmt.Fprintln(os.Stderr, "       mnemo projects merge --from=PROJECT --to=PROJECT (--dry-run|--yes) [--json]")
 	fmt.Fprintln(os.Stderr, "       mnemo projects merge --auto-by-path (--dry-run|--yes) [--json]")
+	fmt.Fprintln(os.Stderr, "       mnemo projects rename (--id=PROJECT|--path=DIR) --name=NAME (--dry-run|--yes) [--json]")
 }
 
 func runProjectsList(s *store.Store) {
@@ -122,6 +140,36 @@ func runProjectsMerge(s *store.Store) {
 	}
 	if err := printProjectsMergeApplyOutput(os.Stdout, opts.JSON, results); err != nil {
 		fmt.Fprintf(os.Stderr, "mnemo projects merge: json: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func runProjectsRename(s *store.Store) {
+	opts, err := parseProjectsRenameArgs(os.Args[3:])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mnemo projects rename: %v\n", err)
+		os.Exit(1)
+	}
+	selector := projectsRenameSelector(opts)
+	if opts.DryRun {
+		plan, err := s.BuildProjectRenamePlan(selector, opts.Name)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "mnemo projects rename: %v\n", err)
+			os.Exit(1)
+		}
+		if err := printProjectsRenameDryRunOutput(os.Stdout, opts.JSON, *plan); err != nil {
+			fmt.Fprintf(os.Stderr, "mnemo projects rename: json: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
+	result, err := s.RenameProject(selector, opts.Name)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mnemo projects rename: %v\n", err)
+		os.Exit(1)
+	}
+	if err := printProjectsRenameApplyOutput(os.Stdout, opts.JSON, *result); err != nil {
+		fmt.Fprintf(os.Stderr, "mnemo projects rename: json: %v\n", err)
 		os.Exit(1)
 	}
 }
@@ -193,6 +241,45 @@ func parseProjectsMergeArgs(args []string) (projectsMergeOptions, error) {
 		return opts, fmt.Errorf("explicit merge requires --from and --to")
 	}
 	return opts, nil
+}
+
+func parseProjectsRenameArgs(args []string) (projectsRenameOptions, error) {
+	var opts projectsRenameOptions
+	for _, arg := range args {
+		switch {
+		case arg == "--dry-run":
+			opts.DryRun = true
+		case arg == "--yes":
+			opts.Yes = true
+		case arg == "--json":
+			opts.JSON = true
+		case strings.HasPrefix(arg, "--id="):
+			opts.ID = strings.TrimSpace(arg[len("--id="):])
+		case strings.HasPrefix(arg, "--path="):
+			opts.Path = strings.TrimSpace(arg[len("--path="):])
+		case strings.HasPrefix(arg, "--name="):
+			opts.Name = strings.TrimSpace(arg[len("--name="):])
+		default:
+			return opts, fmt.Errorf("unknown argument %q", arg)
+		}
+	}
+	if opts.DryRun && opts.Yes {
+		return opts, fmt.Errorf("--dry-run and --yes are mutually exclusive")
+	}
+	if !opts.DryRun && !opts.Yes {
+		return opts, fmt.Errorf("refusing to rename without --dry-run or --yes")
+	}
+	if (opts.ID == "") == (opts.Path == "") {
+		return opts, fmt.Errorf("select exactly one project with --id or --path")
+	}
+	if opts.Name == "" {
+		return opts, fmt.Errorf("--name is required")
+	}
+	return opts, nil
+}
+
+func projectsRenameSelector(opts projectsRenameOptions) store.ProjectRenameSelector {
+	return store.ProjectRenameSelector{ID: opts.ID, Path: opts.Path}
 }
 
 func normalizeProjectsSort(value string) (string, error) {
@@ -470,11 +557,36 @@ func printProjectsMergeJSONTo(out io.Writer, report projectsMergeReport) error {
 	return err
 }
 
+func printProjectsRenameJSONTo(out io.Writer, report projectsRenameReport) error {
+	data, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintln(out, string(data))
+	return err
+}
+
 func printProjectsMergeApplyOutput(out io.Writer, jsonOutput bool, results []store.ProjectMergeResult) error {
 	if jsonOutput {
 		return printProjectsMergeJSONTo(out, projectsMergeReport{DryRun: false, Total: len(results), Results: results})
 	}
 	printProjectsMergeResults(out, results)
+	return nil
+}
+
+func printProjectsRenameDryRunOutput(out io.Writer, jsonOutput bool, plan store.ProjectRenamePlan) error {
+	if jsonOutput {
+		return printProjectsRenameJSONTo(out, projectsRenameReport{DryRun: true, Plan: &plan})
+	}
+	printProjectsRenamePlan(out, plan)
+	return nil
+}
+
+func printProjectsRenameApplyOutput(out io.Writer, jsonOutput bool, result store.ProjectRenameResult) error {
+	if jsonOutput {
+		return printProjectsRenameJSONTo(out, projectsRenameReport{DryRun: false, Result: &result})
+	}
+	printProjectsRenameResult(out, result)
 	return nil
 }
 
@@ -486,10 +598,7 @@ func printProjectsListTo(out io.Writer, projects []store.ProjectSummary) {
 		if strings.TrimSpace(lastSeen) == "" {
 			lastSeen = "never"
 		}
-		nameOrPath := project.Name
-		if strings.TrimSpace(project.Directory) != "" {
-			nameOrPath = project.Directory
-		}
+		nameOrPath := projectDisplayName(project)
 		_, _ = fmt.Fprintf(w, "%s\t%s\t%d\t%d\t%d\t%s\n",
 			projectsTableCell(project.ID),
 			projectsTableCell(nameOrPath),
@@ -500,6 +609,16 @@ func printProjectsListTo(out io.Writer, projects []store.ProjectSummary) {
 		)
 	}
 	_ = w.Flush()
+}
+
+func projectDisplayName(project store.ProjectSummary) string {
+	if strings.TrimSpace(project.Name) != "" && project.Name != project.ID {
+		return project.Name
+	}
+	if strings.TrimSpace(project.Directory) != "" {
+		return project.Directory
+	}
+	return project.Name
 }
 
 func printProjectsMergePlans(out io.Writer, plans []store.ProjectMergePlan) {
@@ -521,6 +640,33 @@ func printProjectsMergePlans(out io.Writer, plans []store.ProjectMergePlan) {
 		)
 	}
 	_, _ = fmt.Fprintln(w, "\nDry run only. Re-run with --yes to apply.")
+	_ = w.Flush()
+}
+
+func printProjectsRenamePlan(out io.Writer, plan store.ProjectRenamePlan) {
+	w := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+	_, _ = fmt.Fprintln(w, "ID\tCurrent Name\tNew Name\tSelector\tChange")
+	_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s=%s\t%s\n",
+		projectsTableCell(plan.Project.ID),
+		projectsTableCell(plan.Project.Name),
+		projectsTableCell(plan.NewName),
+		projectsTableCell(plan.Selector),
+		projectsTableCell(plan.SelectorValue),
+		projectRenameChangeCell(plan.WillChange),
+	)
+	_, _ = fmt.Fprintln(w, "\nDry run only. Re-run with --yes to apply.")
+	_ = w.Flush()
+}
+
+func printProjectsRenameResult(out io.Writer, result store.ProjectRenameResult) {
+	w := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+	_, _ = fmt.Fprintln(w, "ID\tOld Name\tNew Name\tChanged")
+	_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\n",
+		projectsTableCell(result.Plan.Project.ID),
+		projectsTableCell(result.Plan.Project.Name),
+		projectsTableCell(result.Plan.NewName),
+		projectRenameChangeCell(result.Renamed),
+	)
 	_ = w.Flush()
 }
 
@@ -561,6 +707,13 @@ func projectMergeDeletedCell(deleted bool) string {
 		return "deleted"
 	}
 	return "-"
+}
+
+func projectRenameChangeCell(changed bool) string {
+	if changed {
+		return "yes"
+	}
+	return "no"
 }
 
 func projectsTableCell(value string) string {

--- a/cmd/mnemo/projects_test.go
+++ b/cmd/mnemo/projects_test.go
@@ -71,6 +71,30 @@ func TestParseProjectsMergeArgsAutoByPath(t *testing.T) {
 	}
 }
 
+func TestParseProjectsRenameArgsByID(t *testing.T) {
+	opts, err := parseProjectsRenameArgs([]string{"--id=alpha", "--name=Alpha Project", "--dry-run", "--json"})
+	if err != nil {
+		t.Fatalf("parse projects rename args: %v", err)
+	}
+	if opts.ID != "alpha" || opts.Path != "" || opts.Name != "Alpha Project" || !opts.DryRun || !opts.JSON || opts.Yes {
+		t.Fatalf("unexpected options: %+v", opts)
+	}
+}
+
+func TestParseProjectsRenameArgsRejectsAmbiguousSelector(t *testing.T) {
+	_, err := parseProjectsRenameArgs([]string{"--id=alpha", "--path=/tmp/alpha", "--name=Alpha", "--dry-run"})
+	if err == nil {
+		t.Fatal("expected selector conflict")
+	}
+}
+
+func TestParseProjectsRenameArgsRequiresSafetyFlag(t *testing.T) {
+	_, err := parseProjectsRenameArgs([]string{"--id=alpha", "--name=Alpha"})
+	if err == nil {
+		t.Fatal("expected safety flag error")
+	}
+}
+
 func TestProjectsListFiltersAndSorts(t *testing.T) {
 	projects := []store.ProjectSummary{
 		{ID: "beta", Name: "Beta", ObservationCount: 2, LastSeenAt: "2026-01-15 10:00:00"},
@@ -178,6 +202,44 @@ func TestPreferProjectMergeDestinationPrefersUUIDThenActivity(t *testing.T) {
 	lessActiveProject := store.ProjectSummary{ID: "11111111-2222-3333-4444-555555555555", ObservationCount: 1}
 	if !preferProjectMergeDestination(activeProject, lessActiveProject) {
 		t.Fatal("expected more active UUID project to be preferred")
+	}
+}
+
+func TestPrintProjectsListUsesRenamedProjectName(t *testing.T) {
+	projects := []store.ProjectSummary{{
+		ID:               "alpha",
+		Name:             "Alpha Project",
+		Directory:        "/tmp/alpha",
+		ObservationCount: 1,
+		SessionCount:     2,
+		PromptCount:      3,
+		LastSeenAt:       "2026-01-15 10:00:00",
+	}}
+	var out bytes.Buffer
+
+	printProjectsListTo(&out, projects)
+
+	got := out.String()
+	if !strings.Contains(got, "Alpha Project") {
+		t.Fatalf("table output missing renamed project name:\n%s", got)
+	}
+	if strings.Contains(got, "/tmp/alpha") {
+		t.Fatalf("table output should prefer explicit project name over directory:\n%s", got)
+	}
+}
+
+func TestPrintProjectsListFallsBackToDirectoryForUnrenamedProject(t *testing.T) {
+	projects := []store.ProjectSummary{{
+		ID:        "alpha",
+		Name:      "alpha",
+		Directory: "/tmp/alpha",
+	}}
+	var out bytes.Buffer
+
+	printProjectsListTo(&out, projects)
+
+	if got := out.String(); !strings.Contains(got, "/tmp/alpha") {
+		t.Fatalf("table output missing directory fallback:\n%s", got)
 	}
 }
 

--- a/cmd/mnemo/templates/usage.txt
+++ b/cmd/mnemo/templates/usage.txt
@@ -14,6 +14,7 @@ Usage:
   mnemo projects list [--sort=FIELD] [--asc|--desc] [--unused-since=DURATION|DATE] [--empty] [--json]  List known projects
   mnemo projects merge --from=PROJECT --to=PROJECT (--dry-run|--yes) [--json]  Merge one project into another
   mnemo projects merge --auto-by-path (--dry-run|--yes) [--json]  Merge duplicate project identities by shared directory
+  mnemo projects rename (--id=PROJECT|--path=DIR) --name=NAME (--dry-run|--yes) [--json]  Rename project display metadata
   mnemo memories review [--project=PROJECT] [--topic=TOPIC_KEY] [--json]  Review potential memory conflicts
   mnemo memories mark-reviewed OBSERVATION_ID [--reason=TEXT]  Mark a memory as reviewed
   mnemo memories mark-stale OBSERVATION_ID [--reason=TEXT]  Mark a memory as stale
@@ -81,6 +82,14 @@ Projects list options:
   --unused-since=AGE   Show projects not seen since AGE (for example 90d, 24h, or 2026-01-01)
   --empty              Show projects with no observations or prompts
   --json               Emit a stable JSON project list
+
+Projects rename options:
+  --id=PROJECT         Select a project by stable project ID
+  --path=DIR           Select a project by latest session directory
+  --name=NAME          Set project display name
+  --dry-run            Preview the rename without writing changes
+  --yes                Apply the rename
+  --json               Emit stable JSON output
 
 Tool profiles for mcp:
   --tools=agent    17 tools for AI agents (default when using plugin)

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -15,6 +15,7 @@ mnemo setup uninstall --agent=AGENT [--home=DIR]  Remove global setup files for 
 mnemo projects list [--sort=FIELD] [--asc|--desc] [--unused-since=DURATION|DATE] [--empty] [--json]  List known projects
 mnemo projects merge --from=PROJECT --to=PROJECT (--dry-run|--yes) [--json]  Merge one project into another
 mnemo projects merge --auto-by-path (--dry-run|--yes) [--json]  Merge duplicate project identities by shared directory
+mnemo projects rename (--id=PROJECT|--path=DIR) --name=NAME (--dry-run|--yes) [--json]  Rename project display metadata
 mnemo memories review [--project=PROJECT] [--topic=TOPIC_KEY] [--json]  Review potential memory conflicts
 mnemo memories mark-reviewed OBSERVATION_ID [--reason=TEXT]  Mark a memory as reviewed
 mnemo memories mark-stale OBSERVATION_ID [--reason=TEXT]  Mark a memory as stale
@@ -88,6 +89,13 @@ Merge duplicate project identities by shared directory:
 ```bash
 mnemo projects merge --auto-by-path --dry-run --json
 mnemo projects merge --auto-by-path --yes
+```
+
+Rename project display metadata without changing the stable project ID:
+
+```bash
+mnemo projects rename --id=myapp --name="My App" --dry-run
+mnemo projects rename --path=/path/to/myapp --name="My App" --yes
 ```
 
 Review memory conflicts:

--- a/internal/db/generated/projects.sql.go
+++ b/internal/db/generated/projects.sql.go
@@ -160,3 +160,18 @@ func (q *Queries) ListProjects(ctx context.Context) ([]Project, error) {
 	}
 	return items, nil
 }
+
+const upsertProjectName = `-- name: UpsertProjectName :exec
+INSERT INTO projects (id, name) VALUES (?, ?)
+ON CONFLICT(id) DO UPDATE SET name = excluded.name
+`
+
+type UpsertProjectNameParams struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+func (q *Queries) UpsertProjectName(ctx context.Context, arg UpsertProjectNameParams) error {
+	_, err := q.db.ExecContext(ctx, upsertProjectName, arg.ID, arg.Name)
+	return err
+}

--- a/internal/db/generated/querier.go
+++ b/internal/db/generated/querier.go
@@ -119,6 +119,7 @@ type Querier interface {
 	UpdatePulledObservation(ctx context.Context, arg UpdatePulledObservationParams) error
 	UpdateSyncAckState(ctx context.Context, arg UpdateSyncAckStateParams) error
 	UpsertMemoryReviewState(ctx context.Context, arg UpsertMemoryReviewStateParams) error
+	UpsertProjectName(ctx context.Context, arg UpsertProjectNameParams) error
 	UpsertSession(ctx context.Context, arg UpsertSessionParams) error
 }
 

--- a/internal/db/queries/projects.sql
+++ b/internal/db/queries/projects.sql
@@ -1,6 +1,10 @@
 -- name: EnsureProject :exec
 INSERT OR IGNORE INTO projects (id, name) VALUES (?, ?);
 
+-- name: UpsertProjectName :exec
+INSERT INTO projects (id, name) VALUES (?, ?)
+ON CONFLICT(id) DO UPDATE SET name = excluded.name;
+
 -- name: GetProjectByID :one
 SELECT id, name, created_at FROM projects WHERE id = ?;
 

--- a/internal/store/project.go
+++ b/internal/store/project.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	dbgen "github.com/jmeiracorbal/mnemo/internal/db/generated"
@@ -202,6 +203,96 @@ func (s *Store) MergeProjects(from, to string) (*ProjectMergeResult, error) {
 		return nil, err
 	}
 	return result, nil
+}
+
+func (s *Store) BuildProjectRenamePlan(selector ProjectRenameSelector, newName string) (*ProjectRenamePlan, error) {
+	newName = strings.TrimSpace(newName)
+	if newName == "" {
+		return nil, fmt.Errorf("project name must not be empty")
+	}
+
+	selector.ID = strings.TrimSpace(selector.ID)
+	selector.Path = strings.TrimSpace(selector.Path)
+	if (selector.ID == "") == (selector.Path == "") {
+		return nil, fmt.Errorf("select exactly one project with id or path")
+	}
+
+	projects, err := s.ListProjectSummaries()
+	if err != nil {
+		return nil, err
+	}
+
+	var project ProjectSummary
+	selectorName := "id"
+	selectorValue := selector.ID
+	if selector.ID != "" {
+		found := false
+		for _, candidate := range projects {
+			if candidate.ID == selector.ID {
+				project = candidate
+				found = true
+				break
+			}
+		}
+		if !found {
+			return nil, fmt.Errorf("project %q not found", selector.ID)
+		}
+	} else {
+		selectorName = "path"
+		selectorValue = normalizeProjectPath(selector.Path)
+		var matches []ProjectSummary
+		for _, candidate := range projects {
+			if normalizeProjectPath(candidate.Directory) == selectorValue {
+				matches = append(matches, candidate)
+			}
+		}
+		switch len(matches) {
+		case 0:
+			return nil, fmt.Errorf("project path %q not found", selector.Path)
+		case 1:
+			project = matches[0]
+		default:
+			ids := make([]string, 0, len(matches))
+			for _, match := range matches {
+				ids = append(ids, match.ID)
+			}
+			return nil, fmt.Errorf("project path %q matches multiple projects: %s", selector.Path, strings.Join(ids, ", "))
+		}
+	}
+
+	return &ProjectRenamePlan{
+		Project:       project,
+		Selector:      selectorName,
+		SelectorValue: selectorValue,
+		NewName:       newName,
+		WillChange:    project.Name != newName,
+	}, nil
+}
+
+func (s *Store) RenameProject(selector ProjectRenameSelector, newName string) (*ProjectRenameResult, error) {
+	plan, err := s.BuildProjectRenamePlan(selector, newName)
+	if err != nil {
+		return nil, err
+	}
+	result := &ProjectRenameResult{Plan: *plan, Renamed: plan.WillChange}
+	if !plan.WillChange {
+		return result, nil
+	}
+	if err := s.q.UpsertProjectName(context.Background(), dbgen.UpsertProjectNameParams{
+		ID:   plan.Project.ID,
+		Name: plan.NewName,
+	}); err != nil {
+		return nil, fmt.Errorf("rename project metadata: %w", err)
+	}
+	return result, nil
+}
+
+func normalizeProjectPath(path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return ""
+	}
+	return filepath.Clean(path)
 }
 
 func (s *Store) MigrateProject(oldName, newName string) (*MigrateResult, error) {

--- a/internal/store/project_test.go
+++ b/internal/store/project_test.go
@@ -1,6 +1,9 @@
 package store
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestListProjectSummariesIncludesRegisteredAndActivityProjects(t *testing.T) {
 	s := newTestStore(t)
@@ -204,6 +207,106 @@ func TestMergeProjectsConsolidatesProjectData(t *testing.T) {
 	}
 	if sourceMutations != 0 || destinationMutations != 3 {
 		t.Fatalf("unexpected sync mutation counts: source=%d destination=%d", sourceMutations, destinationMutations)
+	}
+}
+
+func TestRenameProjectUpdatesMetadataWithoutChangingActivityProjectID(t *testing.T) {
+	s := newTestStore(t)
+
+	if err := s.CreateSession("s-alpha", "alpha", "/tmp/alpha"); err != nil {
+		t.Fatalf("create alpha session: %v", err)
+	}
+	if _, err := s.AddObservation(AddObservationParams{
+		SessionID: "s-alpha",
+		Type:      "decision",
+		Title:     "Alpha rename",
+		Content:   "Keep activity project id stable",
+		Project:   "alpha",
+		Scope:     "project",
+	}); err != nil {
+		t.Fatalf("add alpha observation: %v", err)
+	}
+
+	result, err := s.RenameProject(ProjectRenameSelector{ID: "alpha"}, "Alpha Project")
+	if err != nil {
+		t.Fatalf("rename project: %v", err)
+	}
+	if !result.Renamed || result.Plan.Project.ID != "alpha" || result.Plan.NewName != "Alpha Project" {
+		t.Fatalf("unexpected rename result: %+v", result)
+	}
+
+	project, err := s.GetProjectByID("alpha")
+	if err != nil {
+		t.Fatalf("get project metadata: %v", err)
+	}
+	if project == nil || project.Name != "Alpha Project" {
+		t.Fatalf("project metadata = %+v, want renamed metadata", project)
+	}
+
+	projects, err := s.ListProjectSummaries()
+	if err != nil {
+		t.Fatalf("list project summaries: %v", err)
+	}
+	summary := findProjectSummary(projects, "alpha")
+	if summary == nil || summary.Name != "Alpha Project" || summary.ObservationCount != 1 || summary.SessionCount != 1 {
+		t.Fatalf("unexpected renamed summary: %+v in %+v", summary, projects)
+	}
+
+	results, err := s.Search("Alpha rename", SearchOptions{Project: "alpha", Limit: 10})
+	if err != nil {
+		t.Fatalf("search renamed project id: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected activity to remain under project id alpha, got %d", len(results))
+	}
+	results, err = s.Search("Alpha rename", SearchOptions{Project: "Alpha Project", Limit: 10})
+	if err != nil {
+		t.Fatalf("search display name: %v", err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("expected no activity under display name, got %d", len(results))
+	}
+}
+
+func TestRenameProjectSelectsByPath(t *testing.T) {
+	s := newTestStore(t)
+
+	if err := s.CreateSession("s-alpha", "alpha", "/tmp/alpha"); err != nil {
+		t.Fatalf("create alpha session: %v", err)
+	}
+
+	result, err := s.RenameProject(ProjectRenameSelector{Path: "/tmp/alpha/."}, "Alpha Project")
+	if err != nil {
+		t.Fatalf("rename project by path: %v", err)
+	}
+	if !result.Renamed || result.Plan.Selector != "path" || result.Plan.SelectorValue != "/tmp/alpha" {
+		t.Fatalf("unexpected path rename result: %+v", result)
+	}
+	project, err := s.GetProjectByID("alpha")
+	if err != nil {
+		t.Fatalf("get project metadata: %v", err)
+	}
+	if project == nil || project.Name != "Alpha Project" {
+		t.Fatalf("project metadata = %+v, want renamed metadata", project)
+	}
+}
+
+func TestBuildProjectRenamePlanByPathRejectsAmbiguousPath(t *testing.T) {
+	s := newTestStore(t)
+
+	if err := s.CreateSession("s-alpha", "alpha", "/tmp/shared"); err != nil {
+		t.Fatalf("create alpha session: %v", err)
+	}
+	if err := s.CreateSession("s-beta", "beta", "/tmp/shared"); err != nil {
+		t.Fatalf("create beta session: %v", err)
+	}
+
+	_, err := s.BuildProjectRenamePlan(ProjectRenameSelector{Path: "/tmp/shared/."}, "Shared")
+	if err == nil {
+		t.Fatal("expected ambiguous path error")
+	}
+	if !strings.Contains(err.Error(), "matches multiple projects") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/internal/store/types.go
+++ b/internal/store/types.go
@@ -321,6 +321,24 @@ type ProjectMergeResult struct {
 	EnrollmentTransferred bool             `json:"enrollment_transferred"`
 }
 
+type ProjectRenameSelector struct {
+	ID   string `json:"id,omitempty"`
+	Path string `json:"path,omitempty"`
+}
+
+type ProjectRenamePlan struct {
+	Project       ProjectSummary `json:"project"`
+	Selector      string         `json:"selector"`
+	SelectorValue string         `json:"selector_value"`
+	NewName       string         `json:"new_name"`
+	WillChange    bool           `json:"will_change"`
+}
+
+type ProjectRenameResult struct {
+	Plan    ProjectRenamePlan `json:"plan"`
+	Renamed bool              `json:"renamed"`
+}
+
 type PassiveCaptureParams struct {
 	SessionID string `json:"session_id"`
 	Content   string `json:"content"`


### PR DESCRIPTION
Adds a safe projects rename command with explicit selectors, dry-run/apply guardrails, and docs/tests.