### PR TITLE
feat: add agent spec registry

### DIFF
--- a/internal/agentinit/check.go
+++ b/internal/agentinit/check.go
@@ -21,102 +21,63 @@ type Check struct {
 
 // Label returns the display name owned by agent.
 func Label(agent string) string {
-	switch agent {
-	case "claudecode":
-		return claudeCodeLabel()
-	case "cursor":
-		return cursorLabel()
-	case "windsurf":
-		return windsurfLabel()
-	case "codex":
-		return codexLabel()
-	case "opencode":
-		return openCodeLabel()
-	default:
-		return strings.ToUpper(agent[:1]) + agent[1:]
+	if spec, ok := Spec(agent); ok {
+		return spec.Label
 	}
+	if agent == "" {
+		return ""
+	}
+	return strings.ToUpper(agent[:1]) + agent[1:]
 }
 
 // Detected reports whether agent's user-scope directory exists under home.
 func Detected(home, agent string) bool {
-	for _, path := range detectionPaths(home, agent) {
-		if pathExists(path) {
-			return true
-		}
+	spec, ok := Spec(agent)
+	if !ok || spec.Detect == nil {
+		return false
 	}
-	return false
-}
-
-func detectionPaths(home, agent string) []string {
-	switch agent {
-	case "claudecode":
-		return claudeCodeDetectionPaths(home)
-	case "cursor":
-		return cursorDetectionPaths(home)
-	case "windsurf":
-		return windsurfDetectionPaths(home)
-	case "codex":
-		return codexDetectionPaths(home)
-	case "opencode":
-		return openCodeDetectionPaths(home)
-	default:
-		return nil
-	}
+	return spec.Detect(home)
 }
 
 // CheckInstructions reports whether agent's global instructions look installed.
 func CheckInstructions(home, agent string) Check {
-	switch agent {
-	case "claudecode":
-		return claudeCodeCheckInstructions(home)
-	case "cursor":
-		return cursorCheckInstructions(home)
-	case "windsurf":
-		return windsurfCheckInstructions(home)
-	case "codex":
-		return codexCheckInstructions(home)
-	case "opencode":
-		return openCodeCheckInstructions(home)
-	default:
+	spec, ok := Spec(agent)
+	if !ok {
 		return Check{ID: "global_instructions." + agent, Status: "error", Severity: "error", Message: fmt.Sprintf("unknown agent %q", agent)}
 	}
+	instruction, ok := globalInstructionSpec(spec)
+	if !ok || instruction.Check == nil {
+		return Check{ID: "global_instructions." + agent, Status: "error", Severity: "error", Message: fmt.Sprintf("agent %q has no global instruction check", agent)}
+	}
+	return instruction.Check(home)
 }
 
 // CheckMCP reports whether agent's MCP config contains the mnemo server.
 func CheckMCP(home, agent string) Check {
-	switch agent {
-	case "claudecode":
-		return claudeCodeCheckMCP(home)
-	case "cursor":
-		return cursorCheckMCP(home)
-	case "windsurf":
-		return windsurfCheckMCP(home)
-	case "codex":
-		return codexCheckMCP(home)
-	case "opencode":
-		return openCodeCheckMCP(home)
-	default:
+	spec, ok := Spec(agent)
+	if !ok || spec.MCP.Check == nil {
 		return checkError(agent, "mcp_config."+agent, "unknown agent", "")
 	}
+	return spec.MCP.Check(home)
 }
 
 // CheckRuntime reports whether agent's runtime files (hooks/plugin) are present.
 // A zero Check means the agent has no runtime surface to report.
 func CheckRuntime(home, agent string) Check {
-	switch agent {
-	case "claudecode":
-		return claudeCodeCheckRuntime(home)
-	case "cursor":
-		return cursorCheckRuntime(home)
-	case "windsurf":
-		return windsurfCheckRuntime(home)
-	case "codex":
-		return codexCheckRuntime(home)
-	case "opencode":
-		return openCodeCheckRuntime(home)
-	default:
+	spec, ok := Spec(agent)
+	if !ok {
 		return Check{}
 	}
+	for _, hook := range spec.Hooks {
+		if hook.Check == nil {
+			continue
+		}
+		check := hook.Check(home)
+		if check.ID != "" {
+			return check
+		}
+	}
+	return Check{}
 }
 
 func checkInstructionFile(agent, path string, requireMarkers bool) Check {

--- a/internal/agentinit/global.go
+++ b/internal/agentinit/global.go
@@ -6,7 +6,7 @@ import (
 
 // SupportedAgents is the canonical set of agent IDs accepted by mnemo init and
 // the installer helpers. Keep this list stable for scripts and docs.
-var SupportedAgents = []string{"claudecode", "cursor", "windsurf", "codex", "opencode"}
+var SupportedAgents = agentSpecIDs(agentSpecs)
 
 const (
 	AgentClaudeCode = "claudecode"
@@ -22,67 +22,50 @@ func ExpandAgents(agent string) ([]string, error) {
 	if agent == "all" {
 		return append([]string(nil), SupportedAgents...), nil
 	}
-	for _, a := range SupportedAgents {
-		if agent == a {
-			return []string{agent}, nil
-		}
+	if _, ok := Spec(agent); ok {
+		return []string{agent}, nil
 	}
-	return nil, fmt.Errorf("unknown agent %q — valid: claudecode | cursor | windsurf | codex | opencode | all", agent)
+	return nil, fmt.Errorf("unknown agent %q — valid: %s", agent, validAgentList())
 }
 
 // GlobalInstructionPath returns the user-scope instruction path used by an agent.
 func GlobalInstructionPath(home, agent string) (string, error) {
-	switch agent {
-	case "claudecode":
-		return claudeCodeInstructionPath(home), nil
-	case "cursor":
-		return cursorInstructionPath(home), nil
-	case "windsurf":
-		return windsurfInstructionPath(home), nil
-	case "codex":
-		return codexInstructionPath(home), nil
-	case "opencode":
-		return openCodeInstructionPath(home), nil
-	default:
-		return "", fmt.Errorf("unknown agent %q", agent)
+	spec, err := lookupAgentSpec(agent)
+	if err != nil {
+		return "", err
 	}
+	instruction, ok := globalInstructionSpec(spec)
+	if !ok || instruction.Path == nil {
+		return "", fmt.Errorf("agent %q has no global instruction path", agent)
+	}
+	return instruction.Path(home), nil
 }
 
 // InstallGlobalInstructions writes the short, conditional mnemo instructions to
 // an agent's global instruction surface. The block is conditional on a valid
 // project .mnemo marker so a global install does not activate mnemo everywhere.
 func InstallGlobalInstructions(home, agent string) (string, error) {
-	switch agent {
-	case "claudecode":
-		return claudeCodeInstallInstructions(home)
-	case "cursor":
-		return cursorInstallInstructions(home)
-	case "windsurf":
-		return windsurfInstallInstructions(home)
-	case "codex":
-		return codexInstallInstructions(home)
-	case "opencode":
-		return openCodeInstallInstructions(home)
-	default:
-		return "", fmt.Errorf("unknown agent %q", agent)
+	spec, err := lookupAgentSpec(agent)
+	if err != nil {
+		return "", err
 	}
+	instruction, ok := globalInstructionSpec(spec)
+	if !ok || instruction.Install == nil {
+		return "", fmt.Errorf("agent %q has no global instruction installer", agent)
+	}
+	return instruction.Install(home)
 }
 
 // RemoveGlobalInstructions removes mnemo's global instruction surface for an
 // agent while preserving user content outside the managed mnemo section.
 func RemoveGlobalInstructions(home, agent string) (string, bool, error) {
-	switch agent {
-	case "claudecode":
-		return claudeCodeRemoveInstructions(home)
-	case "cursor":
-		return cursorRemoveInstructions(home)
-	case "windsurf":
-		return windsurfRemoveInstructions(home)
-	case "codex":
-		return codexRemoveInstructions(home)
-	case "opencode":
-		return openCodeRemoveInstructions(home)
-	default:
-		return "", false, fmt.Errorf("unknown agent %q", agent)
+	spec, err := lookupAgentSpec(agent)
+	if err != nil {
+		return "", false, err
 	}
+	instruction, ok := globalInstructionSpec(spec)
+	if !ok || instruction.Remove == nil {
+		return "", false, fmt.Errorf("agent %q has no global instruction remover", agent)
+	}
+	return instruction.Remove(home)
 }

--- a/internal/agentinit/project_instructions.go
+++ b/internal/agentinit/project_instructions.go
@@ -18,30 +18,56 @@ func InstallProjectInstructions(root, agent string) ([]string, error) {
 	}
 	updated = append(updated, agentsPath)
 
-	switch agent {
-	case "claudecode":
-		claudePath := filepath.Join(root, "CLAUDE.md")
-		if err := AppendClaudeSection(claudePath, templates.ClaudeCode); err != nil {
-			return nil, fmt.Errorf("CLAUDE.md: %w", err)
-		}
-		updated = append(updated, claudePath)
-	case "cursor":
-		cursorPath := filepath.Join(root, ".cursor", "rules", "mnemo.mdc")
-		if err := WriteFile(cursorPath, []byte(templates.Cursor)); err != nil {
-			return nil, fmt.Errorf(".cursor/rules/mnemo.mdc: %w", err)
-		}
-		updated = append(updated, cursorPath)
-	case "windsurf":
-		windsurfPath := filepath.Join(root, ".windsurf", "rules", "mnemo.md")
-		if err := AppendSection(windsurfPath, templates.Windsurf); err != nil {
-			return nil, fmt.Errorf(".windsurf/rules/mnemo.md: %w", err)
-		}
-		updated = append(updated, windsurfPath)
-	case "codex", "opencode":
-		// AGENTS.md covers codex and opencode project authority.
-	default:
+	spec, ok := Spec(agent)
+	if !ok {
 		return nil, fmt.Errorf("unsupported agent %q for project instructions", agent)
+	}
+	for _, instruction := range projectInstructionSpecs(spec) {
+		if instruction.Install == nil {
+			return nil, fmt.Errorf("agent %q has an incomplete project instruction spec", agent)
+		}
+		path, err := instruction.Install(root)
+		if err != nil {
+			return nil, err
+		}
+		updated = append(updated, path)
 	}
 
 	return updated, nil
+}
+
+func claudeCodeProjectInstructionPath(root string) string {
+	return filepath.Join(root, "CLAUDE.md")
+}
+
+func claudeCodeInstallProjectInstructions(root string) (string, error) {
+	path := claudeCodeProjectInstructionPath(root)
+	if err := AppendClaudeSection(path, templates.ClaudeCode); err != nil {
+		return "", fmt.Errorf("CLAUDE.md: %w", err)
+	}
+	return path, nil
+}
+
+func cursorProjectInstructionPath(root string) string {
+	return filepath.Join(root, ".cursor", "rules", "mnemo.mdc")
+}
+
+func cursorInstallProjectInstructions(root string) (string, error) {
+	path := cursorProjectInstructionPath(root)
+	if err := WriteFile(path, []byte(templates.Cursor)); err != nil {
+		return "", fmt.Errorf(".cursor/rules/mnemo.mdc: %w", err)
+	}
+	return path, nil
+}
+
+func windsurfProjectInstructionPath(root string) string {
+	return filepath.Join(root, ".windsurf", "rules", "mnemo.md")
+}
+
+func windsurfInstallProjectInstructions(root string) (string, error) {
+	path := windsurfProjectInstructionPath(root)
+	if err := AppendSection(path, templates.Windsurf); err != nil {
+		return "", fmt.Errorf(".windsurf/rules/mnemo.md: %w", err)
+	}
+	return path, nil
 }

--- a/internal/agentinit/setup.go
+++ b/internal/agentinit/setup.go
@@ -90,20 +90,11 @@ func Uninstall(home, agent string) ([]string, error) {
 
 // ConfigSnippets returns the config fragments owned by agent.
 func ConfigSnippets(home, mnemoBin, agent string) ([]ConfigSnippet, error) {
-	switch agent {
-	case "claudecode":
-		return claudeCodeConfigSnippets(home, mnemoBin), nil
-	case "cursor":
-		return cursorConfigSnippets(home, mnemoBin), nil
-	case "windsurf":
-		return windsurfConfigSnippets(home, mnemoBin), nil
-	case "codex":
-		return codexConfigSnippets(home, mnemoBin), nil
-	case "opencode":
-		return openCodeConfigSnippets(home, mnemoBin), nil
-	default:
+	spec, ok := Spec(agent)
+	if !ok || spec.MCP.Snippets == nil {
 		return nil, fmt.Errorf("unsupported agent %q for setup print-config", agent)
 	}
+	return spec.MCP.Snippets(home, mnemoBin), nil
 }
 
 func applyConfig(snippet ConfigSnippet) error {
@@ -132,37 +123,25 @@ func applyConfig(snippet ConfigSnippet) error {
 }
 
 func uninstallConfig(home, agent string) ([]string, error) {
-	switch agent {
-	case "claudecode":
-		return claudeCodeUninstallConfig(home)
-	case "cursor":
-		return cursorUninstallConfig(home)
-	case "windsurf":
-		return windsurfUninstallConfig(home)
-	case "codex":
-		return codexUninstallConfig(home)
-	case "opencode":
-		return openCodeUninstallConfig(home)
-	default:
+	spec, ok := Spec(agent)
+	if !ok || spec.MCP.Uninstall == nil {
 		return nil, fmt.Errorf("unsupported agent %q for setup uninstall", agent)
 	}
+	return spec.MCP.Uninstall(home)
 }
 
 func runtimeAssets(agent string) ([]assetTarget, error) {
-	switch agent {
-	case "claudecode":
-		return claudeCodeRuntimeAssets(), nil
-	case "cursor":
-		return cursorRuntimeAssets(), nil
-	case "windsurf":
-		return windsurfRuntimeAssets(), nil
-	case "codex":
-		return codexRuntimeAssets(), nil
-	case "opencode":
-		return openCodeRuntimeAssets(), nil
-	default:
+	spec, ok := Spec(agent)
+	if !ok {
 		return nil, fmt.Errorf("unsupported agent %q for setup runtime files", agent)
 	}
+	var targets []assetTarget
+	for _, hook := range spec.Hooks {
+		if hook.RuntimeAssets != nil {
+			targets = append(targets, hook.RuntimeAssets()...)
+		}
+	}
+	return targets, nil
 }
 
 func writeRuntime(home, agent string) ([]string, error) {

--- a/internal/agentinit/spec.go
+++ b/internal/agentinit/spec.go
@@ -1,0 +1,250 @@
+package agentinit
+
+import (
+	"fmt"
+	"strings"
+)
+
+// AgentSpec describes the mnemo integration surfaces owned by one agent.
+type AgentSpec struct {
+	ID           string
+	Label        string
+	Detect       func(home string) bool
+	MCP          MCPConfigSpec
+	Instructions []InstructionSpec
+	Hooks        []HookSpec
+	Supports     AgentSpecCapabilities
+}
+
+// AgentSpecCapabilities records which integration surfaces an AgentSpec supports.
+type AgentSpecCapabilities struct {
+	MCP              bool
+	MCPConditional   bool
+	Instructions     bool
+	Skills           bool
+	Hooks            bool
+	SessionLifecycle bool
+	RPC              bool
+	ACP              bool
+}
+
+// MCPConfigSpec describes an agent MCP configuration surface.
+type MCPConfigSpec struct {
+	Snippets  func(home, mnemoBin string) []ConfigSnippet
+	Uninstall func(home string) ([]string, error)
+	Check     func(home string) Check
+}
+
+// InstructionScope identifies where an instruction surface is installed.
+type InstructionScope string
+
+const (
+	InstructionScopeGlobal  InstructionScope = "global"
+	InstructionScopeProject InstructionScope = "project"
+)
+
+// InstructionSpec describes an agent instruction surface.
+type InstructionSpec struct {
+	Scope   InstructionScope
+	Path    func(home string) string
+	Install func(home string) (string, error)
+	Remove  func(home string) (string, bool, error)
+	Check   func(home string) Check
+}
+
+// HookSpec describes agent runtime assets or hook/plugin validation.
+type HookSpec struct {
+	RuntimeAssets func() []assetTarget
+	Check         func(home string) Check
+}
+
+var agentSpecs = []AgentSpec{
+	{
+		ID:     AgentClaudeCode,
+		Label:  claudeCodeLabel(),
+		Detect: detectFromPaths(claudeCodeDetectionPaths),
+		MCP: MCPConfigSpec{
+			Snippets:  claudeCodeConfigSnippets,
+			Uninstall: claudeCodeUninstallConfig,
+			Check:     claudeCodeCheckMCP,
+		},
+		Instructions: []InstructionSpec{{
+			Scope:   InstructionScopeGlobal,
+			Path:    claudeCodeInstructionPath,
+			Install: claudeCodeInstallInstructions,
+			Remove:  claudeCodeRemoveInstructions,
+			Check:   claudeCodeCheckInstructions,
+		}, {
+			Scope:   InstructionScopeProject,
+			Path:    claudeCodeProjectInstructionPath,
+			Install: claudeCodeInstallProjectInstructions,
+		}},
+		Hooks: []HookSpec{{
+			RuntimeAssets: claudeCodeRuntimeAssets,
+			Check:         claudeCodeCheckRuntime,
+		}},
+		Supports: AgentSpecCapabilities{MCP: true, Instructions: true, Skills: true, Hooks: true},
+	},
+	{
+		ID:     AgentCursor,
+		Label:  cursorLabel(),
+		Detect: detectFromPaths(cursorDetectionPaths),
+		MCP: MCPConfigSpec{
+			Snippets:  cursorConfigSnippets,
+			Uninstall: cursorUninstallConfig,
+			Check:     cursorCheckMCP,
+		},
+		Instructions: []InstructionSpec{{
+			Scope:   InstructionScopeGlobal,
+			Path:    cursorInstructionPath,
+			Install: cursorInstallInstructions,
+			Remove:  cursorRemoveInstructions,
+			Check:   cursorCheckInstructions,
+		}, {
+			Scope:   InstructionScopeProject,
+			Path:    cursorProjectInstructionPath,
+			Install: cursorInstallProjectInstructions,
+		}},
+		Hooks: []HookSpec{{
+			RuntimeAssets: cursorRuntimeAssets,
+			Check:         cursorCheckRuntime,
+		}},
+		Supports: AgentSpecCapabilities{MCP: true, Instructions: true, Hooks: true, SessionLifecycle: true},
+	},
+	{
+		ID:     AgentWindsurf,
+		Label:  windsurfLabel(),
+		Detect: detectFromPaths(windsurfDetectionPaths),
+		MCP: MCPConfigSpec{
+			Snippets:  windsurfConfigSnippets,
+			Uninstall: windsurfUninstallConfig,
+			Check:     windsurfCheckMCP,
+		},
+		Instructions: []InstructionSpec{{
+			Scope:   InstructionScopeGlobal,
+			Path:    windsurfInstructionPath,
+			Install: windsurfInstallInstructions,
+			Remove:  windsurfRemoveInstructions,
+			Check:   windsurfCheckInstructions,
+		}, {
+			Scope:   InstructionScopeProject,
+			Path:    windsurfProjectInstructionPath,
+			Install: windsurfInstallProjectInstructions,
+		}},
+		Hooks: []HookSpec{{
+			RuntimeAssets: windsurfRuntimeAssets,
+			Check:         windsurfCheckRuntime,
+		}},
+		Supports: AgentSpecCapabilities{MCP: true, Instructions: true, Skills: true, Hooks: true, SessionLifecycle: true},
+	},
+	{
+		ID:     AgentCodex,
+		Label:  codexLabel(),
+		Detect: detectFromPaths(codexDetectionPaths),
+		MCP: MCPConfigSpec{
+			Snippets:  codexConfigSnippets,
+			Uninstall: codexUninstallConfig,
+			Check:     codexCheckMCP,
+		},
+		Instructions: []InstructionSpec{{
+			Scope:   InstructionScopeGlobal,
+			Path:    codexInstructionPath,
+			Install: codexInstallInstructions,
+			Remove:  codexRemoveInstructions,
+			Check:   codexCheckInstructions,
+		}},
+		Hooks: []HookSpec{{
+			RuntimeAssets: codexRuntimeAssets,
+			Check:         codexCheckRuntime,
+		}},
+		Supports: AgentSpecCapabilities{MCP: true, Instructions: true, Hooks: true, SessionLifecycle: true},
+	},
+	{
+		ID:     AgentOpenCode,
+		Label:  openCodeLabel(),
+		Detect: detectFromPaths(openCodeDetectionPaths),
+		MCP: MCPConfigSpec{
+			Snippets:  openCodeConfigSnippets,
+			Uninstall: openCodeUninstallConfig,
+			Check:     openCodeCheckMCP,
+		},
+		Instructions: []InstructionSpec{{
+			Scope:   InstructionScopeGlobal,
+			Path:    openCodeInstructionPath,
+			Install: openCodeInstallInstructions,
+			Remove:  openCodeRemoveInstructions,
+			Check:   openCodeCheckInstructions,
+		}},
+		Hooks: []HookSpec{{
+			RuntimeAssets: openCodeRuntimeAssets,
+			Check:         openCodeCheckRuntime,
+		}},
+		Supports: AgentSpecCapabilities{MCP: true, Instructions: true, Hooks: true},
+	},
+}
+
+var agentSpecsByID = indexAgentSpecs(agentSpecs)
+
+// Spec returns the AgentSpec for agent.
+func Spec(agent string) (AgentSpec, bool) {
+	spec, ok := agentSpecsByID[agent]
+	return spec, ok
+}
+
+func lookupAgentSpec(agent string) (AgentSpec, error) {
+	spec, ok := Spec(agent)
+	if !ok {
+		return AgentSpec{}, fmt.Errorf("unknown agent %q", agent)
+	}
+	return spec, nil
+}
+
+func globalInstructionSpec(spec AgentSpec) (InstructionSpec, bool) {
+	for _, instruction := range spec.Instructions {
+		if instruction.Scope == InstructionScopeGlobal {
+			return instruction, true
+		}
+	}
+	return InstructionSpec{}, false
+}
+
+func projectInstructionSpecs(spec AgentSpec) []InstructionSpec {
+	var instructions []InstructionSpec
+	for _, instruction := range spec.Instructions {
+		if instruction.Scope == InstructionScopeProject {
+			instructions = append(instructions, instruction)
+		}
+	}
+	return instructions
+}
+
+func agentSpecIDs(specs []AgentSpec) []string {
+	ids := make([]string, 0, len(specs))
+	for _, spec := range specs {
+		ids = append(ids, spec.ID)
+	}
+	return ids
+}
+
+func indexAgentSpecs(specs []AgentSpec) map[string]AgentSpec {
+	indexed := make(map[string]AgentSpec, len(specs))
+	for _, spec := range specs {
+		indexed[spec.ID] = spec
+	}
+	return indexed
+}
+
+func validAgentList() string {
+	return strings.Join(append(append([]string(nil), SupportedAgents...), "all"), " | ")
+}
+
+func detectFromPaths(paths func(home string) []string) func(home string) bool {
+	return func(home string) bool {
+		for _, path := range paths(home) {
+			if pathExists(path) {
+				return true
+			}
+		}
+		return false
+	}
+}

--- a/internal/agentinit/spec_test.go
+++ b/internal/agentinit/spec_test.go
@@ -1,0 +1,39 @@
+package agentinit
+
+import "testing"
+
+func TestAgentSpecsDefineSupportedAgents(t *testing.T) {
+	seen := map[string]bool{}
+	for _, id := range SupportedAgents {
+		spec, ok := Spec(id)
+		if !ok {
+			t.Fatalf("missing spec for supported agent %q", id)
+		}
+		if seen[id] {
+			t.Fatalf("duplicate supported agent %q", id)
+		}
+		seen[id] = true
+		if spec.ID != id {
+			t.Fatalf("spec ID = %q, want %q", spec.ID, id)
+		}
+		if spec.Label == "" {
+			t.Fatalf("%s: missing label", id)
+		}
+		if spec.Detect == nil {
+			t.Fatalf("%s: missing detection", id)
+		}
+		if spec.Supports.MCP && (spec.MCP.Snippets == nil || spec.MCP.Uninstall == nil || spec.MCP.Check == nil) {
+			t.Fatalf("%s: MCP capability missing contract functions", id)
+		}
+		if spec.Supports.Instructions && len(spec.Instructions) == 0 {
+			t.Fatalf("%s: instructions capability missing specs", id)
+		}
+	}
+	if len(seen) != len(agentSpecs) {
+		t.Fatalf("supported agents = %d, specs = %d", len(seen), len(agentSpecs))
+	}
+}
+
+func TestAgentSpecCapabilitiesNameBelongsToAgentSpec(t *testing.T) {
+	var _ AgentSpecCapabilities
+}


### PR DESCRIPTION
## Summary
- add an AgentSpec registry for supported agents
- route setup, checks, runtime assets, and instructions through the registry

## Validation
- go test ./...
- go build ./...
- golangci-lint run ./...
- setup status/refresh/uninstall smoke tests