### PR TITLE
feat: add fx agent support

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -9,7 +9,7 @@
 </p>
 
 <p align="center">
-  Dale a Claude Code, Codex, Cursor, Windsurf y OpenCode una memoria local compartida que sobrevive a sesiones, compactaciones y cambios de agente.
+  Dale a Claude Code, Codex, Cursor, Windsurf, OpenCode y fx una memoria local compartida que sobrevive a sesiones, compactaciones y cambios de agente.
 </p>
 
 <p align="center">
@@ -81,7 +81,7 @@ mnemo search "SQLite" --project miapp
 | Problema | mnemo aporta |
 |---|---|
 | Los agentes olvidan decisiones entre sesiones | Memoria persistente de proyecto en `~/.mnemo/memory.db` |
-| Cada agente mantiene una memoria distinta | Una capa compartida para Claude Code, Codex, Cursor, Windsurf y OpenCode |
+| Cada agente mantiene una memoria distinta | Una capa compartida para Claude Code, Codex, Cursor, Windsurf, OpenCode y fx |
 | Los archivos markdown de memoria se desordenan | Observaciones estructuradas, tags, topic keys y estados de revisión |
 | Los hooks globales pueden ser peligrosos | Activación opt-in por proyecto mediante `.mnemo`; el resto se ignora |
 | El setup puede fallar en silencio | `mnemo doctor` y `mnemo setup status` explican qué está configurado |
@@ -110,6 +110,7 @@ mnemo search "SQLite" --project miapp
 | Cursor | ✅ | ✅ | ✅ | ✅ | Soportado |
 | Windsurf | ✅ | ✅ | ✅ | ✅ | Soportado |
 | OpenCode | ✅ | ✅ | ✅ | ✅ | Soportado |
+| fx | ✅ | n/a | ✅ | ✅ vía ruta canónica | Soportado |
 
 El setup global se instala una vez. La activación del proyecto sigue siendo local y explícita:
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 </p>
 
 <p align="center">
-  Give Claude Code, Codex, Cursor, Windsurf and OpenCode one shared local memory that survives sessions, compactions and agent switches.
+  Give Claude Code, Codex, Cursor, Windsurf, OpenCode and fx one shared local memory that survives sessions, compactions and agent switches.
 </p>
 
 <p align="center">
@@ -80,7 +80,7 @@ mnemo search "SQLite" --project myapp
 | Problem | mnemo gives you |
 |---|---|
 | Agents forget decisions between sessions | Durable project memory in `~/.mnemo/memory.db` |
-| Different agents keep different memories | One shared layer for Claude Code, Codex, Cursor, Windsurf and OpenCode |
+| Different agents keep different memories | One shared layer for Claude Code, Codex, Cursor, Windsurf, OpenCode and fx |
 | Markdown memory files drift or conflict | Structured observations, tags, topic keys and review states |
 | Global hooks can be risky | Project opt-in via a `.mnemo` marker; projects without it are ignored |
 | Setup breaks silently | `mnemo doctor` and `mnemo setup status` explain exactly what is configured |
@@ -109,6 +109,7 @@ mnemo search "SQLite" --project myapp
 | Cursor | ✅ | ✅ | ✅ | ✅ | Supported |
 | Windsurf | ✅ | ✅ | ✅ | ✅ | Supported |
 | OpenCode | ✅ | ✅ | ✅ | ✅ | Supported |
+| fx | ✅ | n/a | ✅ | ✅ via canonical path | Supported |
 
 Global setup is installed once. Project activation stays local and opt-in:
 

--- a/cmd/mnemo/setup_print_config_test.go
+++ b/cmd/mnemo/setup_print_config_test.go
@@ -88,8 +88,7 @@ func TestBuildSetupConfigSnippetsForAll(t *testing.T) {
 	if err != nil {
 		t.Fatalf("build snippets: %v", err)
 	}
-	if len(snippets) != 8 {
-		t.Fatalf("snippets = %d, want 8", len(snippets))
+	if len(snippets) != 9 {
+		t.Fatalf("snippets = %d, want 9", len(snippets))
 	}
 }
-

--- a/cmd/mnemo/setup_status_test.go
+++ b/cmd/mnemo/setup_status_test.go
@@ -81,6 +81,23 @@ func TestBuildSetupStatusReportReportsMissingAgent(t *testing.T) {
 	}
 }
 
+func TestBuildSetupStatusReportReportsConfiguredFx(t *testing.T) {
+	home := t.TempDir()
+
+	if _, err := agentinit.Refresh(home, "/bin/mnemo", "fx"); err != nil {
+		t.Fatalf("refresh fx: %v", err)
+	}
+
+	report := buildSetupStatusReport(setupStatusOptions{Agent: "fx", Home: home})
+	if report.Status != "ok" {
+		t.Fatalf("status = %q, want ok", report.Status)
+	}
+	row := report.Rows[0]
+	if row.Agent != "fx" || row.Detected != "yes" || row.MCP != "yes" || row.Hooks != "n/a" || row.Instructions != "yes" {
+		t.Fatalf("unexpected row: %+v", row)
+	}
+}
+
 func TestBuildSetupStatusReportChecksClaudeCodePluginHooks(t *testing.T) {
 	for name, registry := range map[string]string{
 		"array":  `{"plugins":{"mnemo@mnemo":[{"installPath":"%s"}]}}`,

--- a/cmd/mnemo/templates/usage.txt
+++ b/cmd/mnemo/templates/usage.txt
@@ -40,6 +40,7 @@ Agents for init / install-instructions:
   --agent=windsurf     Windsurf global rule / .mnemo activation
   --agent=codex        Codex global AGENTS.md instructions / .mnemo activation
   --agent=opencode     OpenCode global AGENTS.md instructions / .mnemo activation
+  --agent=fx           fx global AGENTS.md instructions / .mnemo activation
   --agent=all          All agents
   --path=DIR           Target project directory for init/doctor (default: current directory)
 
@@ -55,7 +56,7 @@ Setup status options:
   --home=DIR           Override home directory for global agent checks
 
 Setup print-config options:
-  AGENT                claudecode | cursor | windsurf | codex | opencode | all
+  AGENT                claudecode | cursor | windsurf | codex | opencode | fx | all
   --home=DIR           Use DIR when rendering user-level config paths
   --mnemo-bin=PATH     Use PATH as the mnemo binary in snippets
 

--- a/docs/AGENT_INTEGRATION.md
+++ b/docs/AGENT_INTEGRATION.md
@@ -1,16 +1,16 @@
 # Agent integration
 
-mnemo supports Claude Code, Cursor, Windsurf, Codex and OpenCode through global setup surfaces plus project-local activation.
+mnemo supports Claude Code, Cursor, Windsurf, Codex, OpenCode and fx through global setup surfaces plus project-local activation.
 
 ## Global surfaces
 
-| | Claude Code | Cursor | Windsurf | Codex | OpenCode |
-|---|---|---|---|---|---|
-| **Hook scripts** | via plugin or n/a via `install.sh` | `~/.cursor/hooks/` | `~/.codeium/windsurf/hooks/` | `~/.codex/hooks/` | `~/.config/opencode/plugins/` |
-| **MCP** | `~/.claude/.mcp.json` | `~/.cursor/mcp.json` | `~/.codeium/windsurf/mcp_config.json` | `~/.codex/config.toml` | `~/.config/opencode/opencode.json` |
-| **Hook config** | plugin hooks check `.mnemo` | `~/.cursor/hooks.json` | `~/.codeium/windsurf/hooks.json` | `~/.codex/hooks.json` checks `.mnemo` | global plugin checks `.mnemo` |
-| **Global protocol** | `~/.claude/CLAUDE.md` | `~/.cursor/rules/mnemo.mdc` | `~/.codeium/windsurf/memories/global_rules.md` | `~/.codex/AGENTS.md` | `~/.config/opencode/AGENTS.md` |
-| **Skill access** | symlinks under `~/.claude/skills/` | canonical `~/.agents/skills/` | symlinks under `~/.codeium/windsurf/skills/` | canonical `~/.agents/skills/` | canonical `~/.agents/skills/` |
+| | Claude Code | Cursor | Windsurf | Codex | OpenCode | fx |
+|---|---|---|---|---|---|---|
+| **Hook scripts** | via plugin or n/a via `install.sh` | `~/.cursor/hooks/` | `~/.codeium/windsurf/hooks/` | `~/.codex/hooks/` | `~/.config/opencode/plugins/` | n/a |
+| **MCP** | `~/.claude/.mcp.json` | `~/.cursor/mcp.json` | `~/.codeium/windsurf/mcp_config.json` | `~/.codex/config.toml` | `~/.config/opencode/opencode.json` | `~/.fx/mcp.json` |
+| **Hook config** | plugin hooks check `.mnemo` | `~/.cursor/hooks.json` | `~/.codeium/windsurf/hooks.json` | `~/.codex/hooks.json` checks `.mnemo` | global plugin checks `.mnemo` | n/a |
+| **Global protocol** | `~/.claude/CLAUDE.md` | `~/.cursor/rules/mnemo.mdc` | `~/.codeium/windsurf/memories/global_rules.md` | `~/.codex/AGENTS.md` | `~/.config/opencode/AGENTS.md` | `~/.fx/AGENTS.md` |
+| **Skill access** | symlinks under `~/.claude/skills/` | canonical `~/.agents/skills/` | symlinks under `~/.codeium/windsurf/skills/` | canonical `~/.agents/skills/` | canonical `~/.agents/skills/` | canonical `~/.agents/skills/` |
 
 All supported agents use global hook/configuration surfaces where available. Their global instructions are conditional: if `.mnemo` is missing or invalid, agents skip mnemo entirely and do not create fallback memory files.
 
@@ -86,5 +86,11 @@ The `.mnemo` file at the project root activates mnemo for a project:
 | `session.created` | New session created | Registers session with mnemo |
 | `experimental.chat.system.transform` | First prompt of a conversation | Injects memory context into the system prompt |
 | `experimental.session.compacting` | Context compaction | Refreshes context from mnemo, re-arms context injection |
+
+### fx
+
+fx support uses MCP, global `AGENTS.md` instructions and the canonical `mnemo-memory` skill under `~/.agents/skills/`. It does not install hooks because fx does not expose a supported hook surface for mnemo to rely on.
+
+fx also has a native `memory` tool backed by `~/.fx/memories.json`. The mnemo-managed `~/.fx/AGENTS.md` block explicitly disables that native memory surface for repository/project memory whenever a valid `.mnemo` marker exists; agents must use mnemo MCP tools instead.
 
 On session start, every hook resolves the Git root and reads the project identifier from `.mnemo`. This keeps the same identity regardless of which subdirectory the editor opens.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -47,6 +47,7 @@ Agents for `mnemo init`, `mnemo install-instructions` and setup commands:
 --agent=windsurf     Windsurf global rule / .mnemo activation
 --agent=codex        Codex global AGENTS.md instructions / .mnemo activation
 --agent=opencode     OpenCode global AGENTS.md instructions / .mnemo activation
+--agent=fx           fx global AGENTS.md instructions / .mnemo activation
 --agent=all          All agents
 ```
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -9,7 +9,7 @@ Global hooks are intentionally inert outside projects with a valid `.mnemo` mark
 
 ## Prerequisite: binary in PATH
 
-The `mnemo` binary must be in your `PATH` before any agent integration will work. This applies to Claude Code, Cursor, Windsurf, Codex and OpenCode regardless of how the integration is installed.
+The `mnemo` binary must be in your `PATH` before any agent integration will work. This applies to Claude Code, Cursor, Windsurf, Codex, OpenCode and fx regardless of how the integration is installed.
 
 The hooks that fire on session start, session end and passive capture call `mnemo` directly. The MCP server is also the `mnemo` binary. Without it in PATH, hooks and MCP cannot start.
 
@@ -26,6 +26,7 @@ Explicit targets are supported:
 ```bash
 curl -sSf https://raw.githubusercontent.com/jmeiracorbal/mnemo/main/install.sh | bash -s -- --agent=codex
 curl -sSf https://raw.githubusercontent.com/jmeiracorbal/mnemo/main/install.sh | bash -s -- --agent=opencode
+curl -sSf https://raw.githubusercontent.com/jmeiracorbal/mnemo/main/install.sh | bash -s -- --agent=fx
 curl -sSf https://raw.githubusercontent.com/jmeiracorbal/mnemo/main/install.sh | bash -s -- --agent=all
 ```
 
@@ -83,7 +84,7 @@ mnemo --version
 From the project root:
 
 ```bash
-mnemo init --agent=claudecode   # or cursor, windsurf, codex, opencode, all
+mnemo init --agent=claudecode   # or cursor, windsurf, codex, opencode, fx, all
 # optional: --no-project-rules for .mnemo marker only
 ```
 
@@ -91,7 +92,7 @@ This creates a `.mnemo` marker and records the selected agent. Agent hooks, MCP 
 
 ## Optional skills
 
-`install.sh` and `mnemo setup refresh` embed the `mnemo-memory` skill at `~/.agents/skills/mnemo-memory/` and link Claude Code and Windsurf to it. You normally do not need a separate skill install step.
+`install.sh` and `mnemo setup refresh` embed the `mnemo-memory` skill at `~/.agents/skills/mnemo-memory/` and link Claude Code and Windsurf to it. fx, Codex, Cursor and OpenCode use the canonical `~/.agents/skills/` path directly. You normally do not need a separate skill install step.
 
 If you prefer the skills CLI or need to refresh manually:
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -45,6 +45,7 @@ grep "mnemo:start" ~/.codex/AGENTS.md ~/.claude/CLAUDE.md 2>/dev/null
 head -3 ~/.cursor/rules/mnemo.mdc   # should have: alwaysApply: true
 grep "mnemo:start" ~/.codeium/windsurf/memories/global_rules.md 2>/dev/null
 grep "mnemo:start" ~/.config/opencode/AGENTS.md 2>/dev/null
+grep "mnemo:start" ~/.fx/AGENTS.md 2>/dev/null
 ```
 
 Global hooks/config:
@@ -52,6 +53,7 @@ Global hooks/config:
 ```bash
 grep "mnemo" ~/.cursor/hooks.json ~/.codeium/windsurf/hooks.json ~/.codex/hooks.json 2>/dev/null
 ls ~/.config/opencode/plugins/mnemo.ts ~/.config/opencode/plugins/mnemo-protocol.md
+grep "mnemo" ~/.fx/mcp.json 2>/dev/null
 ```
 
 Canonical Agent Skill and symlinks:
@@ -62,7 +64,7 @@ ls -l ~/.claude/skills/mnemo-memory \
   ~/.codeium/windsurf/skills/mnemo-memory
 ```
 
-Only symlinks for selected agent-specific consumers are expected to exist. Codex and Cursor use the canonical `.agents/skills` path directly.
+Only symlinks for selected agent-specific consumers are expected to exist. Codex, Cursor, OpenCode and fx use the canonical `.agents/skills` path directly.
 
 ## Claude Code plugin validation
 

--- a/install.sh
+++ b/install.sh
@@ -8,6 +8,7 @@
 #   bash -s -- --agent=windsurf
 #   bash -s -- --agent=codex
 #   bash -s -- --agent=opencode
+#   bash -s -- --agent=fx
 #   bash -s -- --agent=all
 #
 # Environment overrides:
@@ -202,6 +203,9 @@ agent_detected() {
     opencode)
       command -v opencode >/dev/null 2>&1 || [ -d "$HOME/.config/opencode" ]
       ;;
+    fx)
+      command -v fx >/dev/null 2>&1 || [ -d "$HOME/.fx" ]
+      ;;
     *) return 1 ;;
   esac
 }
@@ -209,7 +213,7 @@ agent_detected() {
 detect_agents() {
   local found=""
   local agent
-  for agent in claudecode cursor windsurf codex opencode; do
+  for agent in claudecode cursor windsurf codex opencode fx; do
     if agent_detected "$agent"; then
       found="$found $agent"
     fi
@@ -273,17 +277,17 @@ main() {
       ok "Done. Run 'mnemo init --agent=all' in projects that should use mnemo."
       ;;
     all)
-      for selected in claudecode cursor windsurf codex opencode; do
+      for selected in claudecode cursor windsurf codex opencode fx; do
         setup_agent "$selected" "$mnemo_bin"
       done
       ok "Done. Run 'mnemo init --agent=all' in projects that should use mnemo."
       ;;
-    claudecode|cursor|windsurf|codex|opencode)
+    claudecode|cursor|windsurf|codex|opencode|fx)
       setup_agent "$AGENT" "$mnemo_bin"
       ok "Done. Run 'mnemo init --agent=${AGENT}' in projects that should use mnemo."
       ;;
     *)
-      err "Unknown agent: ${AGENT}. Valid options: auto | claudecode | cursor | windsurf | codex | opencode | all"
+      err "Unknown agent: ${AGENT}. Valid options: auto | claudecode | cursor | windsurf | codex | opencode | fx | all"
       ;;
   esac
 }

--- a/internal/agentinit/fx.go
+++ b/internal/agentinit/fx.go
@@ -1,0 +1,74 @@
+package agentinit
+
+import (
+	"path/filepath"
+
+	"github.com/jmeiracorbal/mnemo/templates"
+)
+
+func fxLabel() string { return "fx" }
+
+func fxDetectionPaths(home string) []string {
+	return []string{filepath.Join(home, ".fx")}
+}
+
+func fxInstructionPath(home string) string {
+	return filepath.Join(home, ".fx", "AGENTS.md")
+}
+
+func fxInstallInstructions(home string) (string, error) {
+	path := fxInstructionPath(home)
+	if err := AppendSection(path, templates.Global+"\n\n"+templates.Fx); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+func fxRemoveInstructions(home string) (string, bool, error) {
+	path := fxInstructionPath(home)
+	changed, err := RemoveSection(path)
+	return path, changed, err
+}
+
+func fxConfigSnippets(home, mnemoBin string) []ConfigSnippet {
+	return []ConfigSnippet{{
+		Agent:  fxLabel(),
+		Path:   filepath.Join(home, ".fx", "mcp.json"),
+		Format: "json",
+		Content: prettyJSON(map[string]any{
+			"mcp": map[string]any{
+				"mnemo": map[string]any{
+					"command": []string{mnemoBin, "mcp", "--tools=agent"},
+					"environment": map[string]string{
+						"MNEMO_AGENT":         AgentFx,
+						"MNEMO_MCP_CLIENT":    AgentFx,
+						"MNEMO_MCP_TRANSPORT": "stdio",
+					},
+				},
+			},
+		}),
+	}}
+}
+
+func fxRuntimeAssets() []assetTarget {
+	return nil
+}
+
+func fxUninstallConfig(home string) ([]string, error) {
+	path := filepath.Join(home, ".fx", "mcp.json")
+	changed, err := removeMCPServer(path, "mcp", "mnemo")
+	return appendChanged(path, changed, err)
+}
+
+func fxCheckInstructions(home string) Check {
+	return checkInstructionFile("fx", fxInstructionPath(home), true)
+}
+
+func fxCheckMCP(home string) Check {
+	path := filepath.Join(home, ".fx", "mcp.json")
+	return checkJSONMCPWithEnv(path, "mcp_config.fx", "fx", "environment", "mcp", "mnemo")
+}
+
+func fxCheckRuntime(home string) Check {
+	return Check{}
+}

--- a/internal/agentinit/global.go
+++ b/internal/agentinit/global.go
@@ -14,6 +14,7 @@ const (
 	AgentWindsurf   = "windsurf"
 	AgentCodex      = "codex"
 	AgentOpenCode   = "opencode"
+	AgentFx         = "fx"
 )
 
 // ExpandAgents resolves a single agent flag value to one or more concrete agent

--- a/internal/agentinit/global_test.go
+++ b/internal/agentinit/global_test.go
@@ -16,6 +16,7 @@ func TestInstallGlobalInstructionsWritesConditionalAgentFiles(t *testing.T) {
 		"windsurf":   filepath.Join(home, ".codeium", "windsurf", "memories", "global_rules.md"),
 		"codex":      filepath.Join(home, ".codex", "AGENTS.md"),
 		"opencode":   filepath.Join(home, ".config", "opencode", "AGENTS.md"),
+		"fx":         filepath.Join(home, ".fx", "AGENTS.md"),
 	}
 
 	for agent, wantPath := range cases {
@@ -128,6 +129,22 @@ func TestRemoveGlobalInstructionsRemovesCursorRuleFile(t *testing.T) {
 	}
 	if _, err := os.Stat(path); !os.IsNotExist(err) {
 		t.Fatalf("cursor rule file still exists or stat failed: %v", err)
+	}
+}
+
+func TestFxGlobalInstructionsDisableNativeMemory(t *testing.T) {
+	home := t.TempDir()
+	path, err := InstallGlobalInstructions(home, "fx")
+	if err != nil {
+		t.Fatalf("install fx global instructions: %v", err)
+	}
+
+	content := string(mustReadFile(t, path))
+	if !strings.Contains(content, "FX NATIVE MEMORY") ||
+		!strings.Contains(content, "`memory` tool") ||
+		!strings.Contains(content, "~/.fx/memories.json") ||
+		!strings.Contains(content, "Do not call the native `memory` tool") {
+		t.Fatalf("fx instructions do not disable native memory:\n%s", content)
 	}
 }
 

--- a/internal/agentinit/setup_test.go
+++ b/internal/agentinit/setup_test.go
@@ -32,8 +32,8 @@ func TestConfigSnippetsForAll(t *testing.T) {
 		}
 		snippets = append(snippets, agentSnippets...)
 	}
-	if len(snippets) != 8 {
-		t.Fatalf("snippets = %d, want 8", len(snippets))
+	if len(snippets) != 9 {
+		t.Fatalf("snippets = %d, want 9", len(snippets))
 	}
 }
 
@@ -82,6 +82,49 @@ func TestOpenCodeConfigUsesCurrentMCPServersShapeAndRemovesLegacyEntry(t *testin
 	}
 	if !strings.Contains(content, `"other"`) {
 		t.Fatalf("unrelated OpenCode MCP config was not preserved:\n%s", content)
+	}
+}
+
+func TestFxConfigUsesNativeMCPShape(t *testing.T) {
+	home := t.TempDir()
+	configPath := filepath.Join(home, ".fx", "mcp.json")
+	writeTestFile(t, configPath, `{
+  "mcp": {
+    "other": {"command": ["/bin/other"]}
+  }
+}`)
+
+	if _, err := Refresh(home, "/bin/mnemo", "fx"); err != nil {
+		t.Fatalf("refresh fx: %v", err)
+	}
+
+	content := readTestFile(t, configPath)
+	if !strings.Contains(content, `"mnemo"`) || !strings.Contains(content, `"command"`) || !strings.Contains(content, `"MNEMO_AGENT": "fx"`) {
+		t.Fatalf("fx MCP config missing mnemo server or provenance env:\n%s", content)
+	}
+	if !strings.Contains(content, `"other"`) {
+		t.Fatalf("unrelated fx MCP config was not preserved:\n%s", content)
+	}
+}
+
+func TestFxUninstallRemovesMCPConfig(t *testing.T) {
+	home := t.TempDir()
+	if _, err := Refresh(home, "/bin/mnemo", "fx"); err != nil {
+		t.Fatalf("refresh fx: %v", err)
+	}
+
+	removed, err := Uninstall(home, "fx")
+	if err != nil {
+		t.Fatalf("uninstall fx: %v", err)
+	}
+	if len(removed) != 2 {
+		t.Fatalf("removed paths = %v, want instructions and MCP config", removed)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".fx", "AGENTS.md")); !os.IsNotExist(err) {
+		t.Fatalf("fx AGENTS.md still exists or stat failed: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".fx", "mcp.json")); !os.IsNotExist(err) {
+		t.Fatalf("fx mcp.json still exists or stat failed: %v", err)
 	}
 }
 

--- a/internal/agentinit/skill_test.go
+++ b/internal/agentinit/skill_test.go
@@ -38,6 +38,18 @@ func TestInstallGlobalSkillCopiesCanonicalFiles(t *testing.T) {
 	if !GlobalSkillInstalled(home) {
 		t.Fatal("global skill not detected after install")
 	}
+	for _, link := range []string{
+		filepath.Join(home, ".claude", "skills", globalSkillName),
+		filepath.Join(home, ".codeium", "windsurf", "skills", globalSkillName),
+	} {
+		info, err := os.Lstat(link)
+		if err != nil {
+			t.Fatalf("stat skill link %s: %v", link, err)
+		}
+		if info.Mode()&os.ModeSymlink == 0 {
+			t.Fatalf("%s is not a symlink", link)
+		}
+	}
 }
 
 func TestUpsertCodexCompactPromptFile(t *testing.T) {

--- a/internal/agentinit/spec.go
+++ b/internal/agentinit/spec.go
@@ -181,6 +181,28 @@ var agentSpecs = []AgentSpec{
 		}},
 		Supports: AgentSpecCapabilities{MCP: true, Instructions: true, Hooks: true},
 	},
+	{
+		ID:     AgentFx,
+		Label:  fxLabel(),
+		Detect: detectFromPaths(fxDetectionPaths),
+		MCP: MCPConfigSpec{
+			Snippets:  fxConfigSnippets,
+			Uninstall: fxUninstallConfig,
+			Check:     fxCheckMCP,
+		},
+		Instructions: []InstructionSpec{{
+			Scope:   InstructionScopeGlobal,
+			Path:    fxInstructionPath,
+			Install: fxInstallInstructions,
+			Remove:  fxRemoveInstructions,
+			Check:   fxCheckInstructions,
+		}},
+		Hooks: []HookSpec{{
+			RuntimeAssets: fxRuntimeAssets,
+			Check:         fxCheckRuntime,
+		}},
+		Supports: AgentSpecCapabilities{MCP: true, Instructions: true, Skills: true},
+	},
 }
 
 var agentSpecsByID = indexAgentSpecs(agentSpecs)

--- a/internal/mcp/diagnostics.go
+++ b/internal/mcp/diagnostics.go
@@ -45,7 +45,7 @@ func registerDiagnosticTools(srv *server.MCPServer, allowlist map[string]bool) {
 					mcp.Description("Project path to diagnose (default: current working directory)"),
 				),
 				mcp.WithString("agent",
-					mcp.Description("Agent integration to check: claudecode, cursor, windsurf, codex, opencode, or all (default: all)"),
+					mcp.Description("Agent integration to check: claudecode, cursor, windsurf, codex, opencode, fx, or all (default: all)"),
 				),
 			),
 			handleDoctor(),

--- a/internal/store/provenance.go
+++ b/internal/store/provenance.go
@@ -19,6 +19,7 @@ const (
 	AgentCursor     = "cursor"
 	AgentWindsurf   = "windsurf"
 	AgentOpenCode   = "opencode"
+	AgentFx         = "fx"
 
 	SourceUnknown        = "unknown"
 	SourceCLI            = "cli"
@@ -94,7 +95,8 @@ func (s *Store) seedProvenanceCatalog() error {
 			('claudecode', 'Claude Code', 'agent'),
 			('cursor', 'Cursor', 'agent'),
 			('windsurf', 'Windsurf', 'agent'),
-			('opencode', 'OpenCode', 'agent')`,
+			('opencode', 'OpenCode', 'agent'),
+			('fx', 'fx', 'agent')`,
 		`INSERT OR IGNORE INTO source_kinds (id, display_name) VALUES
 			('unknown', 'Unknown'),
 			('cli', 'CLI'),
@@ -408,6 +410,7 @@ func displayName(id string) string {
 		"cursor":          "Cursor",
 		"windsurf":        "Windsurf",
 		"opencode":        "OpenCode",
+		"fx":              "fx",
 		"mcp":             "MCP",
 		"hook":            "Hook",
 		"passive_capture": "Passive Capture",

--- a/templates/rules/fx.md
+++ b/templates/rules/fx.md
@@ -1,0 +1,6 @@
+### FX NATIVE MEMORY
+
+fx's built-in `memory` tool and `~/.fx/memories.json` are DISABLED for repository/project memory when this workspace has a valid `.mnemo` marker.
+Do not call the native `memory` tool to save, list, clear, remember, forget, or recall project facts, decisions, bugs, conventions, session summaries, or implementation notes.
+Use mnemo MCP tools (`mem_save`, `mem_search`, `mem_context`, `mem_session_summary`, and related tools) as the only persistent project memory surface.
+If mnemo MCP is unavailable, report that persistent project memory is unavailable and continue without saving to fx native memory.

--- a/templates/templates.go
+++ b/templates/templates.go
@@ -17,5 +17,8 @@ var Windsurf string
 //go:embed rules/global.md
 var Global string
 
+//go:embed rules/fx.md
+var Fx string
+
 //go:embed rules/cursor-global.mdc
 var CursorGlobal string


### PR DESCRIPTION
## Summary
- add fx setup support through AgentSpec
- configure fx MCP and global AGENTS.md instructions
- disable fx native memory for mnemo projects

## Validation
- go test ./...
- go build ./...
- golangci-lint run ./...
- setup/init smoke tests