### PR TITLE
refactor: move skill links into agent specs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,19 @@ Any second identity scheme fragments stored memory. Changing this is a storage c
 
 Tests must cover: hook config references to existing scripts, shipped metadata consistency, filename matches between hook JSON and actual scripts. If a real shipped file can be wrong while tests pass, coverage is insufficient.
 
+### 9. New agent integrations must declare and validate skill discovery
+
+When adding or changing an agent integration, audit that agent's current skill discovery documentation before deciding how mnemo should expose skills.
+
+The preferred model is:
+
+1. Keep the canonical mnemo skill at `~/.agents/skills/mnemo-memory/`.
+2. If the agent directly discovers `~/.agents/skills`, do not create a redundant agent-specific copy or symlink.
+3. If the agent requires its own global skill directory, declare the symlink path in that agent's `AgentSpec` through `AgentSkillSpec.GlobalLinkPath`.
+4. Validate the resulting layout in a clean temporary `HOME`: canonical skill files exist, expected symlinks point to the canonical folder, and agents that use the canonical path do not receive redundant symlinks.
+
+Do not add skill paths to a hardcoded global list outside the agent spec. The skill surface is part of the concrete agent contract.
+
 ## Pre-commit checklist
 
 Before committing any change that touches hooks, plugin metadata, setup/install flows, versioning, or memory behavior:
@@ -90,6 +103,7 @@ Before committing any change that touches hooks, plugin metadata, setup/install 
 - [ ] Hook filenames in `hooks.json` match actual embedded scripts
 - [ ] Version strings updated in all required metadata files
 - [ ] Shipped hooks resolve PROJECT from `.mnemo` id
+- [ ] New/changed agent integrations validate whether skills are loaded from `~/.agents/skills` directly or via an `AgentSpec` symlink
 - [ ] No previously working path was broken
 
 State what was verified in the commit message. Do not claim completion without verification evidence.

--- a/docs/AGENT_INTEGRATION.md
+++ b/docs/AGENT_INTEGRATION.md
@@ -14,6 +14,15 @@ mnemo supports Claude Code, Cursor, Windsurf, Codex, OpenCode, fx and Pi through
 
 All supported agents use global hook/configuration surfaces where available. Their global instructions are conditional: if `.mnemo` is missing or invalid, agents skip mnemo entirely and do not create fallback memory files.
 
+## Skill installation model
+
+mnemo keeps one canonical global skill copy at `~/.agents/skills/mnemo-memory/`. Agent-specific skill directories never receive independent copies from mnemo; when an agent needs its own skill directory, the agent's `AgentSpec` declares a symlink to that canonical folder.
+
+Current behavior:
+
+- Claude Code, Windsurf and Pi receive symlinks from their agent-specific global skill directories to `~/.agents/skills/mnemo-memory/`.
+- Codex, Cursor, OpenCode and fx load `~/.agents/skills/` directly according to their current skill discovery docs, so mnemo does not add redundant agent-specific symlinks for them.
+
 MCP setup records lightweight provenance for supported configurations by setting `MNEMO_AGENT`, `MNEMO_MCP_CLIENT` and `MNEMO_MCP_TRANSPORT` in the generated MCP server entry. mnemo stores that metadata in normalized SQLite tables separate from the project identity in `.mnemo`.
 
 ## What `mnemo init` creates

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -99,7 +99,7 @@ This creates a `.mnemo` marker and records the selected agent. Agent hooks, MCP 
 
 ## Optional skills
 
-`install.sh` and `mnemo setup refresh` embed the `mnemo-memory` skill at `~/.agents/skills/mnemo-memory/` and link Claude Code and Windsurf to it. fx, Codex, Cursor and OpenCode use the canonical `~/.agents/skills/` path directly. Pi receives a symlink under `~/.pi/agent/skills/`. You normally do not need a separate skill install step.
+`install.sh` and `mnemo setup refresh` embed the `mnemo-memory` skill at `~/.agents/skills/mnemo-memory/`. Claude Code, Windsurf and Pi receive agent-specific symlinks to that canonical folder. Codex, Cursor, OpenCode and fx use the canonical `~/.agents/skills/` path directly according to their current skill discovery docs. You normally do not need a separate skill install step.
 
 If you prefer the skills CLI or need to refresh manually:
 

--- a/internal/agentinit/claudecode.go
+++ b/internal/agentinit/claudecode.go
@@ -26,6 +26,10 @@ func claudeCodeInstructionPath(home string) string {
 	return filepath.Join(home, ".claude", "CLAUDE.md")
 }
 
+func claudeCodeSkillLinkPath(home string) string {
+	return filepath.Join(home, ".claude", "skills", globalSkillName)
+}
+
 func claudeCodeInstallInstructions(home string) (string, error) {
 	path := claudeCodeInstructionPath(home)
 	if err := AppendSection(path, templates.Global); err != nil {

--- a/internal/agentinit/pi.go
+++ b/internal/agentinit/pi.go
@@ -16,6 +16,10 @@ func piInstructionPath(home string) string {
 	return filepath.Join(home, ".pi", "agent", "APPEND_SYSTEM.md")
 }
 
+func piSkillLinkPath(home string) string {
+	return filepath.Join(home, ".pi", "agent", "skills", globalSkillName)
+}
+
 func piInstallInstructions(home string) (string, error) {
 	path := piInstructionPath(home)
 	if err := AppendSection(path, templates.Global+"\n\n"+templates.Pi); err != nil {

--- a/internal/agentinit/skill.go
+++ b/internal/agentinit/skill.go
@@ -54,20 +54,17 @@ func InstallGlobalSkill(home string) ([]string, error) {
 }
 
 func globalSkillSymlinks(home, destRoot string) []skillSymlink {
-	return []skillSymlink{
-		{
-			link:   filepath.Join(home, ".claude", "skills", globalSkillName),
+	var symlinks []skillSymlink
+	for _, spec := range agentSpecs {
+		if spec.Skill.GlobalLinkPath == nil {
+			continue
+		}
+		symlinks = append(symlinks, skillSymlink{
+			link:   spec.Skill.GlobalLinkPath(home),
 			target: destRoot,
-		},
-		{
-			link:   filepath.Join(home, ".codeium", "windsurf", "skills", globalSkillName),
-			target: destRoot,
-		},
-		{
-			link:   filepath.Join(home, ".pi", "agent", "skills", globalSkillName),
-			target: destRoot,
-		},
+		})
 	}
+	return symlinks
 }
 
 func ensureDirSymlink(link, target string) error {

--- a/internal/agentinit/spec.go
+++ b/internal/agentinit/spec.go
@@ -13,6 +13,7 @@ type AgentSpec struct {
 	MCP          MCPConfigSpec
 	Instructions []InstructionSpec
 	Hooks        []HookSpec
+	Skill        AgentSkillSpec
 	Supports     AgentSpecCapabilities
 }
 
@@ -58,6 +59,11 @@ type HookSpec struct {
 	Check         func(home string) Check
 }
 
+// AgentSkillSpec describes how an agent discovers the canonical global skill.
+type AgentSkillSpec struct {
+	GlobalLinkPath func(home string) string
+}
+
 var agentSpecs = []AgentSpec{
 	{
 		ID:     AgentClaudeCode,
@@ -83,6 +89,7 @@ var agentSpecs = []AgentSpec{
 			RuntimeAssets: claudeCodeRuntimeAssets,
 			Check:         claudeCodeCheckRuntime,
 		}},
+		Skill:    AgentSkillSpec{GlobalLinkPath: claudeCodeSkillLinkPath},
 		Supports: AgentSpecCapabilities{MCP: true, Instructions: true, Skills: true, Hooks: true},
 	},
 	{
@@ -135,6 +142,7 @@ var agentSpecs = []AgentSpec{
 			RuntimeAssets: windsurfRuntimeAssets,
 			Check:         windsurfCheckRuntime,
 		}},
+		Skill:    AgentSkillSpec{GlobalLinkPath: windsurfSkillLinkPath},
 		Supports: AgentSpecCapabilities{MCP: true, Instructions: true, Skills: true, Hooks: true, SessionLifecycle: true},
 	},
 	{
@@ -223,6 +231,7 @@ var agentSpecs = []AgentSpec{
 			Path:    piProjectInstructionPath,
 			Install: piInstallProjectInstructions,
 		}},
+		Skill:    AgentSkillSpec{GlobalLinkPath: piSkillLinkPath},
 		Supports: AgentSpecCapabilities{MCP: true, MCPConditional: true, Instructions: true, Skills: true},
 	},
 }

--- a/internal/agentinit/spec_test.go
+++ b/internal/agentinit/spec_test.go
@@ -1,6 +1,9 @@
 package agentinit
 
-import "testing"
+import (
+	"path/filepath"
+	"testing"
+)
 
 func TestAgentSpecsDefineSupportedAgents(t *testing.T) {
 	seen := map[string]bool{}
@@ -28,6 +31,9 @@ func TestAgentSpecsDefineSupportedAgents(t *testing.T) {
 		if spec.Supports.Instructions && len(spec.Instructions) == 0 {
 			t.Fatalf("%s: instructions capability missing specs", id)
 		}
+		if spec.Skill.GlobalLinkPath != nil && !spec.Supports.Skills {
+			t.Fatalf("%s: skill link configured without skills capability", id)
+		}
 	}
 	if len(seen) != len(agentSpecs) {
 		t.Fatalf("supported agents = %d, specs = %d", len(seen), len(agentSpecs))
@@ -36,4 +42,36 @@ func TestAgentSpecsDefineSupportedAgents(t *testing.T) {
 
 func TestAgentSpecCapabilitiesNameBelongsToAgentSpec(t *testing.T) {
 	var _ AgentSpecCapabilities
+}
+
+func TestAgentSpecsDeclareSkillLinkSurfaces(t *testing.T) {
+	home := t.TempDir()
+	wantLinks := map[string]string{
+		AgentClaudeCode: filepath.Join(home, ".claude", "skills", globalSkillName),
+		AgentWindsurf:   filepath.Join(home, ".codeium", "windsurf", "skills", globalSkillName),
+		AgentPi:         filepath.Join(home, ".pi", "agent", "skills", globalSkillName),
+	}
+	canonicalSkillAgents := map[string]bool{
+		AgentCursor:   true,
+		AgentCodex:    true,
+		AgentOpenCode: true,
+		AgentFx:       true,
+	}
+
+	for _, spec := range agentSpecs {
+		want, shouldLink := wantLinks[spec.ID]
+		switch {
+		case shouldLink:
+			if spec.Skill.GlobalLinkPath == nil {
+				t.Fatalf("%s: missing skill link path", spec.ID)
+			}
+			if got := spec.Skill.GlobalLinkPath(home); got != want {
+				t.Fatalf("%s: skill link path = %q, want %q", spec.ID, got, want)
+			}
+		case canonicalSkillAgents[spec.ID]:
+			if spec.Skill.GlobalLinkPath != nil {
+				t.Fatalf("%s: unexpected skill link for canonical ~/.agents/skills consumer", spec.ID)
+			}
+		}
+	}
 }

--- a/internal/agentinit/windsurf.go
+++ b/internal/agentinit/windsurf.go
@@ -16,6 +16,10 @@ func windsurfInstructionPath(home string) string {
 	return filepath.Join(home, ".codeium", "windsurf", "memories", "global_rules.md")
 }
 
+func windsurfSkillLinkPath(home string) string {
+	return filepath.Join(home, ".codeium", "windsurf", "skills", globalSkillName)
+}
+
 func windsurfInstallInstructions(home string) (string, error) {
 	path := windsurfInstructionPath(home)
 	if err := AppendSection(path, templates.Global); err != nil {


### PR DESCRIPTION
## Summary
- Move agent-specific skill symlink ownership into AgentSpec.
- Document and validate canonical ~/.agents/skills behavior.

## Validation
- go test ./...
- go build ./...
- golangci-lint run ./...
- govulncheck -scan module