### PR TITLE
fix: suppress hook write output

### DIFF
--- a/cmd/mnemo/plugin_integrity_test.go
+++ b/cmd/mnemo/plugin_integrity_test.go
@@ -132,6 +132,69 @@ func TestShippedHooksResolveProjectFromMarker(t *testing.T) {
 	}
 }
 
+func TestShippedHooksSuppressInternalMnemoWriteOutput(t *testing.T) {
+	roots := []string{
+		filepath.Join("..", "..", "plugin", "claude-code", "scripts"),
+		filepath.Join("..", "..", "scripts", "cursor", "hooks"),
+		filepath.Join("..", "..", "scripts", "windsurf", "hooks"),
+		filepath.Join("..", "..", "scripts", "codex", "hooks"),
+	}
+
+	writeCommands := []string{
+		"mnemo session start ",
+		"mnemo session end ",
+		"mnemo save ",
+		"mnemo capture ",
+		"| mnemo capture ",
+	}
+
+	checked := 0
+	for _, root := range roots {
+		err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() || filepath.Ext(path) != ".sh" {
+				return nil
+			}
+
+			data, err := os.ReadFile(path)
+			if err != nil {
+				t.Errorf("read %s: %v", path, err)
+				return nil
+			}
+			lines := strings.Split(string(data), "\n")
+			for i, line := range lines {
+				for _, command := range writeCommands {
+					if !strings.Contains(line, command) {
+						continue
+					}
+					checked++
+					terminator := line
+					if !strings.Contains(terminator, "|| true") {
+						for _, nextLine := range lines[i+1:] {
+							terminator = nextLine
+							if strings.Contains(terminator, "|| true") {
+								break
+							}
+						}
+					}
+					if strings.Contains(terminator, "2>/dev/null || true") && !strings.Contains(terminator, ">/dev/null 2>&1") {
+						t.Errorf("%s:%d suppresses stderr only for %q; hook-internal mnemo writes must suppress stdout too", path, i+1, command)
+					}
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("walk %s: %v", root, err)
+		}
+	}
+	if checked == 0 {
+		t.Fatal("no hook-internal mnemo write commands were checked")
+	}
+}
+
 func TestShippedProtocolsForbidFallbackMemory(t *testing.T) {
 	files := []string{
 		filepath.Join("..", "..", "templates", "rules", "generic.md"),

--- a/plugin/claude-code/scripts/post-bash-git.sh
+++ b/plugin/claude-code/scripts/post-bash-git.sh
@@ -31,6 +31,6 @@ mnemo save \
 **Where**: ${PROJECT_ROOT}" \
   --type decision \
   --project "$PROJECT" \
-  2>/dev/null || true
+  >/dev/null 2>&1 || true
 
 exit 0

--- a/plugin/claude-code/scripts/post-compact.sh
+++ b/plugin/claude-code/scripts/post-compact.sh
@@ -19,7 +19,7 @@ MNEMO_FILE="${PROJECT_ROOT}/.mnemo"
 [ -z "$PROJECT" ] && exit 0
 
 if [ -n "$SESSION_ID" ] && [ -n "$PROJECT" ]; then
-  mnemo session start "$SESSION_ID" --project "$PROJECT" --dir "$CWD" 2>/dev/null || true
+  mnemo session start "$SESSION_ID" --project "$PROJECT" --dir "$CWD" >/dev/null 2>&1 || true
 fi
 
 CONTEXT=$(mnemo context "$PROJECT" 2>/dev/null)

--- a/plugin/claude-code/scripts/post-file-edit.sh
+++ b/plugin/claude-code/scripts/post-file-edit.sh
@@ -28,6 +28,6 @@ mnemo save \
   --type file-change \
   --project "$PROJECT" \
   --topic "$TOPIC" \
-  2>/dev/null || true
+  >/dev/null 2>&1 || true
 
 exit 0

--- a/plugin/claude-code/scripts/session-start.sh
+++ b/plugin/claude-code/scripts/session-start.sh
@@ -24,7 +24,7 @@ IS_RESUME=$(mnemo session exists "$SESSION_ID" 2>/dev/null)
 if [ "$IS_RESUME" = "true" ]; then
   printf "\n[mnemo] Session resumed (project: %s)\n" "$PROJECT"
 else
-  mnemo session start "$SESSION_ID" --project "$PROJECT" --dir "$CWD" 2>/dev/null || true
+  mnemo session start "$SESSION_ID" --project "$PROJECT" --dir "$CWD" >/dev/null 2>&1 || true
   printf "\n[mnemo] New session started (project: %s)\n" "$PROJECT"
 fi
 

--- a/plugin/claude-code/scripts/session-stop.sh
+++ b/plugin/claude-code/scripts/session-stop.sh
@@ -13,9 +13,9 @@ MNEMO_FILE="${PROJECT_ROOT}/.mnemo"
 [ -f "$MNEMO_FILE" ] && PROJECT=$(mnemo json id < "$MNEMO_FILE" 2>/dev/null)
 [ -z "$PROJECT" ] && exit 0
 
-OBS_COUNT=$(mnemo session obs-count "$SESSION_ID" 2>/dev/null)
+OBS_COUNT=$(mnemo session project-obs-count "$SESSION_ID" 2>/dev/null)
 
-mnemo session end "$SESSION_ID" 2>/dev/null || true
+mnemo session end "$SESSION_ID" >/dev/null 2>&1 || true
 
 if [ "${OBS_COUNT:-0}" = "0" ]; then
   printf "\n[mnemo] warning: session ended with 0 memories saved.\n" >&2

--- a/plugin/claude-code/scripts/subagent-stop.sh
+++ b/plugin/claude-code/scripts/subagent-stop.sh
@@ -18,6 +18,6 @@ MNEMO_FILE="${PROJECT_ROOT}/.mnemo"
 [ -f "$MNEMO_FILE" ] && PROJECT=$(mnemo json id < "$MNEMO_FILE" 2>/dev/null)
 [ -z "$PROJECT" ] && exit 0
 
-mnemo capture "$OUTPUT" --session "$SESSION_ID" --project "$PROJECT" 2>/dev/null || true
+printf '%s' "$OUTPUT" | mnemo capture - --session "$SESSION_ID" --project "$PROJECT" >/dev/null 2>&1 || true
 
 exit 0

--- a/scripts/codex/hooks/session-start.sh
+++ b/scripts/codex/hooks/session-start.sh
@@ -36,7 +36,7 @@ IS_RESUME=$(mnemo session exists "$SESSION_ID" 2>/dev/null)
 if [ "$IS_RESUME" = "true" ]; then
   STATUS="[mnemo] Session resumed (project: ${PROJECT})"
 else
-  mnemo session start "$SESSION_ID" --project "$PROJECT" --dir "$CWD" 2>/dev/null || true
+  mnemo session start "$SESSION_ID" --project "$PROJECT" --dir "$CWD" >/dev/null 2>&1 || true
   STATUS="[mnemo] New session started (project: ${PROJECT})"
 fi
 

--- a/scripts/cursor/hooks/before-submit-prompt.sh
+++ b/scripts/cursor/hooks/before-submit-prompt.sh
@@ -30,7 +30,7 @@ IS_KNOWN=$(mnemo session exists "$CONVERSATION_ID" 2>/dev/null)
 [ "$IS_KNOWN" = "true" ] && exit 0
 
 # New conversation — register session and emit general context
-mnemo session start "$CONVERSATION_ID" --project "$PROJECT" --dir "$WORKSPACE" 2>/dev/null || true
+mnemo session start "$CONVERSATION_ID" --project "$PROJECT" --dir "$WORKSPACE" >/dev/null 2>&1 || true
 printf "\n[mnemo] New session started (project: %s)\n" "$PROJECT"
 
 CONTEXT=$(mnemo context "$PROJECT" 2>/dev/null)

--- a/scripts/cursor/hooks/stop.sh
+++ b/scripts/cursor/hooks/stop.sh
@@ -29,12 +29,12 @@ if [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ]; then
   CONTENT=$(mnemo extract-transcript "$TRANSCRIPT_PATH" 2>/dev/null)
 
   if [ -n "$CONTENT" ]; then
-    printf '%s' "$CONTENT" | mnemo capture - --session "$CONVERSATION_ID" --project "$PROJECT" 2>/dev/null || true
+    printf '%s' "$CONTENT" | mnemo capture - --session "$CONVERSATION_ID" --project "$PROJECT" >/dev/null 2>&1 || true
   fi
 fi
 
-OBS_COUNT=$(mnemo session obs-count "$CONVERSATION_ID" 2>/dev/null)
-mnemo session end "$CONVERSATION_ID" 2>/dev/null || true
+OBS_COUNT=$(mnemo session project-obs-count "$CONVERSATION_ID" 2>/dev/null)
+mnemo session end "$CONVERSATION_ID" >/dev/null 2>&1 || true
 
 if [ "${OBS_COUNT:-0}" = "0" ]; then
   printf "\n[mnemo] warning: session ended with 0 memories saved.\n" >&2

--- a/scripts/windsurf/hooks/post-cascade-response.sh
+++ b/scripts/windsurf/hooks/post-cascade-response.sh
@@ -28,12 +28,12 @@ if [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ]; then
   CONTENT=$(mnemo extract-transcript "$TRANSCRIPT_PATH" 2>/dev/null)
 
   if [ -n "$CONTENT" ]; then
-    printf '%s' "$CONTENT" | mnemo capture - --session "$TRAJECTORY_ID" --project "$PROJECT" 2>/dev/null || true
+    printf '%s' "$CONTENT" | mnemo capture - --session "$TRAJECTORY_ID" --project "$PROJECT" >/dev/null 2>&1 || true
   fi
 fi
 
-OBS_COUNT=$(mnemo session obs-count "$TRAJECTORY_ID" 2>/dev/null)
-mnemo session end "$TRAJECTORY_ID" 2>/dev/null || true
+OBS_COUNT=$(mnemo session project-obs-count "$TRAJECTORY_ID" 2>/dev/null)
+mnemo session end "$TRAJECTORY_ID" >/dev/null 2>&1 || true
 
 if [ "${OBS_COUNT:-0}" = "0" ]; then
   printf "\n[mnemo] warning: session ended with 0 memories saved.\n" >&2

--- a/scripts/windsurf/hooks/pre-user-prompt.sh
+++ b/scripts/windsurf/hooks/pre-user-prompt.sh
@@ -28,7 +28,7 @@ IS_KNOWN=$(mnemo session exists "$TRAJECTORY_ID" 2>/dev/null)
 [ "$IS_KNOWN" = "true" ] && exit 0
 
 # New conversation — register session and emit general context
-mnemo session start "$TRAJECTORY_ID" --project "$PROJECT" --dir "$WORKSPACE" 2>/dev/null || true
+mnemo session start "$TRAJECTORY_ID" --project "$PROJECT" --dir "$WORKSPACE" >/dev/null 2>&1 || true
 printf "\n[mnemo] New session started (project: %s)\n" "$PROJECT"
 
 CONTEXT=$(mnemo context "$PROJECT" 2>/dev/null)


### PR DESCRIPTION
Closes #59.

Silences hook-internal mnemo writes so agents do not receive session/save output as conversation context. Also counts project-level memory activity for stop warnings. Validated with tests, lint, install checks, plugin validation, and MCP smoke tests.