### PR TITLE
feat: add Pi agent support

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -9,7 +9,7 @@
 </p>
 
 <p align="center">
-  Dale a Claude Code, Codex, Cursor, Windsurf, OpenCode y fx una memoria local compartida que sobrevive a sesiones, compactaciones y cambios de agente.
+  Dale a Claude Code, Codex, Cursor, Windsurf, OpenCode, fx y Pi una memoria local compartida que sobrevive a sesiones, compactaciones y cambios de agente.
 </p>
 
 <p align="center">
@@ -77,7 +77,7 @@ mnemo search "SQLite" --project miapp
 | Problema | mnemo aporta |
 |---|---|
 | Los agentes olvidan decisiones entre sesiones | Memoria persistente de proyecto en `~/.mnemo/memory.db` |
-| Cada agente mantiene una memoria distinta | Una capa compartida para Claude Code, Codex, Cursor, Windsurf, OpenCode y fx |
+| Cada agente mantiene una memoria distinta | Una capa compartida para Claude Code, Codex, Cursor, Windsurf, OpenCode, fx y Pi |
 | Los archivos markdown de memoria se desordenan | Observaciones estructuradas, tags, topic keys y estados de revisión |
 | Los hooks globales pueden ser peligrosos | Activación opt-in por proyecto mediante `.mnemo`; el resto se ignora |
 | El setup puede fallar en silencio | `mnemo doctor` y `mnemo setup status` explican qué está configurado |
@@ -106,6 +106,7 @@ mnemo search "SQLite" --project miapp
   <img alt="Windsurf" src="https://img.shields.io/badge/Windsurf-soportado-2563EB?logo=windsurf&logoColor=white">
   <img alt="OpenCode" src="https://img.shields.io/badge/OpenCode-soportado-F97316?logo=opencode&logoColor=white">
   <img alt="fx" src="https://img.shields.io/badge/fx-soportado-7C3AED?logo=vercel&logoColor=white">
+  <img alt="Pi" src="https://img.shields.io/badge/Pi-soportado-0EA5E9">
 </p>
 
 | Agente | MCP | Hooks / runtime | Instrucciones globales | Skills | Estado |
@@ -116,6 +117,7 @@ mnemo search "SQLite" --project miapp
 | Windsurf | ✅ | ✅ | ✅ | ✅ | Soportado |
 | OpenCode | ✅ | ✅ | ✅ | ✅ | Soportado |
 | fx | ✅ | n/a | ✅ | ✅ vía ruta canónica | Soportado |
+| Pi | ✅ vía extensión MCP | n/a | ✅ | ✅ vía `~/.pi/agent/skills/` | Soportado |
 
 El setup global se instala una vez. La activación del proyecto sigue siendo local y explícita:
 
@@ -124,7 +126,8 @@ project/
 ├── .mnemo      # ID de proyecto + agentes activados, ignorado por git
 ├── AGENTS.md   # autoridad de memoria compartida
 ├── CLAUDE.md   # reglas específicas de Claude cuando se selecciona
-└── .cursor/    # reglas de Cursor cuando se selecciona
+├── .cursor/    # reglas de Cursor cuando se selecciona
+└── .pi/        # extensiones de prompt de Pi cuando se selecciona
 ```
 
 ## Verlo en acción

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 </p>
 
 <p align="center">
-  Give Claude Code, Codex, Cursor, Windsurf, OpenCode and fx one shared local memory that survives sessions, compactions and agent switches.
+  Give Claude Code, Codex, Cursor, Windsurf, OpenCode, fx and Pi one shared local memory that survives sessions, compactions and agent switches.
 </p>
 
 <p align="center">
@@ -76,7 +76,7 @@ mnemo search "SQLite" --project myapp
 | Problem | mnemo gives you |
 |---|---|
 | Agents forget decisions between sessions | Durable project memory in `~/.mnemo/memory.db` |
-| Different agents keep different memories | One shared layer for Claude Code, Codex, Cursor, Windsurf, OpenCode and fx |
+| Different agents keep different memories | One shared layer for Claude Code, Codex, Cursor, Windsurf, OpenCode, fx and Pi |
 | Markdown memory files drift or conflict | Structured observations, tags, topic keys and review states |
 | Global hooks can be risky | Project opt-in via a `.mnemo` marker; projects without it are ignored |
 | Setup breaks silently | `mnemo doctor` and `mnemo setup status` explain exactly what is configured |
@@ -105,6 +105,7 @@ mnemo search "SQLite" --project myapp
   <img alt="Windsurf" src="https://img.shields.io/badge/Windsurf-supported-2563EB?logo=windsurf&logoColor=white">
   <img alt="OpenCode" src="https://img.shields.io/badge/OpenCode-supported-F97316?logo=opencode&logoColor=white">
   <img alt="fx" src="https://img.shields.io/badge/fx-supported-7C3AED?logo=vercel&logoColor=white">
+  <img alt="Pi" src="https://img.shields.io/badge/Pi-supported-0EA5E9">
 </p>
 
 | Agent | MCP | Hooks / runtime | Global instructions | Skill access | Status |
@@ -115,6 +116,7 @@ mnemo search "SQLite" --project myapp
 | Windsurf | ✅ | ✅ | ✅ | ✅ | Supported |
 | OpenCode | ✅ | ✅ | ✅ | ✅ | Supported |
 | fx | ✅ | n/a | ✅ | ✅ via canonical path | Supported |
+| Pi | ✅ via MCP extension | n/a | ✅ | ✅ via `~/.pi/agent/skills/` | Supported |
 
 Global setup is installed once. Project activation stays local and opt-in:
 
@@ -123,7 +125,8 @@ project/
 ├── .mnemo      # project ID + activated agents, ignored by git
 ├── AGENTS.md   # shared project memory authority
 ├── CLAUDE.md   # Claude-specific rules when selected
-└── .cursor/    # Cursor rules when selected
+├── .cursor/    # Cursor rules when selected
+└── .pi/        # Pi prompt extensions when selected
 ```
 
 ## See it in action

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -9,7 +9,7 @@
 </p>
 
 <p align="center">
-  为 Claude Code、Codex、Cursor、Windsurf、OpenCode 和 fx 提供一套共享的本地记忆，跨会话、压缩和代理切换仍然保留。
+  为 Claude Code、Codex、Cursor、Windsurf、OpenCode、fx 和 Pi 提供一套共享的本地记忆，跨会话、压缩和代理切换仍然保留。
 </p>
 
 <p align="center">
@@ -77,7 +77,7 @@ mnemo search "SQLite" --project myapp
 | 问题 | mnemo 提供 |
 |---|---|
 | 代理在不同会话之间忘记决策 | 保存在 `~/.mnemo/memory.db` 中的持久化项目记忆 |
-| 不同代理维护不同的记忆 | Claude Code、Codex、Cursor、Windsurf、OpenCode 和 fx 共享同一层记忆 |
+| 不同代理维护不同的记忆 | Claude Code、Codex、Cursor、Windsurf、OpenCode、fx 和 Pi 共享同一层记忆 |
 | Markdown 记忆文件容易漂移或冲突 | 结构化 observations、tags、topic keys 和 review 状态 |
 | 全局 hooks 可能有风险 | 通过 `.mnemo` 标记按项目显式启用；没有标记的项目会被忽略 |
 | 安装问题可能静默失败 | `mnemo doctor` 和 `mnemo setup status` 会说明当前配置状态 |
@@ -106,6 +106,7 @@ mnemo search "SQLite" --project myapp
   <img alt="Windsurf" src="https://img.shields.io/badge/Windsurf-supported-2563EB?logo=windsurf&logoColor=white">
   <img alt="OpenCode" src="https://img.shields.io/badge/OpenCode-supported-F97316?logo=opencode&logoColor=white">
   <img alt="fx" src="https://img.shields.io/badge/fx-supported-7C3AED?logo=vercel&logoColor=white">
+  <img alt="Pi" src="https://img.shields.io/badge/Pi-supported-0EA5E9">
 </p>
 
 | 代理 | MCP | Hooks / runtime | 全局指令 | Skill 访问 | 状态 |
@@ -116,6 +117,7 @@ mnemo search "SQLite" --project myapp
 | Windsurf | ✅ | ✅ | ✅ | ✅ | 支持 |
 | OpenCode | ✅ | ✅ | ✅ | ✅ | 支持 |
 | fx | ✅ | n/a | ✅ | 通过标准路径 ✅ | 支持 |
+| Pi | 通过 MCP 扩展 ✅ | n/a | ✅ | 通过 `~/.pi/agent/skills/` ✅ | 支持 |
 
 全局配置只需安装一次。项目启用仍然是本地、显式的 opt-in：
 
@@ -124,7 +126,8 @@ project/
 ├── .mnemo      # 项目 ID + 已启用代理，忽略提交到 git
 ├── AGENTS.md   # 共享项目记忆权威
 ├── CLAUDE.md   # 选择 Claude 时使用的专用规则
-└── .cursor/    # 选择 Cursor 时使用的规则
+├── .cursor/    # 选择 Cursor 时使用的规则
+└── .pi/        # 选择 Pi 时使用的 prompt 扩展
 ```
 
 ## 实际效果

--- a/cmd/mnemo/plugin_integrity_test.go
+++ b/cmd/mnemo/plugin_integrity_test.go
@@ -202,6 +202,7 @@ func TestShippedProtocolsForbidFallbackMemory(t *testing.T) {
 		filepath.Join("..", "..", "templates", "rules", "cursor.mdc"),
 		filepath.Join("..", "..", "templates", "rules", "cursor-global.mdc"),
 		filepath.Join("..", "..", "templates", "rules", "windsurf.md"),
+		filepath.Join("..", "..", "templates", "rules", "pi.md"),
 		filepath.Join("..", "..", "plugin", "claude-code", "scripts", "mnemo.md"),
 		filepath.Join("..", "..", "plugin", "claude-code", "scripts", "session-start-protocol.md"),
 		filepath.Join("..", "..", "plugin", "claude-code", "scripts", "post-compact-protocol-header.md"),

--- a/cmd/mnemo/setup_print_config_test.go
+++ b/cmd/mnemo/setup_print_config_test.go
@@ -88,7 +88,7 @@ func TestBuildSetupConfigSnippetsForAll(t *testing.T) {
 	if err != nil {
 		t.Fatalf("build snippets: %v", err)
 	}
-	if len(snippets) != 9 {
-		t.Fatalf("snippets = %d, want 9", len(snippets))
+	if len(snippets) != 10 {
+		t.Fatalf("snippets = %d, want 10", len(snippets))
 	}
 }

--- a/cmd/mnemo/setup_refresh_test.go
+++ b/cmd/mnemo/setup_refresh_test.go
@@ -35,8 +35,8 @@ func TestRefreshSetupWritesCodexFiles(t *testing.T) {
 	if err != nil {
 		t.Fatalf("refresh setup: %v", err)
 	}
-	if len(updated) != 12 {
-		t.Fatalf("updated paths = %d, want 12 (%v)", len(updated), updated)
+	if len(updated) != 13 {
+		t.Fatalf("updated paths = %d, want 13 (%v)", len(updated), updated)
 	}
 
 	config := readTestFile(t, filepath.Join(home, ".codex", "config.toml"))

--- a/cmd/mnemo/setup_status_test.go
+++ b/cmd/mnemo/setup_status_test.go
@@ -98,6 +98,23 @@ func TestBuildSetupStatusReportReportsConfiguredFx(t *testing.T) {
 	}
 }
 
+func TestBuildSetupStatusReportReportsConfiguredPi(t *testing.T) {
+	home := t.TempDir()
+
+	if _, err := agentinit.Refresh(home, "/bin/mnemo", "pi"); err != nil {
+		t.Fatalf("refresh pi: %v", err)
+	}
+
+	report := buildSetupStatusReport(setupStatusOptions{Agent: "pi", Home: home})
+	if report.Status != "ok" {
+		t.Fatalf("status = %q, want ok", report.Status)
+	}
+	row := report.Rows[0]
+	if row.Agent != "Pi" || row.Detected != "yes" || row.MCP != "yes" || row.Hooks != "n/a" || row.Instructions != "yes" {
+		t.Fatalf("unexpected row: %+v", row)
+	}
+}
+
 func TestBuildSetupStatusReportChecksClaudeCodePluginHooks(t *testing.T) {
 	for name, registry := range map[string]string{
 		"array":  `{"plugins":{"mnemo@mnemo":[{"installPath":"%s"}]}}`,

--- a/cmd/mnemo/templates/usage.txt
+++ b/cmd/mnemo/templates/usage.txt
@@ -41,6 +41,7 @@ Agents for init / install-instructions:
   --agent=codex        Codex global AGENTS.md instructions / .mnemo activation
   --agent=opencode     OpenCode global AGENTS.md instructions / .mnemo activation
   --agent=fx           fx global AGENTS.md instructions / .mnemo activation
+  --agent=pi           Pi global APPEND_SYSTEM.md instructions / .mnemo activation
   --agent=all          All agents
   --path=DIR           Target project directory for init/doctor (default: current directory)
 
@@ -56,7 +57,7 @@ Setup status options:
   --home=DIR           Override home directory for global agent checks
 
 Setup print-config options:
-  AGENT                claudecode | cursor | windsurf | codex | opencode | fx | all
+  AGENT                claudecode | cursor | windsurf | codex | opencode | fx | pi | all
   --home=DIR           Use DIR when rendering user-level config paths
   --mnemo-bin=PATH     Use PATH as the mnemo binary in snippets
 

--- a/docs/AGENT_INTEGRATION.md
+++ b/docs/AGENT_INTEGRATION.md
@@ -1,16 +1,16 @@
 # Agent integration
 
-mnemo supports Claude Code, Cursor, Windsurf, Codex, OpenCode and fx through global setup surfaces plus project-local activation.
+mnemo supports Claude Code, Cursor, Windsurf, Codex, OpenCode, fx and Pi through global setup surfaces plus project-local activation.
 
 ## Global surfaces
 
-| | Claude Code | Cursor | Windsurf | Codex | OpenCode | fx |
-|---|---|---|---|---|---|---|
-| **Hook scripts** | via plugin or n/a via `install.sh` | `~/.cursor/hooks/` | `~/.codeium/windsurf/hooks/` | `~/.codex/hooks/` | `~/.config/opencode/plugins/` | n/a |
-| **MCP** | `~/.claude/.mcp.json` | `~/.cursor/mcp.json` | `~/.codeium/windsurf/mcp_config.json` | `~/.codex/config.toml` | `~/.config/opencode/opencode.json` | `~/.fx/mcp.json` |
-| **Hook config** | plugin hooks check `.mnemo` | `~/.cursor/hooks.json` | `~/.codeium/windsurf/hooks.json` | `~/.codex/hooks.json` checks `.mnemo` | global plugin checks `.mnemo` | n/a |
-| **Global protocol** | `~/.claude/CLAUDE.md` | `~/.cursor/rules/mnemo.mdc` | `~/.codeium/windsurf/memories/global_rules.md` | `~/.codex/AGENTS.md` | `~/.config/opencode/AGENTS.md` | `~/.fx/AGENTS.md` |
-| **Skill access** | symlinks under `~/.claude/skills/` | canonical `~/.agents/skills/` | symlinks under `~/.codeium/windsurf/skills/` | canonical `~/.agents/skills/` | canonical `~/.agents/skills/` | canonical `~/.agents/skills/` |
+| | Claude Code | Cursor | Windsurf | Codex | OpenCode | fx | Pi |
+|---|---|---|---|---|---|---|---|
+| **Hook scripts** | via plugin or n/a via `install.sh` | `~/.cursor/hooks/` | `~/.codeium/windsurf/hooks/` | `~/.codex/hooks/` | `~/.config/opencode/plugins/` | n/a | n/a |
+| **MCP** | `~/.claude/.mcp.json` | `~/.cursor/mcp.json` | `~/.codeium/windsurf/mcp_config.json` | `~/.codex/config.toml` | `~/.config/opencode/opencode.json` | `~/.fx/mcp.json` | `~/.pi/agent/mcp.json` via MCP extension |
+| **Hook config** | plugin hooks check `.mnemo` | `~/.cursor/hooks.json` | `~/.codeium/windsurf/hooks.json` | `~/.codex/hooks.json` checks `.mnemo` | global plugin checks `.mnemo` | n/a | n/a |
+| **Global protocol** | `~/.claude/CLAUDE.md` | `~/.cursor/rules/mnemo.mdc` | `~/.codeium/windsurf/memories/global_rules.md` | `~/.codex/AGENTS.md` | `~/.config/opencode/AGENTS.md` | `~/.fx/AGENTS.md` | `~/.pi/agent/APPEND_SYSTEM.md` |
+| **Skill access** | symlinks under `~/.claude/skills/` | canonical `~/.agents/skills/` | symlinks under `~/.codeium/windsurf/skills/` | canonical `~/.agents/skills/` | canonical `~/.agents/skills/` | canonical `~/.agents/skills/` | symlink under `~/.pi/agent/skills/` |
 
 All supported agents use global hook/configuration surfaces where available. Their global instructions are conditional: if `.mnemo` is missing or invalid, agents skip mnemo entirely and do not create fallback memory files.
 
@@ -24,10 +24,11 @@ project/
 ├── AGENTS.md                     ← mnemo memory authority (managed section)
 ├── CLAUDE.md                     ← Claude-specific block (when --agent=claudecode)
 ├── .cursor/rules/mnemo.mdc       ← Cursor project rules (when --agent=cursor)
-└── .windsurf/rules/mnemo.md      ← Windsurf project rules (when --agent=windsurf)
+├── .windsurf/rules/mnemo.md      ← Windsurf project rules (when --agent=windsurf)
+└── .pi/APPEND_SYSTEM.md          ← Pi prompt extension (when --agent=pi)
 ```
 
-By default, `mnemo init` writes project-level memory authority rules inside managed `<!-- mnemo:start -->` … `<!-- mnemo:end -->` sections, or dedicated Cursor/Windsurf rule files. Use `--no-project-rules` to create only the `.mnemo` marker.
+By default, `mnemo init` writes project-level memory authority rules inside managed `<!-- mnemo:start -->` … `<!-- mnemo:end -->` sections, or dedicated Cursor/Windsurf/Pi prompt files. Use `--no-project-rules` to create only the `.mnemo` marker.
 
 ## The `.mnemo` marker
 
@@ -92,5 +93,11 @@ The `.mnemo` file at the project root activates mnemo for a project:
 fx support uses MCP, global `AGENTS.md` instructions and the canonical `mnemo-memory` skill under `~/.agents/skills/`. It does not install hooks because fx does not expose a supported hook surface for mnemo to rely on.
 
 fx also has a native `memory` tool backed by `~/.fx/memories.json`. The mnemo-managed `~/.fx/AGENTS.md` block explicitly disables that native memory surface for repository/project memory whenever a valid `.mnemo` marker exists; agents must use mnemo MCP tools instead.
+
+### Pi
+
+Pi support uses global `~/.pi/agent/APPEND_SYSTEM.md` instructions, project `AGENTS.md` activation, the canonical `mnemo-memory` skill linked into `~/.pi/agent/skills/`, and a standard `mcpServers` entry in `~/.pi/agent/mcp.json` for environments that have a Pi MCP extension such as `pi-mcp-adapter`, `pi-mcp-extension`, or `pi-mcp` installed.
+
+mnemo does not write `.pi/SYSTEM.md` because that file replaces Pi's default system prompt. The managed PI guidance is appended instead, so Pi keeps its default prompt, context files and skills behavior. Pi support does not install hooks because Pi does not expose a stable declarative hook surface for mnemo to rely on.
 
 On session start, every hook resolves the Git root and reads the project identifier from `.mnemo`. This keeps the same identity regardless of which subdirectory the editor opens.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -48,6 +48,7 @@ Agents for `mnemo init`, `mnemo install-instructions` and setup commands:
 --agent=codex        Codex global AGENTS.md instructions / .mnemo activation
 --agent=opencode     OpenCode global AGENTS.md instructions / .mnemo activation
 --agent=fx           fx global AGENTS.md instructions / .mnemo activation
+--agent=pi           Pi global APPEND_SYSTEM.md instructions / .mnemo activation
 --agent=all          All agents
 ```
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -9,7 +9,7 @@ Global hooks are intentionally inert outside projects with a valid `.mnemo` mark
 
 ## Prerequisite: binary in PATH
 
-The `mnemo` binary must be in your `PATH` before any agent integration will work. This applies to Claude Code, Cursor, Windsurf, Codex, OpenCode and fx regardless of how the integration is installed.
+The `mnemo` binary must be in your `PATH` before any agent integration will work. This applies to Claude Code, Cursor, Windsurf, Codex, OpenCode, fx and Pi regardless of how the integration is installed.
 
 The hooks that fire on session start, session end and passive capture call `mnemo` directly. The MCP server is also the `mnemo` binary. Without it in PATH, hooks and MCP cannot start.
 
@@ -27,6 +27,7 @@ Explicit targets are supported:
 curl -sSf https://raw.githubusercontent.com/jmeiracorbal/mnemo/main/install.sh | bash -s -- --agent=codex
 curl -sSf https://raw.githubusercontent.com/jmeiracorbal/mnemo/main/install.sh | bash -s -- --agent=opencode
 curl -sSf https://raw.githubusercontent.com/jmeiracorbal/mnemo/main/install.sh | bash -s -- --agent=fx
+curl -sSf https://raw.githubusercontent.com/jmeiracorbal/mnemo/main/install.sh | bash -s -- --agent=pi
 curl -sSf https://raw.githubusercontent.com/jmeiracorbal/mnemo/main/install.sh | bash -s -- --agent=all
 ```
 
@@ -69,6 +70,12 @@ claude plugin install mnemo@mnemo
 
 `install.sh` configures Claude Code through MCP and global instructions. Claude plugin hooks are optional in that path, so a fresh install without a plugin registry is valid.
 
+## Pi notes
+
+Pi support installs global guidance into `~/.pi/agent/APPEND_SYSTEM.md` so mnemo extends Pi's default prompt instead of replacing it with `.pi/SYSTEM.md`. It also writes a standard `mcpServers` entry to `~/.pi/agent/mcp.json` for Pi environments that have an MCP extension such as `pi-mcp-adapter`, `pi-mcp-extension`, or `pi-mcp` installed.
+
+Pi does not expose a stable declarative hook surface for mnemo, so setup does not install hooks for Pi.
+
 ## Build from source
 
 ```bash
@@ -84,7 +91,7 @@ mnemo --version
 From the project root:
 
 ```bash
-mnemo init --agent=claudecode   # or cursor, windsurf, codex, opencode, fx, all
+mnemo init --agent=claudecode   # or cursor, windsurf, codex, opencode, fx, pi, all
 # optional: --no-project-rules for .mnemo marker only
 ```
 
@@ -92,7 +99,7 @@ This creates a `.mnemo` marker and records the selected agent. Agent hooks, MCP 
 
 ## Optional skills
 
-`install.sh` and `mnemo setup refresh` embed the `mnemo-memory` skill at `~/.agents/skills/mnemo-memory/` and link Claude Code and Windsurf to it. fx, Codex, Cursor and OpenCode use the canonical `~/.agents/skills/` path directly. You normally do not need a separate skill install step.
+`install.sh` and `mnemo setup refresh` embed the `mnemo-memory` skill at `~/.agents/skills/mnemo-memory/` and link Claude Code and Windsurf to it. fx, Codex, Cursor and OpenCode use the canonical `~/.agents/skills/` path directly. Pi receives a symlink under `~/.pi/agent/skills/`. You normally do not need a separate skill install step.
 
 If you prefer the skills CLI or need to refresh manually:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,4 +22,5 @@ This directory contains the extended mnemo documentation. Start here when you ne
 | [Cursor memory surfaces](memories/cursor.md) | Cursor rules, User Rules, Team Rules, and import candidates. |
 | [Windsurf memory surfaces](memories/windsurf.md) | Cascade Memories, Rules, and conversion notes. |
 | [OpenCode memory surfaces](memories/opencode.md) | OpenCode instruction discovery and conversion notes. |
+| [Pi memory surfaces](memories/pi.md) | Pi context files, system prompt modes, Skills, and optional MCP extension behavior. |
 | [fx memory surfaces](memories/fx.md) | fx `AGENTS.md` instructions and `~/.fx/memories.json` memory store. |

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -53,7 +53,7 @@ Global hooks/config:
 ```bash
 grep "mnemo" ~/.cursor/hooks.json ~/.codeium/windsurf/hooks.json ~/.codex/hooks.json 2>/dev/null
 ls ~/.config/opencode/plugins/mnemo.ts ~/.config/opencode/plugins/mnemo-protocol.md
-grep "mnemo" ~/.fx/mcp.json 2>/dev/null
+grep "mnemo" ~/.fx/mcp.json ~/.pi/agent/APPEND_SYSTEM.md ~/.pi/agent/mcp.json 2>/dev/null
 ```
 
 Canonical Agent Skill and symlinks:
@@ -61,10 +61,11 @@ Canonical Agent Skill and symlinks:
 ```bash
 test -f ~/.agents/skills/mnemo-memory/SKILL.md
 ls -l ~/.claude/skills/mnemo-memory \
-  ~/.codeium/windsurf/skills/mnemo-memory
+  ~/.codeium/windsurf/skills/mnemo-memory \
+  ~/.pi/agent/skills/mnemo-memory
 ```
 
-Only symlinks for selected agent-specific consumers are expected to exist. Codex, Cursor, OpenCode and fx use the canonical `.agents/skills` path directly.
+Only symlinks for selected agent-specific consumers are expected to exist. Codex, Cursor, OpenCode and fx use the canonical `.agents/skills` path directly. Pi uses a symlink under `~/.pi/agent/skills`.
 
 ## Claude Code plugin validation
 

--- a/docs/memories/README.md
+++ b/docs/memories/README.md
@@ -22,6 +22,7 @@ Conversation transcripts, opaque editor state, cloud-only state, and model-provi
 | Cursor | Rules (`.cursor/rules/*.mdc`), User Rules, Team Rules, `AGENTS.md` | `.cursor/rules/**/*.mdc`, `AGENTS.md`, legacy `.cursorrules` if present | High for project rules; low for opaque/editor-managed memories |
 | Windsurf | Cascade Memories plus Rules / `AGENTS.md` | `~/.codeium/windsurf/memories/`, `~/.codeium/windsurf/memories/global_rules.md`, `.windsurf/rules/**/*.md`, `AGENTS.md`, legacy `.windsurfrules` if present | Medium for generated Memories; high for Rules |
 | OpenCode | `AGENTS.md` instruction discovery and session instruction deltas | `~/.config/opencode/AGENTS.md`, repo/nested `AGENTS.md` | High for markdown instructions; low for session internals |
+| Pi | `AGENTS.md` / `CLAUDE.md`, `.pi/SYSTEM.md`, `.pi/APPEND_SYSTEM.md`, Skills, optional MCP extension config | `AGENTS.md`, `CLAUDE.md`, `.pi/APPEND_SYSTEM.md`, reviewed `.pi/SYSTEM.md`, optional `~/.pi/agent/*` files | High for markdown instructions; no native semantic memory store documented |
 | fx | `AGENTS.md` project instructions plus `~/.fx/memories.json` | `~/.fx/AGENTS.md`, repo/nested `AGENTS.md`, `~/.fx/memories.json` | High for JSON string memories and AGENTS.md |
 
 ## Memory equivalence diagram
@@ -34,6 +35,7 @@ flowchart LR
         Cursor[Cursor<br/>.cursor/rules/*.mdc + AGENTS.md]
         Windsurf[Windsurf<br/>Cascade Memories + Rules]
         OpenCode[OpenCode<br/>AGENTS.md + session instructions]
+        Pi[Pi<br/>AGENTS.md + APPEND_SYSTEM.md + skills]
         FX[fx<br/>AGENTS.md + memories.json]
     end
 
@@ -53,6 +55,8 @@ flowchart LR
     Windsurf --> Observations
     Windsurf --> Provenance
     OpenCode --> Instructions
+    Pi --> Instructions
+    Pi --> Provenance
     FX --> Instructions
     FX --> Observations
     FX --> Provenance
@@ -60,12 +64,12 @@ flowchart LR
 
 ### Equivalence model
 
-| mnemo target concept | Claude Code | Codex | Cursor | Windsurf | OpenCode | fx |
-|---|---|---|---|---|---|---|
-| Instruction-like context | `CLAUDE.md`, `.claude/CLAUDE.md`, `.claude/rules/**/*.md` | `AGENTS.md` hierarchy | `.cursor/rules/**/*.mdc`, `AGENTS.md` | `.windsurf/rules/**/*.md`, `AGENTS.md` | `AGENTS.md` hierarchy | `AGENTS.md` hierarchy |
-| Observation-like memory | Auto-memory `MEMORY.md` index plus referenced topic files | Not documented as a native store | No documented local semantic store | Cascade Memories | Not documented as a native store | `~/.fx/memories.json` strings |
-| Scope signal | User/project/local memory locations | File hierarchy and fallback names | Rule type/path metadata | Workspace/user memory and rule locations | File hierarchy | Profile-level memories plus project instructions |
-| Provenance to preserve | Source file, heading/topic path, auto-memory reference target | Source file and nearest project path | Rule file, frontmatter, referenced `@file` paths | Memory/rule path and activation metadata | Source file and nearest project path | JSON array entry index and profile path |
+| mnemo target concept | Claude Code | Codex | Cursor | Windsurf | OpenCode | Pi | fx |
+|---|---|---|---|---|---|---|---|
+| Instruction-like context | `CLAUDE.md`, `.claude/CLAUDE.md`, `.claude/rules/**/*.md` | `AGENTS.md` hierarchy | `.cursor/rules/**/*.mdc`, `AGENTS.md` | `.windsurf/rules/**/*.md`, `AGENTS.md` | `AGENTS.md` hierarchy | `AGENTS.md`, `CLAUDE.md`, `.pi/APPEND_SYSTEM.md`, `.pi/SYSTEM.md` | `AGENTS.md` hierarchy |
+| Observation-like memory | Auto-memory `MEMORY.md` index plus referenced topic files | Not documented as a native store | No documented local semantic store | Cascade Memories | Not documented as a native store | Not documented as a native store | `~/.fx/memories.json` strings |
+| Scope signal | User/project/local memory locations | File hierarchy and fallback names | Rule type/path metadata | Workspace/user memory and rule locations | File hierarchy | File hierarchy plus Pi global/project system prompt paths | Profile-level memories plus project instructions |
+| Provenance to preserve | Source file, heading/topic path, auto-memory reference target | Source file and nearest project path | Rule file, frontmatter, referenced `@file` paths | Memory/rule path and activation metadata | Source file and nearest project path | Source file, prompt mode, nearest project path, skill source | JSON array entry index and profile path |
 
 This equivalence is intentionally conservative: mnemo should preserve where each memory came from and whether it behaved like an instruction or an observation before turning it into canonical mnemo data.
 
@@ -78,6 +82,7 @@ This equivalence is intentionally conservative: mnemo should preserve where each
 | Cursor | No central memory index | `.mdc` rules are direct import units, but rule bodies may reference supporting files with `@file` links; preserve/follow those separately. |
 | Windsurf | No documented memory index | Generated Memories are local workspace items; Rules are direct files with activation metadata, not a manifest. |
 | OpenCode | No | `AGENTS.md` files and discovered nested instructions are direct instruction sources; V2 config `instructions` entries are parsed but not resolved into model context. |
+| Pi | No | `AGENTS.md`, `CLAUDE.md`, `SYSTEM.md`, and `APPEND_SYSTEM.md` are direct instruction sources; preserve prompt mode because `SYSTEM.md` replaces the default prompt. |
 | fx | No | `~/.fx/memories.json` is the direct memory store: a JSON array of strings. `AGENTS.md` files are scoped instructions. |
 
 ## Importer design implications
@@ -96,6 +101,8 @@ This equivalence is intentionally conservative: mnemo should preserve where each
 - Cursor Rules docs: https://prod.cursor.com/docs/rules
 - Windsurf Cascade Memories and Rules docs: https://docs.windsurf.com/es/windsurf/cascade/memories
 - OpenCode V2 instructions docs: https://opencode.ai/v2/docs/instructions
+- Pi repository and coding agent docs: https://github.com/earendil-works/pi
+- Pi MCP extension docs: https://github.com/dmmulroy/pi-mcp
 - fx project instructions docs: https://fx.sh/docs/configure-fx/project-instructions
 - fx memory tool source: https://raw.githubusercontent.com/vercel-labs/fx/main/src/tools/memory/memory.zig
 - fx profile paths source: https://raw.githubusercontent.com/vercel-labs/fx/main/src/core/shared/profile_paths.zig

--- a/docs/memories/pi.md
+++ b/docs/memories/pi.md
@@ -1,0 +1,85 @@
+# Pi memory surfaces
+
+## Native model
+
+Pi exposes durable context mostly through instruction and customization files rather than a documented semantic memory database.
+
+Relevant surfaces:
+
+1. Context files loaded at startup, especially `AGENTS.md` and `CLAUDE.md`.
+2. System prompt files: `.pi/SYSTEM.md` replaces the default system prompt, while `.pi/APPEND_SYSTEM.md` extends it.
+3. Skills under `~/.pi/agent/skills/` and `.pi/skills/`.
+4. Optional MCP support through community extensions such as `pi-mcp-adapter`, `pi-mcp-extension`, or `pi-mcp`, which read standard MCP configuration.
+
+Pi is also available through Vercel AI SDK's experimental harness layer, but mnemo integration should treat Pi first as an agent runtime with instruction, skill, and optional MCP surfaces.
+
+## Locations
+
+Instructions:
+
+- Global context: `~/.pi/agent/AGENTS.md`.
+- Project context: parent/current `AGENTS.md` or `CLAUDE.md` files.
+- Project system replacement: `.pi/SYSTEM.md`.
+- Project system extension: `.pi/APPEND_SYSTEM.md`.
+- Global system replacement/extension: `~/.pi/agent/SYSTEM.md`, `~/.pi/agent/APPEND_SYSTEM.md`.
+
+Skills:
+
+- Global skills: `~/.pi/agent/skills/**/SKILL.md`.
+- Project skills: `.pi/skills/**/SKILL.md`.
+- Pi also documents package-provided skills.
+
+MCP:
+
+- Pi does not rely on a documented built-in MCP surface in the same way as Codex, Cursor, or Claude Code.
+- Pi MCP adapters read standard MCP config from paths such as `.pi/mcp.json`, `.pi/mcp.jsonc`, and `~/.pi/agent/mcp.json`; mnemo writes the global Pi entry to `~/.pi/agent/mcp.json` using `mcpServers.mnemo`.
+
+## Shape and retrieval
+
+Instructions:
+
+- Plain markdown files.
+- `AGENTS.md` / `CLAUDE.md` files are concatenated from global and project hierarchy.
+- `SYSTEM.md` is a full system-prompt replacement and can suppress default prompt behavior if used incorrectly.
+- `APPEND_SYSTEM.md` is the safer extension point for mnemo-managed global guidance.
+
+Skills:
+
+- `SKILL.md` files use the Agent Skills-style markdown package shape.
+- Skill availability depends on Pi's skill discovery and active tool set.
+
+Native memory:
+
+- No documented local semantic memory store equivalent to Claude Code auto memory, Windsurf Memories, or fx `memories.json` is treated as an import target today.
+- Pi context files may contain long-lived project knowledge, but they are instruction surfaces and should be classified before importing into mnemo observations.
+
+## Conversion notes for mnemo
+
+Recommended import order:
+
+1. Project `AGENTS.md` / `CLAUDE.md` context files.
+2. `.pi/APPEND_SYSTEM.md` because it extends the default prompt and is likely policy/guidance.
+3. `.pi/SYSTEM.md` only with explicit review because it replaces the entire system prompt.
+4. Global `~/.pi/agent/*` instruction files only with explicit user-scope opt-in.
+
+Suggested mapping:
+
+- Context-file behavioral rules -> `pattern` or `config` after classification.
+- Project decisions embedded in context files -> `decision` only after a dry-run preview.
+- User preferences in global files -> `preference` only with user-scope confirmation.
+
+Important importer behavior:
+
+- Preserve whether a source was `AGENTS.md`, `CLAUDE.md`, `SYSTEM.md`, or `APPEND_SYSTEM.md` because the runtime semantics differ.
+- Prefer `APPEND_SYSTEM.md` for generated mnemo integration guidance; avoid writing `SYSTEM.md` so mnemo does not replace Pi's default prompt.
+- Treat Pi MCP as conditional on an installed MCP extension until Pi documents a built-in MCP config contract.
+- Preserve source path, heading, scope, and whether the file was global or project-local.
+
+## Sources
+
+- https://github.com/earendil-works/pi
+- https://github.com/earendil-works/pi/blob/main/packages/coding-agent/README.md
+- https://vercel.com/blog/ai-sdk-7
+- https://www.npmjs.com/package/pi-mcp-adapter
+- https://www.npmjs.com/package/pi-mcp-extension
+- https://github.com/dmmulroy/pi-mcp

--- a/install.sh
+++ b/install.sh
@@ -9,6 +9,7 @@
 #   bash -s -- --agent=codex
 #   bash -s -- --agent=opencode
 #   bash -s -- --agent=fx
+#   bash -s -- --agent=pi
 #   bash -s -- --agent=all
 #
 # Environment overrides:
@@ -206,6 +207,9 @@ agent_detected() {
     fx)
       command -v fx >/dev/null 2>&1 || [ -d "$HOME/.fx" ]
       ;;
+    pi)
+      command -v pi >/dev/null 2>&1 || [ -d "$HOME/.pi/agent" ]
+      ;;
     *) return 1 ;;
   esac
 }
@@ -213,7 +217,7 @@ agent_detected() {
 detect_agents() {
   local found=""
   local agent
-  for agent in claudecode cursor windsurf codex opencode fx; do
+  for agent in claudecode cursor windsurf codex opencode fx pi; do
     if agent_detected "$agent"; then
       found="$found $agent"
     fi
@@ -277,17 +281,17 @@ main() {
       ok "Done. Run 'mnemo init --agent=all' in projects that should use mnemo."
       ;;
     all)
-      for selected in claudecode cursor windsurf codex opencode fx; do
+      for selected in claudecode cursor windsurf codex opencode fx pi; do
         setup_agent "$selected" "$mnemo_bin"
       done
       ok "Done. Run 'mnemo init --agent=all' in projects that should use mnemo."
       ;;
-    claudecode|cursor|windsurf|codex|opencode|fx)
+    claudecode|cursor|windsurf|codex|opencode|fx|pi)
       setup_agent "$AGENT" "$mnemo_bin"
       ok "Done. Run 'mnemo init --agent=${AGENT}' in projects that should use mnemo."
       ;;
     *)
-      err "Unknown agent: ${AGENT}. Valid options: auto | claudecode | cursor | windsurf | codex | opencode | fx | all"
+      err "Unknown agent: ${AGENT}. Valid options: auto | claudecode | cursor | windsurf | codex | opencode | fx | pi | all"
       ;;
   esac
 }

--- a/internal/agentinit/global.go
+++ b/internal/agentinit/global.go
@@ -15,6 +15,7 @@ const (
 	AgentCodex      = "codex"
 	AgentOpenCode   = "opencode"
 	AgentFx         = "fx"
+	AgentPi         = "pi"
 )
 
 // ExpandAgents resolves a single agent flag value to one or more concrete agent

--- a/internal/agentinit/global_test.go
+++ b/internal/agentinit/global_test.go
@@ -17,6 +17,7 @@ func TestInstallGlobalInstructionsWritesConditionalAgentFiles(t *testing.T) {
 		"codex":      filepath.Join(home, ".codex", "AGENTS.md"),
 		"opencode":   filepath.Join(home, ".config", "opencode", "AGENTS.md"),
 		"fx":         filepath.Join(home, ".fx", "AGENTS.md"),
+		"pi":         filepath.Join(home, ".pi", "agent", "APPEND_SYSTEM.md"),
 	}
 
 	for agent, wantPath := range cases {
@@ -145,6 +146,24 @@ func TestFxGlobalInstructionsDisableNativeMemory(t *testing.T) {
 		!strings.Contains(content, "~/.fx/memories.json") ||
 		!strings.Contains(content, "Do not call the native `memory` tool") {
 		t.Fatalf("fx instructions do not disable native memory:\n%s", content)
+	}
+}
+
+func TestPiGlobalInstructionsUseAppendSystemPrompt(t *testing.T) {
+	home := t.TempDir()
+	path, err := InstallGlobalInstructions(home, "pi")
+	if err != nil {
+		t.Fatalf("install pi global instructions: %v", err)
+	}
+	if path != filepath.Join(home, ".pi", "agent", "APPEND_SYSTEM.md") {
+		t.Fatalf("path = %q, want Pi APPEND_SYSTEM.md", path)
+	}
+
+	content := string(mustReadFile(t, path))
+	if !strings.Contains(content, "PI MEMORY GUIDANCE") ||
+		!strings.Contains(content, "Pi context files") ||
+		!strings.Contains(content, "Do not write repository/project memory") {
+		t.Fatalf("pi instructions do not guide Pi memory behavior:\n%s", content)
 	}
 }
 

--- a/internal/agentinit/init_test.go
+++ b/internal/agentinit/init_test.go
@@ -92,3 +92,24 @@ func TestInstallProjectInstructionsWindsurf(t *testing.T) {
 		t.Fatalf("windsurf rule missing: %v", err)
 	}
 }
+
+func TestInstallProjectInstructionsPi(t *testing.T) {
+	root := t.TempDir()
+
+	paths, err := InstallProjectInstructions(root, "pi")
+	if err != nil {
+		t.Fatalf("install pi project instructions: %v", err)
+	}
+	if len(paths) != 2 {
+		t.Fatalf("expected 2 paths, got %d", len(paths))
+	}
+
+	piPath := filepath.Join(root, ".pi", "APPEND_SYSTEM.md")
+	piData, err := os.ReadFile(piPath)
+	if err != nil {
+		t.Fatalf("read Pi APPEND_SYSTEM.md: %v", err)
+	}
+	if !strings.Contains(string(piData), "PI MEMORY GUIDANCE") {
+		t.Fatalf("Pi project prompt extension missing memory guidance:\n%s", string(piData))
+	}
+}

--- a/internal/agentinit/pi.go
+++ b/internal/agentinit/pi.go
@@ -1,0 +1,67 @@
+package agentinit
+
+import (
+	"path/filepath"
+
+	"github.com/jmeiracorbal/mnemo/templates"
+)
+
+func piLabel() string { return "Pi" }
+
+func piDetectionPaths(home string) []string {
+	return []string{filepath.Join(home, ".pi", "agent")}
+}
+
+func piInstructionPath(home string) string {
+	return filepath.Join(home, ".pi", "agent", "APPEND_SYSTEM.md")
+}
+
+func piInstallInstructions(home string) (string, error) {
+	path := piInstructionPath(home)
+	if err := AppendSection(path, templates.Global+"\n\n"+templates.Pi); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+func piRemoveInstructions(home string) (string, bool, error) {
+	path := piInstructionPath(home)
+	changed, err := RemoveSection(path)
+	return path, changed, err
+}
+
+func piConfigSnippets(home, mnemoBin string) []ConfigSnippet {
+	return []ConfigSnippet{{
+		Agent:   piLabel(),
+		Path:    filepath.Join(home, ".pi", "agent", "mcp.json"),
+		Format:  "json",
+		Content: mcpServersJSON(mnemoBin, AgentPi),
+	}}
+}
+
+func piUninstallConfig(home string) ([]string, error) {
+	path := filepath.Join(home, ".pi", "agent", "mcp.json")
+	changed, err := removeMCPServer(path, "mcpServers", "mnemo")
+	return appendChanged(path, changed, err)
+}
+
+func piCheckInstructions(home string) Check {
+	return checkInstructionFile("pi", piInstructionPath(home), true)
+}
+
+func piCheckMCP(home string) Check {
+	path := filepath.Join(home, ".pi", "agent", "mcp.json")
+	return checkJSONMCPWithEnv(path, "mcp_config.pi", "pi", "env", "mcpServers", "mnemo")
+}
+
+func piProjectInstructionPath(root string) string {
+	return filepath.Join(root, ".pi", "APPEND_SYSTEM.md")
+}
+
+func piInstallProjectInstructions(root string) (string, error) {
+	path := piProjectInstructionPath(root)
+	if err := AppendSection(path, templates.Pi); err != nil {
+		return "", err
+	}
+	return path, nil
+}

--- a/internal/agentinit/setup_test.go
+++ b/internal/agentinit/setup_test.go
@@ -32,8 +32,8 @@ func TestConfigSnippetsForAll(t *testing.T) {
 		}
 		snippets = append(snippets, agentSnippets...)
 	}
-	if len(snippets) != 9 {
-		t.Fatalf("snippets = %d, want 9", len(snippets))
+	if len(snippets) != 10 {
+		t.Fatalf("snippets = %d, want 10", len(snippets))
 	}
 }
 
@@ -104,6 +104,28 @@ func TestFxConfigUsesNativeMCPShape(t *testing.T) {
 	}
 	if !strings.Contains(content, `"other"`) {
 		t.Fatalf("unrelated fx MCP config was not preserved:\n%s", content)
+	}
+}
+
+func TestPiConfigUsesMCPServersShape(t *testing.T) {
+	home := t.TempDir()
+	configPath := filepath.Join(home, ".pi", "agent", "mcp.json")
+	writeTestFile(t, configPath, `{
+  "mcpServers": {
+    "other": {"command": "/bin/other"}
+  }
+}`)
+
+	if _, err := Refresh(home, "/bin/mnemo", "pi"); err != nil {
+		t.Fatalf("refresh pi: %v", err)
+	}
+
+	content := readTestFile(t, configPath)
+	if !strings.Contains(content, `"mcpServers"`) || !strings.Contains(content, `"MNEMO_AGENT": "pi"`) || !strings.Contains(content, `"MNEMO_MCP_CLIENT": "pi"`) {
+		t.Fatalf("Pi MCP config missing mnemo server or provenance env:\n%s", content)
+	}
+	if !strings.Contains(content, `"other"`) {
+		t.Fatalf("unrelated Pi MCP config was not preserved:\n%s", content)
 	}
 }
 

--- a/internal/agentinit/skill.go
+++ b/internal/agentinit/skill.go
@@ -63,6 +63,10 @@ func globalSkillSymlinks(home, destRoot string) []skillSymlink {
 			link:   filepath.Join(home, ".codeium", "windsurf", "skills", globalSkillName),
 			target: destRoot,
 		},
+		{
+			link:   filepath.Join(home, ".pi", "agent", "skills", globalSkillName),
+			target: destRoot,
+		},
 	}
 }
 

--- a/internal/agentinit/skill_test.go
+++ b/internal/agentinit/skill_test.go
@@ -41,6 +41,7 @@ func TestInstallGlobalSkillCopiesCanonicalFiles(t *testing.T) {
 	for _, link := range []string{
 		filepath.Join(home, ".claude", "skills", globalSkillName),
 		filepath.Join(home, ".codeium", "windsurf", "skills", globalSkillName),
+		filepath.Join(home, ".pi", "agent", "skills", globalSkillName),
 	} {
 		info, err := os.Lstat(link)
 		if err != nil {

--- a/internal/agentinit/spec.go
+++ b/internal/agentinit/spec.go
@@ -203,6 +203,28 @@ var agentSpecs = []AgentSpec{
 		}},
 		Supports: AgentSpecCapabilities{MCP: true, Instructions: true, Skills: true},
 	},
+	{
+		ID:     AgentPi,
+		Label:  piLabel(),
+		Detect: detectFromPaths(piDetectionPaths),
+		MCP: MCPConfigSpec{
+			Snippets:  piConfigSnippets,
+			Uninstall: piUninstallConfig,
+			Check:     piCheckMCP,
+		},
+		Instructions: []InstructionSpec{{
+			Scope:   InstructionScopeGlobal,
+			Path:    piInstructionPath,
+			Install: piInstallInstructions,
+			Remove:  piRemoveInstructions,
+			Check:   piCheckInstructions,
+		}, {
+			Scope:   InstructionScopeProject,
+			Path:    piProjectInstructionPath,
+			Install: piInstallProjectInstructions,
+		}},
+		Supports: AgentSpecCapabilities{MCP: true, MCPConditional: true, Instructions: true, Skills: true},
+	},
 }
 
 var agentSpecsByID = indexAgentSpecs(agentSpecs)

--- a/internal/mcp/diagnostics.go
+++ b/internal/mcp/diagnostics.go
@@ -45,7 +45,7 @@ func registerDiagnosticTools(srv *server.MCPServer, allowlist map[string]bool) {
 					mcp.Description("Project path to diagnose (default: current working directory)"),
 				),
 				mcp.WithString("agent",
-					mcp.Description("Agent integration to check: claudecode, cursor, windsurf, codex, opencode, fx, or all (default: all)"),
+					mcp.Description("Agent integration to check: claudecode, cursor, windsurf, codex, opencode, fx, pi, or all (default: all)"),
 				),
 			),
 			handleDoctor(),

--- a/internal/store/provenance.go
+++ b/internal/store/provenance.go
@@ -20,6 +20,7 @@ const (
 	AgentWindsurf   = "windsurf"
 	AgentOpenCode   = "opencode"
 	AgentFx         = "fx"
+	AgentPi         = "pi"
 
 	SourceUnknown        = "unknown"
 	SourceCLI            = "cli"
@@ -96,7 +97,8 @@ func (s *Store) seedProvenanceCatalog() error {
 			('cursor', 'Cursor', 'agent'),
 			('windsurf', 'Windsurf', 'agent'),
 			('opencode', 'OpenCode', 'agent'),
-			('fx', 'fx', 'agent')`,
+			('fx', 'fx', 'agent'),
+			('pi', 'Pi', 'agent')`,
 		`INSERT OR IGNORE INTO source_kinds (id, display_name) VALUES
 			('unknown', 'Unknown'),
 			('cli', 'CLI'),
@@ -411,6 +413,7 @@ func displayName(id string) string {
 		"windsurf":        "Windsurf",
 		"opencode":        "OpenCode",
 		"fx":              "fx",
+		"pi":              "Pi",
 		"mcp":             "MCP",
 		"hook":            "Hook",
 		"passive_capture": "Passive Capture",

--- a/templates/rules/pi.md
+++ b/templates/rules/pi.md
@@ -1,0 +1,7 @@
+### PI MEMORY GUIDANCE
+
+Pi context files (`AGENTS.md`, `CLAUDE.md`, `.pi/SYSTEM.md`, and `.pi/APPEND_SYSTEM.md`) are instruction surfaces, not project memory stores.
+mnemo is the ONLY persistent memory system for this project.
+Do not write repository/project memory into Pi context files, `MEMORY.md`, agent memory directories, or arbitrary plaintext files as a memory fallback when this workspace has a valid `.mnemo` marker.
+Use mnemo MCP tools (`mem_save`, `mem_search`, `mem_context`, `mem_session_summary`, and related tools) as the only persistent project memory surface.
+If mnemo MCP is unavailable, report that persistent project memory is unavailable and continue without saving fallback memory.

--- a/templates/templates.go
+++ b/templates/templates.go
@@ -20,5 +20,8 @@ var Global string
 //go:embed rules/fx.md
 var Fx string
 
+//go:embed rules/pi.md
+var Pi string
+
 //go:embed rules/cursor-global.mdc
 var CursorGlobal string


### PR DESCRIPTION
## Summary
- Add full Pi agent setup with instructions, MCP config, skill access, provenance, docs, and tests.
- Validate Pi memory save/search/context flow and all-agent setup diagnostics.

## Validation
- go test ./...
- go build ./...
- golangci-lint run ./...
- govulncheck -scan module