### PR TITLE
Fix agent setup diagnostics gaps

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -119,6 +119,7 @@ Reduce operational drift between installation, setup, schema evolution, and CLI 
 Near-term goals:
 
 - unificar el escritor de setup para que el binario sea la única autoridad sobre MCP, hooks, instrucciones globales y runtime files;
+- centralizar las expectativas por agente (rutas, forma MCP, hooks, skills, install/uninstall/status/doctor) en una única matriz verificable para evitar drift entre instaladores, diagnósticos y tests;
 - unificar la fuente de verdad del esquema para que sqlc y las migraciones no evolucionen por caminos paralelos;
 - `cmd/mnemo` separa memoria, init/migrate, MCP, setup, doctor, projects y utilidades operativas; `main.go` solo enruta;
 - `internal/agentinit` posee la lógica por agente (rutas, snippets, runtime, uninstall y doctor). `cmd/mnemo` orquesta CLI y no vuelve a ramificar por agente.

--- a/cmd/mnemo/doctor.go
+++ b/cmd/mnemo/doctor.go
@@ -10,7 +10,11 @@ import (
 )
 
 func runDoctor() {
-	opts := parseDoctorArgs(os.Args[2:])
+	opts, err := parseDoctorArgs(os.Args[2:])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mnemo doctor: %v\n", err)
+		os.Exit(1)
+	}
 	report := doctor.BuildReport(toDoctorOptions(opts))
 
 	if opts.JSON {
@@ -29,7 +33,7 @@ func runDoctor() {
 	}
 }
 
-func parseDoctorArgs(args []string) doctorOptions {
+func parseDoctorArgs(args []string) (doctorOptions, error) {
 	opts := doctorOptions{Agent: "all", Path: "."}
 	for _, arg := range args {
 		switch {
@@ -43,6 +47,8 @@ func parseDoctorArgs(args []string) doctorOptions {
 			opts.Home = arg[len("--home="):]
 		case strings.HasPrefix(arg, "--data-dir="):
 			opts.DataDir = arg[len("--data-dir="):]
+		default:
+			return opts, fmt.Errorf("unknown argument %q", arg)
 		}
 	}
 	if opts.Agent == "" {
@@ -51,7 +57,7 @@ func parseDoctorArgs(args []string) doctorOptions {
 	if opts.Path == "" {
 		opts.Path = "."
 	}
-	return opts
+	return opts, nil
 }
 
 func toDoctorOptions(opts doctorOptions) doctor.Options {

--- a/cmd/mnemo/doctor_test.go
+++ b/cmd/mnemo/doctor_test.go
@@ -10,9 +10,18 @@ import (
 )
 
 func TestParseDoctorArgs(t *testing.T) {
-	opts := parseDoctorArgs([]string{"--json", "--agent=codex", "--path=/repo", "--home=/home/test", "--data-dir=/data"})
+	opts, err := parseDoctorArgs([]string{"--json", "--agent=codex", "--path=/repo", "--home=/home/test", "--data-dir=/data"})
+	if err != nil {
+		t.Fatalf("parse doctor args: %v", err)
+	}
 	if !opts.JSON || opts.Agent != "codex" || opts.Path != "/repo" || opts.Home != "/home/test" || opts.DataDir != "/data" {
 		t.Fatalf("unexpected options: %+v", opts)
+	}
+}
+
+func TestParseDoctorArgsRejectsUnknown(t *testing.T) {
+	if _, err := parseDoctorArgs([]string{"--bogus"}); err == nil {
+		t.Fatal("expected unknown argument error")
 	}
 }
 
@@ -24,14 +33,10 @@ func TestBuildDoctorReportChecksCodexGlobalInstall(t *testing.T) {
 	if err := agentinit.EnsureMarkerWithID(project, "project-123"); err != nil {
 		t.Fatalf("marker: %v", err)
 	}
-	if _, err := agentinit.InstallGlobalInstructions(home, "codex"); err != nil {
-		t.Fatalf("install instructions: %v", err)
+	if _, err := agentinit.Refresh(home, "/bin/mnemo", "codex"); err != nil {
+		t.Fatalf("refresh codex: %v", err)
 	}
-	writeFile(t, filepath.Join(home, ".codex", "config.toml"), "[mcp_servers.mnemo]\ncommand = \"mnemo\"\nargs = [\"mcp\", \"--tools=agent\"]\n\n[mcp_servers.mnemo.env]\nMNEMO_AGENT = \"codex\"\nMNEMO_MCP_CLIENT = \"codex\"\nMNEMO_MCP_TRANSPORT = \"stdio\"\n")
-	writeFile(t, filepath.Join(home, ".codex", "hooks.json"), `{"hooks":{"SessionStart":[],"Stop":[]}}`)
-	writeExecutable(t, filepath.Join(home, ".codex", "hooks", "session-start.sh"))
-	writeExecutable(t, filepath.Join(home, ".codex", "hooks", "stop.sh"))
-	writeFile(t, filepath.Join(home, ".codex", "hooks", "mnemo-protocol.md"), "protocol")
+	appendCodexHookTrustForStatus(t, home)
 
 	report := doctor.BuildReport(doctor.Options{Agent: "codex", Path: project, Home: home, DataDir: dataDir})
 

--- a/cmd/mnemo/setup_print_config_test.go
+++ b/cmd/mnemo/setup_print_config_test.go
@@ -79,6 +79,27 @@ func TestBuildSetupConfigSnippetsForCodex(t *testing.T) {
 	}
 }
 
+func TestBuildSetupConfigSnippetsForClaudeCode(t *testing.T) {
+	snippets, err := buildSetupConfigSnippets(setupPrintConfigOptions{
+		Agent:    "claudecode",
+		Home:     "/home/test",
+		MnemoBin: "/bin/mnemo",
+	})
+	if err != nil {
+		t.Fatalf("build snippets: %v", err)
+	}
+	if len(snippets) != 1 {
+		t.Fatalf("snippets = %d, want 1", len(snippets))
+	}
+	content := snippets[0].Content
+	if snippets[0].Path != "/home/test/.claude.json" ||
+		!strings.Contains(content, `"type": "stdio"`) ||
+		!strings.Contains(content, `"command": "/bin/mnemo"`) ||
+		!strings.Contains(content, `"MNEMO_AGENT": "claudecode"`) {
+		t.Fatalf("unexpected Claude MCP snippet: %+v", snippets[0])
+	}
+}
+
 func TestBuildSetupConfigSnippetsForAll(t *testing.T) {
 	snippets, err := buildSetupConfigSnippets(setupPrintConfigOptions{
 		Agent:    "all",

--- a/cmd/mnemo/setup_refresh.go
+++ b/cmd/mnemo/setup_refresh.go
@@ -72,7 +72,7 @@ func refreshSetup(opts setupRefreshOptions) ([]string, error) {
 	}
 	var updated []string
 
-	skillFiles, err := agentinit.InstallGlobalSkill(opts.Home)
+	skillFiles, err := agentinit.InstallGlobalSkillForAgents(opts.Home, agents)
 	if err != nil {
 		return nil, fmt.Errorf("global skill: %w", err)
 	}

--- a/cmd/mnemo/setup_refresh_test.go
+++ b/cmd/mnemo/setup_refresh_test.go
@@ -35,8 +35,8 @@ func TestRefreshSetupWritesCodexFiles(t *testing.T) {
 	if err != nil {
 		t.Fatalf("refresh setup: %v", err)
 	}
-	if len(updated) != 13 {
-		t.Fatalf("updated paths = %d, want 13 (%v)", len(updated), updated)
+	if len(updated) != 10 {
+		t.Fatalf("updated paths = %d, want 10 (%v)", len(updated), updated)
 	}
 
 	config := readTestFile(t, filepath.Join(home, ".codex", "config.toml"))
@@ -60,6 +60,39 @@ func TestRefreshSetupWritesCodexFiles(t *testing.T) {
 	}
 }
 
+func TestRefreshSetupScopesAgentSpecificSkillLinks(t *testing.T) {
+	home := t.TempDir()
+
+	if _, err := refreshSetup(setupRefreshOptions{Agent: "cursor", Home: home, MnemoBin: "mnemo"}); err != nil {
+		t.Fatalf("refresh setup: %v", err)
+	}
+
+	if !agentinit.GlobalSkillInstalled(home) {
+		t.Fatal("canonical global skill not installed")
+	}
+	for _, path := range []string{
+		filepath.Join(home, ".claude", "skills", "mnemo-memory"),
+		filepath.Join(home, ".codeium", "windsurf", "skills", "mnemo-memory"),
+		filepath.Join(home, ".pi", "agent", "skills", "mnemo-memory"),
+	} {
+		if _, err := os.Lstat(path); !os.IsNotExist(err) {
+			t.Fatalf("unexpected agent-specific skill link %s after cursor-only refresh: %v", path, err)
+		}
+	}
+
+	if _, err := refreshSetup(setupRefreshOptions{Agent: "windsurf", Home: home, MnemoBin: "mnemo"}); err != nil {
+		t.Fatalf("refresh windsurf setup: %v", err)
+	}
+	windsurfLink := filepath.Join(home, ".codeium", "windsurf", "skills", "mnemo-memory")
+	info, err := os.Lstat(windsurfLink)
+	if err != nil {
+		t.Fatalf("stat windsurf skill link: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("%s is not a symlink", windsurfLink)
+	}
+}
+
 func TestRefreshSetupPreservesExistingJSONConfig(t *testing.T) {
 	home := t.TempDir()
 	writeFile(t, filepath.Join(home, ".cursor", "mcp.json"), `{"mcpServers":{"other":{"command":"other"}}}`)
@@ -72,6 +105,30 @@ func TestRefreshSetupPreservesExistingJSONConfig(t *testing.T) {
 	if !strings.Contains(content, `"other"`) || !strings.Contains(content, `"mnemo"`) {
 		t.Fatalf("merged config did not preserve existing server:\n%s", content)
 	}
+}
+
+func TestRefreshSetupWritesClaudeCodeUserMCPConfig(t *testing.T) {
+	home := t.TempDir()
+	writeFile(t, filepath.Join(home, ".claude.json"), `{"theme":"dark","mcpServers":{"other":{"command":"other"}}}`)
+
+	if _, err := refreshSetup(setupRefreshOptions{Agent: "claudecode", Home: home, MnemoBin: "/bin/mnemo"}); err != nil {
+		t.Fatalf("refresh setup: %v", err)
+	}
+
+	content := readTestFile(t, filepath.Join(home, ".claude.json"))
+	for _, want := range []string{
+		`"theme": "dark"`,
+		`"other"`,
+		`"mnemo"`,
+		`"type": "stdio"`,
+		`"command": "/bin/mnemo"`,
+		`"MNEMO_AGENT": "claudecode"`,
+	} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("Claude user MCP config missing %q:\n%s", want, content)
+		}
+	}
+	assertMissing(t, filepath.Join(home, ".claude", ".mcp.json"))
 }
 
 func TestRefreshSetupReplacesCodexMCPNestedTables(t *testing.T) {

--- a/cmd/mnemo/setup_status.go
+++ b/cmd/mnemo/setup_status.go
@@ -83,7 +83,7 @@ func printSetupUsage() {
 func runSetupStatus() {
 	opts, err := parseSetupStatusArgs(os.Args[3:], os.UserHomeDir)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "mnemo setup status: home: %v\n", err)
+		fmt.Fprintf(os.Stderr, "mnemo setup status: %v\n", err)
 		os.Exit(1)
 	}
 	report := buildSetupStatusReport(opts)
@@ -114,6 +114,8 @@ func parseSetupStatusArgs(args []string, userHomeDir func() (string, error)) (se
 			opts.Agent = strings.TrimSpace(arg[len("--agent="):])
 		case strings.HasPrefix(arg, "--home="):
 			opts.Home = arg[len("--home="):]
+		default:
+			return opts, fmt.Errorf("unknown argument %q", arg)
 		}
 	}
 	if opts.Agent == "" {

--- a/cmd/mnemo/setup_status_test.go
+++ b/cmd/mnemo/setup_status_test.go
@@ -21,17 +21,21 @@ func TestParseSetupStatusArgs(t *testing.T) {
 	}
 }
 
+func TestParseSetupStatusArgsRejectsUnknown(t *testing.T) {
+	if _, err := parseSetupStatusArgs([]string{"--bogus"}, func() (string, error) {
+		return "/home/test", nil
+	}); err == nil {
+		t.Fatal("expected unknown argument error")
+	}
+}
+
 func TestBuildSetupStatusReportReportsConfiguredCodex(t *testing.T) {
 	home := t.TempDir()
 
-	if _, err := agentinit.InstallGlobalInstructions(home, "codex"); err != nil {
-		t.Fatalf("install instructions: %v", err)
+	if _, err := agentinit.Refresh(home, "/bin/mnemo", "codex"); err != nil {
+		t.Fatalf("refresh codex: %v", err)
 	}
-	writeFile(t, filepath.Join(home, ".codex", "config.toml"), "[mcp_servers.mnemo]\ncommand = \"mnemo\"\nargs = [\"mcp\", \"--tools=agent\"]\n\n[mcp_servers.mnemo.env]\nMNEMO_AGENT = \"codex\"\nMNEMO_MCP_CLIENT = \"codex\"\nMNEMO_MCP_TRANSPORT = \"stdio\"\n")
-	writeFile(t, filepath.Join(home, ".codex", "hooks.json"), `{"hooks":{"SessionStart":[],"Stop":[]}}`)
-	writeExecutable(t, filepath.Join(home, ".codex", "hooks", "session-start.sh"))
-	writeExecutable(t, filepath.Join(home, ".codex", "hooks", "stop.sh"))
-	writeFile(t, filepath.Join(home, ".codex", "hooks", "mnemo-protocol.md"), "protocol")
+	appendCodexHookTrustForStatus(t, home)
 
 	report := buildSetupStatusReport(setupStatusOptions{Agent: "codex", Home: home})
 	if report.Status != "ok" {
@@ -127,16 +131,17 @@ func TestBuildSetupStatusReportChecksClaudeCodePluginHooks(t *testing.T) {
 			if _, err := agentinit.InstallGlobalInstructions(home, "claudecode"); err != nil {
 				t.Fatalf("install instructions: %v", err)
 			}
-			writeFile(t, filepath.Join(home, ".claude", ".mcp.json"), `{"mcpServers":{"mnemo":{"command":"mnemo","env":{"MNEMO_AGENT":"claudecode","MNEMO_MCP_CLIENT":"claudecode"}}}}`)
+			writeFile(t, filepath.Join(home, ".claude.json"), claudeMCPFixture())
 			writeFile(t, filepath.Join(home, ".claude", "plugins", "installed_plugins.json"), fmt.Sprintf(registry, installPath))
 			writeFile(t, filepath.Join(installPath, ".claude-plugin", "plugin.json"), `{"name":"mnemo"}`)
-			writeFile(t, filepath.Join(installPath, "hooks", "hooks.json"), `{"hooks":{}}`)
+			writeClaudePluginHooksJSON(t, filepath.Join(installPath, "hooks", "hooks.json"))
 			for _, script := range []string{
 				"session-start.sh",
 				"session-stop.sh",
 				"subagent-stop.sh",
 				"post-compact.sh",
 				"post-compact-resume.sh",
+				"user-prompt-submit.sh",
 				"post-file-edit.sh",
 				"post-bash-git.sh",
 			} {
@@ -155,13 +160,46 @@ func TestBuildSetupStatusReportChecksClaudeCodePluginHooks(t *testing.T) {
 	}
 }
 
+func TestBuildSetupStatusReportWarnsOnClaudeCodeMissingHookCommands(t *testing.T) {
+	home := t.TempDir()
+	installPath := filepath.Join(home, "plugin-cache", "mnemo")
+
+	if _, err := agentinit.InstallGlobalInstructions(home, "claudecode"); err != nil {
+		t.Fatalf("install instructions: %v", err)
+	}
+	writeFile(t, filepath.Join(home, ".claude.json"), claudeMCPFixture())
+	writeFile(t, filepath.Join(home, ".claude", "plugins", "installed_plugins.json"), fmt.Sprintf(`{"plugins":{"mnemo@mnemo":{"installPath":"%s"}}}`, installPath))
+	writeFile(t, filepath.Join(installPath, ".claude-plugin", "plugin.json"), `{"name":"mnemo"}`)
+	writeFile(t, filepath.Join(installPath, "hooks", "hooks.json"), `{"hooks":{}}`)
+	for _, script := range []string{
+		"session-start.sh",
+		"session-stop.sh",
+		"subagent-stop.sh",
+		"post-compact.sh",
+		"post-compact-resume.sh",
+		"user-prompt-submit.sh",
+		"post-file-edit.sh",
+		"post-bash-git.sh",
+	} {
+		writeExecutable(t, filepath.Join(installPath, "scripts", script))
+	}
+
+	report := buildSetupStatusReport(setupStatusOptions{Agent: "claudecode", Home: home})
+	if report.Status != "warning" || report.Summary.Warnings != 1 {
+		t.Fatalf("unexpected report: %+v", report)
+	}
+	if got := report.Rows[0].Hooks; got != "no" {
+		t.Fatalf("hooks = %q, want no", got)
+	}
+}
+
 func TestBuildSetupStatusReportAllowsClaudeCodeWithoutPluginRegistry(t *testing.T) {
 	home := t.TempDir()
 
 	if _, err := agentinit.InstallGlobalInstructions(home, "claudecode"); err != nil {
 		t.Fatalf("install instructions: %v", err)
 	}
-	writeFile(t, filepath.Join(home, ".claude", ".mcp.json"), `{"mcpServers":{"mnemo":{"command":"mnemo","env":{"MNEMO_AGENT":"claudecode","MNEMO_MCP_CLIENT":"claudecode"}}}}`)
+	writeFile(t, filepath.Join(home, ".claude.json"), claudeMCPFixture())
 
 	report := buildSetupStatusReport(setupStatusOptions{Agent: "claudecode", Home: home})
 	if report.Status != "ok" || report.Summary.OK != 1 || report.Summary.Warnings != 0 || report.Summary.Errors != 0 {
@@ -179,7 +217,7 @@ func TestBuildSetupStatusReportCountsRuntimeErrors(t *testing.T) {
 	if _, err := agentinit.InstallGlobalInstructions(home, "claudecode"); err != nil {
 		t.Fatalf("install instructions: %v", err)
 	}
-	writeFile(t, filepath.Join(home, ".claude", ".mcp.json"), `{"mcpServers":{"mnemo":{"command":"mnemo","env":{"MNEMO_AGENT":"claudecode","MNEMO_MCP_CLIENT":"claudecode"}}}}`)
+	writeFile(t, filepath.Join(home, ".claude.json"), claudeMCPFixture())
 	writeFile(t, filepath.Join(home, ".claude", "plugins", "installed_plugins.json"), `{`)
 
 	report := buildSetupStatusReport(setupStatusOptions{Agent: "claudecode", Home: home})
@@ -189,4 +227,51 @@ func TestBuildSetupStatusReportCountsRuntimeErrors(t *testing.T) {
 	if got := report.Rows[0].Hooks; got != "error" {
 		t.Fatalf("hooks = %q, want error", got)
 	}
+}
+
+func appendCodexHookTrustForStatus(t *testing.T, home string) {
+	t.Helper()
+	configPath := filepath.Join(home, ".codex", "config.toml")
+	hooksPath := filepath.Join(home, ".codex", "hooks.json")
+	content := readTestFile(t, configPath)
+	content += fmt.Sprintf(`
+[hooks.state.%q]
+trusted_hash = "sha256:test-session-start"
+
+[hooks.state.%q]
+trusted_hash = "sha256:test-stop"
+`, hooksPath+":session_start:0:0", hooksPath+":stop:0:0")
+	writeFile(t, configPath, content)
+}
+
+func claudeMCPFixture() string {
+	return `{"mcpServers":{"mnemo":{"type":"stdio","command":"mnemo","args":["mcp","--tools=agent"],"env":{"MNEMO_AGENT":"claudecode","MNEMO_MCP_CLIENT":"claudecode","MNEMO_MCP_TRANSPORT":"stdio"}}}}`
+}
+
+func writeClaudePluginHooksJSON(t *testing.T, path string) {
+	t.Helper()
+	writeFile(t, path, `{
+  "hooks": {
+    "SessionStart": [
+      {"hooks": [{"command": "${CLAUDE_PLUGIN_ROOT}/scripts/session-start.sh"}]},
+      {"hooks": [{"command": "${CLAUDE_PLUGIN_ROOT}/scripts/post-compact-resume.sh"}]}
+    ],
+    "SubagentStop": [
+      {"hooks": [{"command": "${CLAUDE_PLUGIN_ROOT}/scripts/subagent-stop.sh"}]}
+    ],
+    "Stop": [
+      {"hooks": [{"command": "${CLAUDE_PLUGIN_ROOT}/scripts/session-stop.sh"}]}
+    ],
+    "PostCompact": [
+      {"hooks": [{"command": "${CLAUDE_PLUGIN_ROOT}/scripts/post-compact.sh"}]}
+    ],
+    "UserPromptSubmit": [
+      {"hooks": [{"command": "${CLAUDE_PLUGIN_ROOT}/scripts/user-prompt-submit.sh"}]}
+    ],
+    "PostToolUse": [
+      {"hooks": [{"command": "${CLAUDE_PLUGIN_ROOT}/scripts/post-file-edit.sh"}]},
+      {"hooks": [{"command": "${CLAUDE_PLUGIN_ROOT}/scripts/post-bash-git.sh"}]}
+    ]
+  }
+}`)
 }

--- a/cmd/mnemo/setup_uninstall_test.go
+++ b/cmd/mnemo/setup_uninstall_test.go
@@ -101,6 +101,23 @@ func TestUninstallSetupRemovesCursorConfigAndRuntimeFiles(t *testing.T) {
 	assertMissing(t, filepath.Join(home, ".cursor", "hooks", "stop.sh"))
 }
 
+func TestUninstallSetupRemovesClaudeCodeUserMCPConfig(t *testing.T) {
+	home := t.TempDir()
+	writeFile(t, filepath.Join(home, ".claude.json"), `{"mcpServers":{"other":{"command":"other"}}}`)
+
+	if _, err := refreshSetup(setupRefreshOptions{Agent: "claudecode", Home: home, MnemoBin: "/bin/mnemo"}); err != nil {
+		t.Fatalf("refresh setup: %v", err)
+	}
+	if _, err := uninstallSetup(setupUninstallOptions{Agent: "claudecode", Home: home}); err != nil {
+		t.Fatalf("uninstall setup: %v", err)
+	}
+
+	config := readTestFile(t, filepath.Join(home, ".claude.json"))
+	if !strings.Contains(config, "other") || strings.Contains(config, "mnemo") {
+		t.Fatalf("unexpected Claude user MCP config:\n%s", config)
+	}
+}
+
 func assertMissing(t *testing.T, path string) {
 	t.Helper()
 	if _, err := os.Stat(path); !os.IsNotExist(err) {

--- a/internal/agentinit/check.go
+++ b/internal/agentinit/check.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 )
 
@@ -150,7 +151,98 @@ func checkJSONMCPWithEnv(path, id, agent, envKey string, keys ...string) Check {
 	if !jsonPathEquals(server, agent, envKey, "MNEMO_AGENT") {
 		return checkWarning(agent, id, "MCP config is missing mnemo provenance environment", path)
 	}
+	if !jsonMCPInvokesAgentTools(server) {
+		return checkWarning(agent, id, "MCP config is missing mnemo agent tool invocation", path)
+	}
 	return checkOK(agent, id, "MCP config contains mnemo server", path)
+}
+
+func jsonMCPInvokesAgentTools(server any) bool {
+	m, ok := server.(map[string]any)
+	if !ok {
+		return false
+	}
+	command, ok := m["command"]
+	if !ok {
+		return false
+	}
+	switch value := command.(type) {
+	case string:
+		if strings.TrimSpace(value) == "" {
+			return false
+		}
+		return jsonStringSliceContains(m["args"], "mcp") && jsonStringSliceContains(m["args"], "--tools=agent")
+	case []any:
+		return jsonStringSliceContains(value, "mcp") && jsonStringSliceContains(value, "--tools=agent")
+	default:
+		return false
+	}
+}
+
+func jsonStringSliceContains(value any, want string) bool {
+	items, ok := value.([]any)
+	if !ok {
+		return false
+	}
+	for _, item := range items {
+		if got, ok := item.(string); ok && got == want {
+			return true
+		}
+	}
+	return false
+}
+
+func checkJSONHookCommands(path, id, agent, okMessage string, eventCommands map[string][]string) Check {
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return checkWarning(agent, id, "hooks config not found", path)
+	}
+	if err != nil {
+		return checkError(agent, id, "read hooks config: "+err.Error(), path)
+	}
+	var root map[string]any
+	if err := json.Unmarshal(data, &root); err != nil {
+		return checkError(agent, id, "parse hooks config JSON: "+err.Error(), path)
+	}
+	hooks, ok := root["hooks"].(map[string]any)
+	if !ok {
+		return checkWarning(agent, id, "hooks config does not contain hooks", path)
+	}
+
+	var missing []string
+	for event, commands := range eventCommands {
+		items, ok := hooks[event].([]any)
+		if !ok {
+			missing = append(missing, event)
+			continue
+		}
+		for _, command := range commands {
+			found := false
+			for _, item := range items {
+				if containsCommand(item, command) {
+					found = true
+					break
+				}
+			}
+			if !found {
+				missing = append(missing, event)
+				break
+			}
+		}
+	}
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		return Check{
+			ID:       id,
+			Status:   "warning",
+			Severity: "warning",
+			Message:  "hooks config is missing mnemo hook commands",
+			Agent:    agent,
+			Path:     path,
+			Details:  map[string]string{"missing_hooks": strings.Join(missing, ",")},
+		}
+	}
+	return checkOK(agent, id, okMessage, path)
 }
 
 func jsonPathValue(v any, keys ...string) (any, bool) {

--- a/internal/agentinit/claudecode.go
+++ b/internal/agentinit/claudecode.go
@@ -30,6 +30,10 @@ func claudeCodeSkillLinkPath(home string) string {
 	return filepath.Join(home, ".claude", "skills", globalSkillName)
 }
 
+func claudeCodeMCPPath(home string) string {
+	return filepath.Join(home, ".claude.json")
+}
+
 func claudeCodeInstallInstructions(home string) (string, error) {
 	path := claudeCodeInstructionPath(home)
 	if err := AppendSection(path, templates.Global); err != nil {
@@ -47,10 +51,27 @@ func claudeCodeRemoveInstructions(home string) (string, bool, error) {
 func claudeCodeConfigSnippets(home, mnemoBin string) []ConfigSnippet {
 	return []ConfigSnippet{{
 		Agent:   claudeCodeLabel(),
-		Path:    filepath.Join(home, ".claude", ".mcp.json"),
+		Path:    claudeCodeMCPPath(home),
 		Format:  "json",
-		Content: mcpServersJSON(mnemoBin, AgentClaudeCode),
+		Content: claudeCodeMCPJSON(mnemoBin),
 	}}
+}
+
+func claudeCodeMCPJSON(mnemoBin string) string {
+	return prettyJSON(map[string]any{
+		"mcpServers": map[string]any{
+			"mnemo": map[string]any{
+				"type":    "stdio",
+				"command": mnemoBin,
+				"args":    []string{"mcp", "--tools=agent"},
+				"env": map[string]string{
+					"MNEMO_AGENT":         AgentClaudeCode,
+					"MNEMO_MCP_CLIENT":    AgentClaudeCode,
+					"MNEMO_MCP_TRANSPORT": "stdio",
+				},
+			},
+		},
+	})
 }
 
 func claudeCodeRuntimeAssets() []assetTarget {
@@ -59,7 +80,7 @@ func claudeCodeRuntimeAssets() []assetTarget {
 }
 
 func claudeCodeUninstallConfig(home string) ([]string, error) {
-	path := filepath.Join(home, ".claude", ".mcp.json")
+	path := claudeCodeMCPPath(home)
 	changed, err := removeMCPServer(path, "mcpServers", "mnemo")
 	return appendChanged(path, changed, err)
 }
@@ -69,7 +90,7 @@ func claudeCodeCheckInstructions(home string) Check {
 }
 
 func claudeCodeCheckMCP(home string) Check {
-	path := filepath.Join(home, ".claude", ".mcp.json")
+	path := claudeCodeMCPPath(home)
 	return checkJSONMCPWithEnv(path, "mcp_config.claudecode", "claudecode", "env", "mcpServers", "mnemo")
 }
 
@@ -93,10 +114,22 @@ func claudeCodeCheckRuntime(home string) Check {
 		filepath.Join(installPath, "scripts", "subagent-stop.sh"),
 		filepath.Join(installPath, "scripts", "post-compact.sh"),
 		filepath.Join(installPath, "scripts", "post-compact-resume.sh"),
+		filepath.Join(installPath, "scripts", "user-prompt-submit.sh"),
 		filepath.Join(installPath, "scripts", "post-file-edit.sh"),
 		filepath.Join(installPath, "scripts", "post-bash-git.sh"),
 	}
-	return checkFiles("claudecode", "runtime_files.claudecode", "Claude Code plugin hooks installed", paths, true)
+	check := checkFiles("claudecode", "runtime_files.claudecode", "Claude Code plugin hooks installed", paths, true)
+	if check.Status != "ok" {
+		return check
+	}
+	return checkJSONHookCommands(filepath.Join(installPath, "hooks", "hooks.json"), "runtime_files.claudecode", "claudecode", "Claude Code plugin hooks installed", map[string][]string{
+		"SessionStart":     {"${CLAUDE_PLUGIN_ROOT}/scripts/session-start.sh", "${CLAUDE_PLUGIN_ROOT}/scripts/post-compact-resume.sh"},
+		"SubagentStop":     {"${CLAUDE_PLUGIN_ROOT}/scripts/subagent-stop.sh"},
+		"Stop":             {"${CLAUDE_PLUGIN_ROOT}/scripts/session-stop.sh"},
+		"PostCompact":      {"${CLAUDE_PLUGIN_ROOT}/scripts/post-compact.sh"},
+		"UserPromptSubmit": {"${CLAUDE_PLUGIN_ROOT}/scripts/user-prompt-submit.sh"},
+		"PostToolUse":      {"${CLAUDE_PLUGIN_ROOT}/scripts/post-file-edit.sh", "${CLAUDE_PLUGIN_ROOT}/scripts/post-bash-git.sh"},
+	})
 }
 
 func claudeMnemoPluginInstallPath(home string) (string, error) {

--- a/internal/agentinit/codex.go
+++ b/internal/agentinit/codex.go
@@ -1,6 +1,7 @@
 package agentinit
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -114,11 +115,15 @@ func codexCheckMCP(home string) Check {
 		return checkError("codex", "mcp_config.codex", "read MCP config: "+err.Error(), path)
 	}
 	content := string(data)
-	if !strings.Contains(content, "[mcp_servers.mnemo]") || !strings.Contains(content, "mcp") {
+	if !tomlHasSection(content, "[mcp_servers.mnemo]") {
 		return checkWarning("codex", "mcp_config.codex", "MCP config does not contain mnemo server", path)
 	}
-	if !strings.Contains(content, "[mcp_servers.mnemo.env]") ||
-		!strings.Contains(content, `MNEMO_AGENT = "codex"`) {
+	if !tomlSectionHasKey(content, "[mcp_servers.mnemo]", "command") ||
+		!tomlSectionHasAssignment(content, "[mcp_servers.mnemo]", "args", `["mcp", "--tools=agent"]`) {
+		return checkWarning("codex", "mcp_config.codex", "MCP config is missing mnemo agent tool invocation", path)
+	}
+	if !tomlHasSection(content, "[mcp_servers.mnemo.env]") ||
+		!tomlSectionHasAssignment(content, "[mcp_servers.mnemo.env]", "MNEMO_AGENT", `"codex"`) {
 		return checkWarning("codex", "mcp_config.codex", "MCP config is missing mnemo provenance environment", path)
 	}
 	return checkOK("codex", "mcp_config.codex", "MCP config contains mnemo server", path)
@@ -131,7 +136,14 @@ func codexCheckRuntime(home string) Check {
 		filepath.Join(home, ".codex", "hooks", "stop.sh"),
 		filepath.Join(home, ".codex", "hooks", "mnemo-protocol.md"),
 	}
-	return checkFiles("codex", "runtime_files.codex", "Codex global hooks installed", paths, true)
+	check := checkFiles("codex", "runtime_files.codex", "Codex global hooks installed", paths, true)
+	if check.Status != "ok" {
+		return check
+	}
+	if trustCheck := codexCheckHookTrust(home); trustCheck.ID != "" {
+		return trustCheck
+	}
+	return check
 }
 
 func upsertCodexMCPConfig(path, section string) error {
@@ -172,7 +184,270 @@ func upsertCodexMCPConfig(path, section string) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		return err
 	}
-	return os.WriteFile(path, []byte(content), 0644)
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		return err
+	}
+	_, err = migrateCodexHookFeatureFlag(path)
+	return err
+}
+
+func migrateCodexHookFeatureFlag(path string) (bool, error) {
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+
+	lines := strings.Split(string(data), "\n")
+	out := make([]string, 0, len(lines))
+	inFeatures := false
+	hooksSeen := false
+	codexHooksValue := ""
+	changed := false
+
+	flushFeatures := func() {
+		if inFeatures && codexHooksValue != "" && !hooksSeen {
+			out = append(out, "hooks = "+codexHooksValue)
+			changed = true
+		}
+	}
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if isTOMLTableHeader(trimmed) {
+			flushFeatures()
+			name, _ := tomlTableName(trimmed)
+			inFeatures = name == "features"
+			hooksSeen = false
+			codexHooksValue = ""
+		}
+		if inFeatures {
+			key, value, ok := tomlAssignment(trimmed)
+			if ok {
+				switch key {
+				case "codex_hooks":
+					if codexHooksValue == "" {
+						codexHooksValue = value
+					}
+					changed = true
+					continue
+				case "hooks":
+					hooksSeen = true
+				}
+			}
+		}
+		out = append(out, line)
+	}
+	flushFeatures()
+	if !changed {
+		return false, nil
+	}
+
+	content := strings.TrimRight(strings.Join(out, "\n"), "\n") + "\n"
+	return true, os.WriteFile(path, []byte(content), 0644)
+}
+
+func tomlAssignment(line string) (key, value string, ok bool) {
+	if line == "" || strings.HasPrefix(line, "#") {
+		return "", "", false
+	}
+	idx := strings.Index(line, "=")
+	if idx < 0 {
+		return "", "", false
+	}
+	key = strings.TrimSpace(line[:idx])
+	value = strings.TrimSpace(line[idx+1:])
+	return key, value, key != ""
+}
+
+func codexCheckHookTrust(home string) Check {
+	hooksPath := filepath.Join(home, ".codex", "hooks.json")
+	configPath := filepath.Join(home, ".codex", "config.toml")
+	identities, missingCommands, err := codexMnemoHookIdentities(hooksPath, home)
+	if err != nil {
+		return checkError("codex", "runtime_files.codex", "parse Codex hooks: "+err.Error(), hooksPath)
+	}
+	if len(missingCommands) > 0 {
+		return Check{
+			ID:       "runtime_files.codex",
+			Status:   "warning",
+			Severity: "warning",
+			Agent:    "codex",
+			Message:  "Codex hooks.json is missing mnemo hook commands",
+			Path:     hooksPath,
+			Details:  map[string]string{"missing_commands": strings.Join(missingCommands, ",")},
+		}
+	}
+
+	data, err := os.ReadFile(configPath)
+	if os.IsNotExist(err) {
+		return Check{
+			ID:       "runtime_files.codex",
+			Status:   "warning",
+			Severity: "warning",
+			Agent:    "codex",
+			Message:  "Codex mnemo hooks need review in Codex",
+			Path:     hooksPath,
+			Details:  map[string]string{"missing_trust": strings.Join(codexHookIdentityStrings(identities), ",")},
+		}
+	}
+	if err != nil {
+		return checkError("codex", "runtime_files.codex", "read Codex config: "+err.Error(), configPath)
+	}
+
+	var missingTrust []string
+	content := string(data)
+	for _, identity := range identities {
+		if !tomlHasSection(content, codexHookTrustSection(identity.Identity)) {
+			missingTrust = append(missingTrust, identity.String())
+		}
+	}
+	if len(missingTrust) > 0 {
+		return Check{
+			ID:       "runtime_files.codex",
+			Status:   "warning",
+			Severity: "warning",
+			Agent:    "codex",
+			Message:  "Codex mnemo hooks need review in Codex",
+			Path:     hooksPath,
+			Details:  map[string]string{"missing_trust": strings.Join(missingTrust, ",")},
+		}
+	}
+	return Check{}
+}
+
+type codexHookIdentity struct {
+	Event    string
+	Identity string
+	Command  string
+}
+
+func (i codexHookIdentity) String() string {
+	return i.Event + ":" + i.Command
+}
+
+func codexHookIdentityStrings(identities []codexHookIdentity) []string {
+	out := make([]string, 0, len(identities))
+	for _, identity := range identities {
+		out = append(out, identity.String())
+	}
+	return out
+}
+
+func codexMnemoHookIdentities(hooksPath, home string) ([]codexHookIdentity, []string, error) {
+	data, err := os.ReadFile(hooksPath)
+	if err != nil {
+		return nil, nil, err
+	}
+	var root map[string]any
+	if err := json.Unmarshal(data, &root); err != nil {
+		return nil, nil, err
+	}
+	hooks, ok := root["hooks"].(map[string]any)
+	if !ok {
+		return nil, []string{"SessionStart", "Stop"}, nil
+	}
+
+	expectedCommands := map[string]string{
+		"SessionStart": filepath.Join(home, ".codex", "hooks", "session-start.sh"),
+		"Stop":         filepath.Join(home, ".codex", "hooks", "stop.sh"),
+	}
+	events := []string{"SessionStart", "Stop"}
+	var identities []codexHookIdentity
+	var missing []string
+	for _, event := range events {
+		command := expectedCommands[event]
+		found := false
+		items, _ := hooks[event].([]any)
+		for itemIndex, item := range items {
+			itemMap, _ := item.(map[string]any)
+			handlers, _ := itemMap["hooks"].([]any)
+			for hookIndex, handler := range handlers {
+				handlerMap, _ := handler.(map[string]any)
+				if got, _ := handlerMap["command"].(string); got == command {
+					found = true
+					identities = append(identities, codexHookIdentity{
+						Event:    event,
+						Identity: codexHookTrustIdentity(hooksPath, event, itemIndex, hookIndex),
+						Command:  command,
+					})
+				}
+			}
+		}
+		if !found {
+			missing = append(missing, event)
+		}
+	}
+	return identities, missing, nil
+}
+
+func codexHookTrustIdentity(hooksPath, event string, itemIndex, hookIndex int) string {
+	return fmt.Sprintf("%s:%s:%d:%d", hooksPath, codexHookEventKey(event), itemIndex, hookIndex)
+}
+
+func codexHookTrustSection(identity string) string {
+	return fmt.Sprintf("[hooks.state.%q]", identity)
+}
+
+func tomlHasSection(content, section string) bool {
+	for _, line := range strings.Split(content, "\n") {
+		if strings.TrimSpace(line) == section {
+			return true
+		}
+	}
+	return false
+}
+
+func tomlSectionHasKey(content, section, wantKey string) bool {
+	for _, line := range tomlSectionLines(content, section) {
+		key, _, ok := tomlAssignment(strings.TrimSpace(line))
+		if ok && key == wantKey {
+			return true
+		}
+	}
+	return false
+}
+
+func tomlSectionHasAssignment(content, section, wantKey, wantValue string) bool {
+	for _, line := range tomlSectionLines(content, section) {
+		key, value, ok := tomlAssignment(strings.TrimSpace(line))
+		if ok && key == wantKey && value == wantValue {
+			return true
+		}
+	}
+	return false
+}
+
+func tomlSectionLines(content, section string) []string {
+	var lines []string
+	inSection := false
+	for _, line := range strings.Split(content, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if isTOMLTableHeader(trimmed) {
+			if inSection {
+				break
+			}
+			inSection = trimmed == section
+			continue
+		}
+		if inSection {
+			lines = append(lines, line)
+		}
+	}
+	return lines
+}
+
+func codexHookEventKey(event string) string {
+	switch event {
+	case "SessionStart":
+		return "session_start"
+	case "Stop":
+		return "stop"
+	default:
+		return strings.ToLower(event)
+	}
 }
 
 func removeCodexMCPConfig(path string) (bool, error) {

--- a/internal/agentinit/codex_compact.go
+++ b/internal/agentinit/codex_compact.go
@@ -29,6 +29,7 @@ func writeCodexCompactionPrompt(home string) ([]string, error) {
 }
 
 func upsertCodexCompactPromptFile(path, promptPath string) error {
+	const key = "experimental_compact_prompt_file"
 	line := fmt.Sprintf("experimental_compact_prompt_file = %q", promptPath)
 	data, err := os.ReadFile(path)
 	if err != nil && !os.IsNotExist(err) {
@@ -36,28 +37,26 @@ func upsertCodexCompactPromptFile(path, promptPath string) error {
 	}
 
 	lines := strings.Split(string(data), "\n")
-	var out []string
-	replaced := false
+	out := make([]string, 0, len(lines)+1)
 	for _, lineText := range lines {
 		trimmed := strings.TrimSpace(lineText)
-		if strings.HasPrefix(trimmed, "experimental_compact_prompt_file") {
-			if !replaced {
-				out = append(out, line)
-				replaced = true
-			}
+		if gotKey, _, ok := tomlAssignment(trimmed); ok && gotKey == key {
 			continue
 		}
 		out = append(out, lineText)
 	}
 
-	content := strings.TrimRight(strings.Join(out, "\n"), "\n")
-	if !replaced {
-		if content != "" {
-			content += "\n\n"
+	insertAt := len(out)
+	for i, lineText := range out {
+		if isTOMLTableHeader(strings.TrimSpace(lineText)) {
+			insertAt = i
+			break
 		}
-		content += line
 	}
-	content += "\n"
+	out = append(out, "")
+	copy(out[insertAt+1:], out[insertAt:])
+	out[insertAt] = line
+	content := strings.TrimRight(strings.Join(out, "\n"), "\n") + "\n"
 
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		return err

--- a/internal/agentinit/cursor.go
+++ b/internal/agentinit/cursor.go
@@ -99,10 +99,20 @@ func cursorCheckMCP(home string) Check {
 }
 
 func cursorCheckRuntime(home string) Check {
+	hooksPath := filepath.Join(home, ".cursor", "hooks.json")
+	hooksDir := filepath.Join(home, ".cursor", "hooks")
 	paths := []string{
-		filepath.Join(home, ".cursor", "hooks.json"),
-		filepath.Join(home, ".cursor", "hooks", "before-submit-prompt.sh"),
-		filepath.Join(home, ".cursor", "hooks", "stop.sh"),
+		hooksPath,
+		filepath.Join(hooksDir, "before-submit-prompt.sh"),
+		filepath.Join(hooksDir, "stop.sh"),
+		filepath.Join(hooksDir, "session-start-protocol.md"),
 	}
-	return checkFiles("cursor", "runtime_files.cursor", "Cursor global hooks installed", paths, true)
+	check := checkFiles("cursor", "runtime_files.cursor", "Cursor global hooks installed", paths, true)
+	if check.Status != "ok" {
+		return check
+	}
+	return checkJSONHookCommands(hooksPath, "runtime_files.cursor", "cursor", "Cursor global hooks installed", map[string][]string{
+		"beforeSubmitPrompt": {filepath.Join(hooksDir, "before-submit-prompt.sh")},
+		"stop":               {filepath.Join(hooksDir, "stop.sh")},
+	})
 }

--- a/internal/agentinit/hook_output_test.go
+++ b/internal/agentinit/hook_output_test.go
@@ -1,0 +1,34 @@
+package agentinit
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestStopHooksDoNotEmitZeroMemoryWarning(t *testing.T) {
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve test filename")
+	}
+	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(filename), "..", ".."))
+	for _, path := range []string{
+		"scripts/codex/hooks/stop.sh",
+		"scripts/cursor/hooks/stop.sh",
+		"scripts/windsurf/hooks/post-cascade-response.sh",
+		"plugin/claude-code/scripts/session-stop.sh",
+	} {
+		t.Run(path, func(t *testing.T) {
+			content, err := os.ReadFile(filepath.Join(repoRoot, path))
+			if err != nil {
+				t.Fatalf("read hook: %v", err)
+			}
+			if strings.Contains(string(content), "session ended with 0 memories saved") ||
+				strings.Contains(string(content), "project-obs-count") {
+				t.Fatalf("%s should end sessions silently when no memories were captured", path)
+			}
+		})
+	}
+}

--- a/internal/agentinit/setup_test.go
+++ b/internal/agentinit/setup_test.go
@@ -1,6 +1,7 @@
 package agentinit
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -174,7 +175,243 @@ func TestRefreshWritesCodexFiles(t *testing.T) {
 	if !strings.Contains(config, "experimental_compact_prompt_file") {
 		t.Fatalf("codex config missing compact prompt file:\n%s", config)
 	}
+	compactIdx := strings.Index(config, "experimental_compact_prompt_file")
+	mcpIdx := strings.Index(config, "[mcp_servers.mnemo]")
+	if compactIdx < 0 || mcpIdx < 0 || compactIdx > mcpIdx {
+		t.Fatalf("codex compact prompt must be top-level before MCP tables:\n%s", config)
+	}
 	assertExecutable(t, filepath.Join(home, ".codex", "hooks", "session-start.sh"))
+}
+
+func TestRefreshMigratesCodexLegacyHookFeatureFlag(t *testing.T) {
+	home := t.TempDir()
+	configPath := filepath.Join(home, ".codex", "config.toml")
+	writeTestFile(t, configPath, `[features]
+codex_hooks = true
+other = false
+
+[mcp_servers.other]
+command = "other"
+`)
+
+	if _, err := Refresh(home, "/bin/mnemo", "codex"); err != nil {
+		t.Fatalf("refresh codex: %v", err)
+	}
+
+	content := readTestFile(t, configPath)
+	if strings.Contains(content, "codex_hooks") {
+		t.Fatalf("legacy codex_hooks flag was not removed:\n%s", content)
+	}
+	if !strings.Contains(content, "[features]") || !strings.Contains(content, "hooks = true") || !strings.Contains(content, "other = false") {
+		t.Fatalf("features table was not migrated correctly:\n%s", content)
+	}
+	if !strings.Contains(content, "[mcp_servers.other]") {
+		t.Fatalf("unrelated Codex config was not preserved:\n%s", content)
+	}
+}
+
+func TestRefreshPreservesExistingCodexHooksFeatureFlag(t *testing.T) {
+	home := t.TempDir()
+	configPath := filepath.Join(home, ".codex", "config.toml")
+	writeTestFile(t, configPath, `[features]
+hooks = false
+codex_hooks = true
+`)
+
+	if _, err := Refresh(home, "/bin/mnemo", "codex"); err != nil {
+		t.Fatalf("refresh codex: %v", err)
+	}
+
+	content := readTestFile(t, configPath)
+	if strings.Contains(content, "codex_hooks") {
+		t.Fatalf("legacy codex_hooks flag was not removed:\n%s", content)
+	}
+	if !strings.Contains(content, "hooks = false") {
+		t.Fatalf("existing hooks flag was not preserved:\n%s", content)
+	}
+	if strings.Contains(content, "hooks = true") {
+		t.Fatalf("legacy codex_hooks value overwrote existing hooks flag:\n%s", content)
+	}
+}
+
+func TestCodexCheckRuntimeWarnsWhenMnemoHooksNeedReview(t *testing.T) {
+	home := t.TempDir()
+	if _, err := Refresh(home, "/bin/mnemo", "codex"); err != nil {
+		t.Fatalf("refresh codex: %v", err)
+	}
+
+	check := codexCheckRuntime(home)
+	if check.Status != "warning" || !strings.Contains(check.Message, "need review") {
+		t.Fatalf("runtime check = %+v, want hook review warning", check)
+	}
+	if !strings.Contains(check.Details["missing_trust"], "SessionStart") || !strings.Contains(check.Details["missing_trust"], "Stop") {
+		t.Fatalf("missing_trust details = %q, want SessionStart and Stop", check.Details["missing_trust"])
+	}
+}
+
+func TestCodexCheckRuntimeAcceptsTrustedMnemoHooks(t *testing.T) {
+	home := t.TempDir()
+	if _, err := Refresh(home, "/bin/mnemo", "codex"); err != nil {
+		t.Fatalf("refresh codex: %v", err)
+	}
+	appendCodexMnemoHookTrust(t, home)
+
+	check := codexCheckRuntime(home)
+	if check.Status != "ok" {
+		t.Fatalf("runtime check = %+v, want ok", check)
+	}
+}
+
+func TestCodexCheckRuntimeIgnoresCommentedTrustSections(t *testing.T) {
+	home := t.TempDir()
+	if _, err := Refresh(home, "/bin/mnemo", "codex"); err != nil {
+		t.Fatalf("refresh codex: %v", err)
+	}
+	configPath := filepath.Join(home, ".codex", "config.toml")
+	hooksPath := filepath.Join(home, ".codex", "hooks.json")
+	content := readTestFile(t, configPath)
+	content += fmt.Sprintf(`
+# %s
+trusted_hash = "sha256:test-session-start"
+
+# %s
+trusted_hash = "sha256:test-stop"
+`, codexHookTrustSection(codexHookTrustIdentity(hooksPath, "SessionStart", 0, 0)), codexHookTrustSection(codexHookTrustIdentity(hooksPath, "Stop", 0, 0)))
+	writeTestFile(t, configPath, content)
+
+	check := codexCheckRuntime(home)
+	if check.Status != "warning" || !strings.Contains(check.Message, "need review") {
+		t.Fatalf("runtime check = %+v, want hook review warning", check)
+	}
+}
+
+func TestCheckMCPWarnsWhenJSONAgentToolInvocationMissing(t *testing.T) {
+	for _, tc := range []struct {
+		agent      string
+		configPath string
+		content    string
+	}{
+		{
+			agent:      "claudecode",
+			configPath: ".claude.json",
+			content:    `{"mcpServers":{"mnemo":{"command":"mnemo","args":["not-mcp"],"env":{"MNEMO_AGENT":"claudecode"}}}}`,
+		},
+		{
+			agent:      "cursor",
+			configPath: filepath.Join(".cursor", "mcp.json"),
+			content:    `{"mcpServers":{"mnemo":{"command":"mnemo","args":["not-mcp"],"env":{"MNEMO_AGENT":"cursor"}}}}`,
+		},
+		{
+			agent:      "windsurf",
+			configPath: filepath.Join(".codeium", "windsurf", "mcp_config.json"),
+			content:    `{"mcpServers":{"mnemo":{"command":"mnemo","args":["not-mcp"],"env":{"MNEMO_AGENT":"windsurf"}}}}`,
+		},
+		{
+			agent:      "opencode",
+			configPath: filepath.Join(".config", "opencode", "opencode.json"),
+			content:    `{"mcp":{"servers":{"mnemo":{"command":["mnemo","not-mcp"],"environment":{"MNEMO_AGENT":"opencode"}}}}}`,
+		},
+		{
+			agent:      "fx",
+			configPath: filepath.Join(".fx", "mcp.json"),
+			content:    `{"mcp":{"mnemo":{"command":["mnemo","not-mcp"],"environment":{"MNEMO_AGENT":"fx"}}}}`,
+		},
+		{
+			agent:      "pi",
+			configPath: filepath.Join(".pi", "agent", "mcp.json"),
+			content:    `{"mcpServers":{"mnemo":{"command":"mnemo","args":["not-mcp"],"env":{"MNEMO_AGENT":"pi"}}}}`,
+		},
+	} {
+		t.Run(tc.agent, func(t *testing.T) {
+			home := t.TempDir()
+			writeTestFile(t, filepath.Join(home, tc.configPath), tc.content)
+
+			check := CheckMCP(home, tc.agent)
+			if check.Status != "warning" || !strings.Contains(check.Message, "agent tool invocation") {
+				t.Fatalf("MCP check = %+v, want missing invocation warning", check)
+			}
+		})
+	}
+}
+
+func TestCodexCheckMCPWarnsWhenAgentToolInvocationMissing(t *testing.T) {
+	home := t.TempDir()
+	configPath := filepath.Join(home, ".codex", "config.toml")
+	writeTestFile(t, configPath, `[mcp_servers.mnemo]
+command = "/bin/mnemo"
+args = ["not-mcp"]
+
+[mcp_servers.mnemo.env]
+MNEMO_AGENT = "codex"
+`)
+
+	check := CheckMCP(home, "codex")
+	if check.Status != "warning" || !strings.Contains(check.Message, "agent tool invocation") {
+		t.Fatalf("MCP check = %+v, want missing invocation warning", check)
+	}
+}
+
+func TestCursorAndWindsurfCheckRuntimeValidateHookCommands(t *testing.T) {
+	for _, tc := range []struct {
+		agent     string
+		hooksPath string
+	}{
+		{
+			agent:     "cursor",
+			hooksPath: filepath.Join(".cursor", "hooks.json"),
+		},
+		{
+			agent:     "windsurf",
+			hooksPath: filepath.Join(".codeium", "windsurf", "hooks.json"),
+		},
+	} {
+		t.Run(tc.agent, func(t *testing.T) {
+			home := t.TempDir()
+			if _, err := Refresh(home, "/bin/mnemo", tc.agent); err != nil {
+				t.Fatalf("refresh %s: %v", tc.agent, err)
+			}
+			writeTestFile(t, filepath.Join(home, tc.hooksPath), `{"hooks":{}}`)
+
+			check := CheckRuntime(home, tc.agent)
+			if check.Status != "warning" || !strings.Contains(check.Message, "missing mnemo hook commands") {
+				t.Fatalf("runtime check = %+v, want missing hook command warning", check)
+			}
+			if check.Details["missing_hooks"] == "" {
+				t.Fatalf("runtime check missing hook details: %+v", check)
+			}
+		})
+	}
+}
+
+func TestCursorAndWindsurfCheckRuntimeRequireSessionProtocol(t *testing.T) {
+	for _, tc := range []struct {
+		agent        string
+		protocolPath string
+	}{
+		{
+			agent:        "cursor",
+			protocolPath: filepath.Join(".cursor", "hooks", "session-start-protocol.md"),
+		},
+		{
+			agent:        "windsurf",
+			protocolPath: filepath.Join(".codeium", "windsurf", "hooks", "session-start-protocol.md"),
+		},
+	} {
+		t.Run(tc.agent, func(t *testing.T) {
+			home := t.TempDir()
+			if _, err := Refresh(home, "/bin/mnemo", tc.agent); err != nil {
+				t.Fatalf("refresh %s: %v", tc.agent, err)
+			}
+			if err := os.Remove(filepath.Join(home, tc.protocolPath)); err != nil {
+				t.Fatalf("remove protocol fixture: %v", err)
+			}
+
+			check := CheckRuntime(home, tc.agent)
+			if check.Status != "warning" || !strings.Contains(check.Details["missing"], "session-start-protocol.md") {
+				t.Fatalf("runtime check = %+v, want missing protocol warning", check)
+			}
+		})
+	}
 }
 
 func TestRemoveCodexMCPConfigRemovesNestedTables(t *testing.T) {
@@ -274,5 +511,30 @@ func assertExecutable(t *testing.T, path string) {
 	}
 	if info.Mode()&0111 == 0 {
 		t.Fatalf("%s is not executable: %v", path, info.Mode())
+	}
+}
+
+func appendCodexMnemoHookTrust(t *testing.T, home string) {
+	t.Helper()
+	configPath := filepath.Join(home, ".codex", "config.toml")
+	hooksPath := filepath.Join(home, ".codex", "hooks.json")
+	trust := fmt.Sprintf(`
+%s
+trusted_hash = "sha256:test-session-start"
+
+%s
+trusted_hash = "sha256:test-stop"
+`, codexHookTrustSection(codexHookTrustIdentity(hooksPath, "SessionStart", 0, 0)), codexHookTrustSection(codexHookTrustIdentity(hooksPath, "Stop", 0, 0)))
+	f, err := os.OpenFile(configPath, os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		t.Fatalf("open config for append: %v", err)
+	}
+	defer func() {
+		if err := f.Close(); err != nil {
+			t.Errorf("close config: %v", err)
+		}
+	}()
+	if _, err := f.WriteString(trust); err != nil {
+		t.Fatalf("append hook trust: %v", err)
 	}
 }

--- a/internal/agentinit/skill.go
+++ b/internal/agentinit/skill.go
@@ -25,6 +25,16 @@ type skillSymlink struct {
 // InstallGlobalSkill copies the embedded mnemo-memory skill to the canonical
 // global path and links agent-specific skill directories to it.
 func InstallGlobalSkill(home string) ([]string, error) {
+	return installGlobalSkill(home, SupportedAgents)
+}
+
+// InstallGlobalSkillForAgents copies the embedded mnemo-memory skill to the
+// canonical global path and links only the requested agents' skill directories.
+func InstallGlobalSkillForAgents(home string, agents []string) ([]string, error) {
+	return installGlobalSkill(home, agents)
+}
+
+func installGlobalSkill(home string, agents []string) ([]string, error) {
 	destRoot := filepath.Join(home, ".agents", "skills", globalSkillName)
 	var updated []string
 
@@ -43,7 +53,7 @@ func InstallGlobalSkill(home string) ([]string, error) {
 		updated = append(updated, path)
 	}
 
-	for _, spec := range globalSkillSymlinks(home, destRoot) {
+	for _, spec := range globalSkillSymlinks(home, destRoot, agents) {
 		if err := ensureDirSymlink(spec.link, spec.target); err != nil {
 			return nil, err
 		}
@@ -53,9 +63,13 @@ func InstallGlobalSkill(home string) ([]string, error) {
 	return updated, nil
 }
 
-func globalSkillSymlinks(home, destRoot string) []skillSymlink {
+func globalSkillSymlinks(home, destRoot string, agents []string) []skillSymlink {
 	var symlinks []skillSymlink
-	for _, spec := range agentSpecs {
+	for _, agent := range agents {
+		spec, ok := Spec(agent)
+		if !ok {
+			continue
+		}
 		if spec.Skill.GlobalLinkPath == nil {
 			continue
 		}

--- a/internal/agentinit/skill_test.go
+++ b/internal/agentinit/skill_test.go
@@ -82,4 +82,22 @@ func TestUpsertCodexCompactPromptFile(t *testing.T) {
 	if strings.Count(string(data), "experimental_compact_prompt_file") != 1 {
 		t.Fatalf("expected one compact prompt key, got: %s", data)
 	}
+
+	if err := os.WriteFile(configPath, []byte("[mcp_servers.mnemo.env]\nMNEMO_AGENT = \"codex\"\nexperimental_compact_prompt_file = \"/old/scoped/path\"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := upsertCodexCompactPromptFile(configPath, promptPath); err != nil {
+		t.Fatalf("move scoped upsert: %v", err)
+	}
+	data, err = os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(data)
+	if strings.Count(content, "experimental_compact_prompt_file") != 1 {
+		t.Fatalf("expected one compact prompt key after scoped move, got: %s", content)
+	}
+	if strings.Index(content, "experimental_compact_prompt_file") > strings.Index(content, "[mcp_servers.mnemo.env]") {
+		t.Fatalf("compact prompt key must be top-level before TOML tables, got: %s", content)
+	}
 }

--- a/internal/agentinit/windsurf.go
+++ b/internal/agentinit/windsurf.go
@@ -96,10 +96,20 @@ func windsurfCheckMCP(home string) Check {
 }
 
 func windsurfCheckRuntime(home string) Check {
+	hooksPath := filepath.Join(home, ".codeium", "windsurf", "hooks.json")
+	hooksDir := filepath.Join(home, ".codeium", "windsurf", "hooks")
 	paths := []string{
-		filepath.Join(home, ".codeium", "windsurf", "hooks.json"),
-		filepath.Join(home, ".codeium", "windsurf", "hooks", "pre-user-prompt.sh"),
-		filepath.Join(home, ".codeium", "windsurf", "hooks", "post-cascade-response.sh"),
+		hooksPath,
+		filepath.Join(hooksDir, "pre-user-prompt.sh"),
+		filepath.Join(hooksDir, "post-cascade-response.sh"),
+		filepath.Join(hooksDir, "session-start-protocol.md"),
 	}
-	return checkFiles("windsurf", "runtime_files.windsurf", "Windsurf global hooks installed", paths, true)
+	check := checkFiles("windsurf", "runtime_files.windsurf", "Windsurf global hooks installed", paths, true)
+	if check.Status != "ok" {
+		return check
+	}
+	return checkJSONHookCommands(hooksPath, "runtime_files.windsurf", "windsurf", "Windsurf global hooks installed", map[string][]string{
+		"pre_user_prompt":                       {filepath.Join(hooksDir, "pre-user-prompt.sh")},
+		"post_cascade_response_with_transcript": {filepath.Join(hooksDir, "post-cascade-response.sh")},
+	})
 }

--- a/plugin/claude-code/scripts/session-stop.sh
+++ b/plugin/claude-code/scripts/session-stop.sh
@@ -13,12 +13,6 @@ MNEMO_FILE="${PROJECT_ROOT}/.mnemo"
 [ -f "$MNEMO_FILE" ] && PROJECT=$(mnemo json id < "$MNEMO_FILE" 2>/dev/null)
 [ -z "$PROJECT" ] && exit 0
 
-OBS_COUNT=$(mnemo session project-obs-count "$SESSION_ID" 2>/dev/null)
-
 mnemo session end "$SESSION_ID" >/dev/null 2>&1 || true
-
-if [ "${OBS_COUNT:-0}" = "0" ]; then
-  printf "\n[mnemo] warning: session ended with 0 memories saved.\n" >&2
-fi
 
 exit 0

--- a/scripts/codex/hooks/stop.sh
+++ b/scripts/codex/hooks/stop.sh
@@ -42,13 +42,7 @@ if [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ]; then
   fi
 fi
 
-OBS_COUNT=$(mnemo session project-obs-count "$SESSION_ID" 2>/dev/null)
 mnemo session end "$SESSION_ID" >/dev/null 2>&1 || true
-
-if [ "${OBS_COUNT:-0}" = "0" ]; then
-  printf '{"continue":true,"systemMessage":"[mnemo] warning: session ended with 0 memories saved."}\n'
-  exit 0
-fi
 
 printf '{"continue":true}\n'
 exit 0

--- a/scripts/cursor/hooks/stop.sh
+++ b/scripts/cursor/hooks/stop.sh
@@ -33,11 +33,6 @@ if [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ]; then
   fi
 fi
 
-OBS_COUNT=$(mnemo session project-obs-count "$CONVERSATION_ID" 2>/dev/null)
 mnemo session end "$CONVERSATION_ID" >/dev/null 2>&1 || true
-
-if [ "${OBS_COUNT:-0}" = "0" ]; then
-  printf "\n[mnemo] warning: session ended with 0 memories saved.\n" >&2
-fi
 
 exit 0

--- a/scripts/windsurf/hooks/post-cascade-response.sh
+++ b/scripts/windsurf/hooks/post-cascade-response.sh
@@ -32,11 +32,6 @@ if [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ]; then
   fi
 fi
 
-OBS_COUNT=$(mnemo session project-obs-count "$TRAJECTORY_ID" 2>/dev/null)
 mnemo session end "$TRAJECTORY_ID" >/dev/null 2>&1 || true
-
-if [ "${OBS_COUNT:-0}" = "0" ]; then
-  printf "\n[mnemo] warning: session ended with 0 memories saved.\n" >&2
-fi
 
 exit 0


### PR DESCRIPTION
## Summary
- Harden setup status/doctor diagnostics for Codex hook trust, real MCP invocations, and agent hook runtime files
- Validate Cursor, Windsurf, and Claude Code hook command configuration instead of only checking file existence
- Scope setup refresh skill links to the selected agents and roadmap a central per-agent expectations matrix

## Validation
- `GOCACHE=/private/tmp/mnemo-go-build-cache-agent-review go test ./...`
- `GOCACHE=/private/tmp/mnemo-go-build-cache-agent-review go vet ./...`
- `git diff --check`
- Per-agent install/status/doctor/uninstall matrix for claudecode, cursor, windsurf, codex, opencode, fx, and pi
- Cursor/Windsurf plugin harnesses and Claude/Codex hook script smoke tests
